### PR TITLE
Register mutations using ReplicacheOptions

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -90,13 +90,9 @@ class Replicache implements ReadTransaction {
     pushAuth: string,
     pullURL: string,
     pullAuth: string,
+    // Registers the mutators, which are used to make changes to the data.
+    mutators: {[name: string]: MutatorImpl}
   });
-
-  // Registers a mutator, which is used to make changes to the data.
-  register<Return, Args>(
-    name: string,
-    mutatorImpl: MutatorImpl<Return, Args>,
-  ): Mutator<Return, Args>;
 
   // Subcribe to changes to the underlying data. Every time the underlying data changes onData is called.
   // The function is also called once the first time the subscription is added.
@@ -107,13 +103,13 @@ class Replicache implements ReadTransaction {
 }
 
 // A Replicache "mutator" function is just a normal JS function that accepts any JSON value, makes changes
-// to Replicache, and returns a JSON value. Users can invoke mutators themselves, via the return value
-// from register(). Also Replicache will itself invoke these functions during sync as part of conflict
-// resolution.
+// to Replicache, and returns a JSON value. Users can invoke mutators themselves, via the `mutate` property
+// of the `Replicache` instance. Also Replicache will itself invoke these functions during sync as part of
+// conflict resolution.
 type MutatorImpl<Return extends JSONValue | void, Args extends JSONValue> = (
   tx: WriteTransaction,
-  args: Args,
-) => Promise<Return>;
+  args?: Args,
+) => MaybePromise<Return>;
 
 interface ReadTransaction {
   get(key: string): Promise<JSONValue | undefined>;

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -6,7 +6,6 @@ export type {
   MaybePromise,
   MutatorImpl,
   MutatorDefs,
-  MutatorReturn,
 } from './replicache.js';
 export type {
   CreateIndexDefinition,

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,7 +1,13 @@
 export {Replicache} from './replicache.js';
 export {TransactionClosedError} from './transaction-closed-error.js';
 
-export type {ReplicacheOptions, MaybePromise} from './replicache.js';
+export type {
+  ReplicacheOptions,
+  MaybePromise,
+  MutatorImpl,
+  MutatorDefs,
+  MutatorReturn,
+} from './replicache.js';
 export type {
   CreateIndexDefinition,
   ReadTransaction,

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -4,7 +4,6 @@ export {TransactionClosedError} from './transaction-closed-error.js';
 export type {
   ReplicacheOptions,
   MaybePromise,
-  MutatorImpl,
   MutatorDefs,
 } from './replicache.js';
 export type {

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -1870,11 +1870,12 @@ test.skip('mut [type checking only]', async () => {
         console.log(tx, x);
       },
 
-      // This should be flagged as an error but I need to use `any` for the arg since I need bivariance an TS uses covariant here.
-      // @ts-expect-error
-      i: (tx: WriteTransaction, d: Date) => {
-        console.log(tx, d);
-      },
+      // // This should be flagged as an error but I need to use `any` for the
+      // // arg since I need covariance and TS uses contravariance here.
+      // // @ts-expect-error XXX
+      // i: (tx: WriteTransaction, d: Date) =>
+      // {console.log(tx, d);
+      // },
     },
   });
 

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -1869,6 +1869,12 @@ test.skip('mut [type checking only]', async () => {
       h: async (tx: WriteTransaction, x: number) => {
         console.log(tx, x);
       },
+
+      // This should be flagged as an error but I need to use `any` for the arg since I need bivariance an TS uses covariant here.
+      // @ts-expect-error
+      i: (tx: WriteTransaction, d: Date) => {
+        console.log(tx, d);
+      },
     },
   });
 

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -157,7 +157,7 @@ testWithBothStores('get, has, scan on empty db', async () => {
 
 testWithBothStores('put, get, has, del inside tx', async () => {
   const rep = await replicacheForTesting('test3', {
-    mut: {
+    mutators: {
       testMut: async (
         tx: WriteTransaction,
         args: {key: string; value: JSONValue},
@@ -175,7 +175,7 @@ testWithBothStores('put, get, has, del inside tx', async () => {
     },
   });
 
-  const {testMut} = rep.mut;
+  const {testMut} = rep.mutate;
 
   for (const [key, value] of Object.entries({
     a: true,
@@ -223,8 +223,12 @@ async function testScanResult<K, V>(
 }
 
 testWithBothStores('scan', async () => {
-  const rep = await replicacheForTesting('test4');
-  const add = rep.register('add-data', addData);
+  const rep = await replicacheForTesting('test4', {
+    mutators: {
+      addData,
+    },
+  });
+  const add = rep.mutate.addData;
   await add({
     'a/0': 0,
     'a/1': 1,
@@ -340,7 +344,11 @@ testWithBothStores('scan', async () => {
 testWithBothStores('subscribe', async () => {
   const log: [string, JSONValue][] = [];
 
-  const rep = await replicacheForTesting('subscribe');
+  const rep = await replicacheForTesting('subscribe', {
+    mutators: {
+      addData,
+    },
+  });
   let queryCallCount = 0;
   const cancel = rep.subscribe(
     async (tx: ReadTransaction) => {
@@ -363,7 +371,7 @@ testWithBothStores('subscribe', async () => {
   expect(log).to.have.length(0);
   expect(queryCallCount).to.equal(0);
 
-  const add = rep.register('add-data', addData);
+  const add = rep.mutate.addData;
   await add({'a/0': 0});
   expect(log).to.deep.equal([['a/0', 0]]);
   expect(queryCallCount).to.equal(2); // One for initial subscribe and one for the add.
@@ -400,7 +408,9 @@ testWithBothStores('subscribe', async () => {
 });
 
 testWithBothStores('subscribe close', async () => {
-  const rep = await replicacheForTesting('subscribe-close');
+  const rep = await replicacheForTesting('subscribe-close', {
+    mutators: {addData},
+  });
 
   const log: (JSONValue | undefined)[] = [];
 
@@ -411,7 +421,7 @@ testWithBothStores('subscribe close', async () => {
 
   expect(log).to.have.length(0);
 
-  const add = rep.register('add-data', addData);
+  const add = rep.mutate.addData;
   await add({k: 0});
   await Promise.resolve();
   expect(log).to.deep.equal([undefined, 0]);
@@ -424,11 +434,11 @@ testWithBothStores('subscribe close', async () => {
 });
 
 testWithBothStores('name', async () => {
-  const repA = await replicacheForTesting('a');
-  const repB = await replicacheForTesting('b');
+  const repA = await replicacheForTesting('a', {mutators: {addData}});
+  const repB = await replicacheForTesting('b', {mutators: {addData}});
 
-  const addA = repA.register('add-data', addData);
-  const addB = repB.register('add-data', addData);
+  const addA = repA.mutate.addData;
+  const addB = repB.mutate.addData;
 
   await addA({key: 'A'});
   await addB({key: 'B'});
@@ -444,14 +454,15 @@ testWithBothStores('name', async () => {
 });
 
 testWithBothStores('register with error', async () => {
-  const rep = await replicacheForTesting('regerr');
-
-  const doErr = rep.register(
-    'err',
-    async (_: WriteTransaction, args: number) => {
-      throw args;
+  const rep = await replicacheForTesting('regerr', {
+    mutators: {
+      err: async (_: WriteTransaction, args: number) => {
+        throw args;
+      },
     },
-  );
+  });
+
+  const doErr = rep.mutate.err;
 
   try {
     await doErr(42);
@@ -462,9 +473,9 @@ testWithBothStores('register with error', async () => {
 });
 
 testWithBothStores('subscribe with error', async () => {
-  const rep = await replicacheForTesting('suberr');
+  const rep = await replicacheForTesting('suberr', {mutators: {addData}});
 
-  const add = rep.register('add-data', addData);
+  const add = rep.mutate.addData;
 
   let gottenValue = 0;
   let error;
@@ -510,19 +521,21 @@ testWithBothStores('overlapping writes', async () => {
 
   const pushURL = 'https://push.com';
   // writes wait on writes
-  const rep = await replicacheForTesting('conflict', {pushURL});
+  const rep = await replicacheForTesting('conflict', {
+    pushURL,
+    mutators: {
+      'wait-then-return': async <T extends JSONValue>(
+        tx: ReadTransaction,
+        {duration, ret}: {duration: number; ret: T},
+      ) => {
+        await dbWait(tx, duration);
+        return ret;
+      },
+    },
+  });
   fetchMock.post(pushURL, {});
 
-  const mut = rep.register(
-    'wait-then-return',
-    async <T extends JSONValue>(
-      tx: ReadTransaction,
-      {duration, ret}: {duration: number; ret: T},
-    ) => {
-      await dbWait(tx, duration);
-      return ret;
-    },
-  );
+  const mut = rep.mutate['wait-then-return'];
 
   let resA = mut({duration: 250, ret: 'a'});
   // create a gap to make sure resA starts first (our rwlock isn't fair).
@@ -553,26 +566,28 @@ testWithBothStores('push', async () => {
     pushAuth: '1',
     pushURL,
     pushDelay: 10,
+    mutators: {
+      createTodo: async <A extends {id: number}>(
+        tx: WriteTransaction,
+        args: A,
+      ) => {
+        createCount++;
+        await tx.put(`/todo/${args.id}`, args);
+      },
+      deleteTodo: async <A extends {id: number}>(
+        tx: WriteTransaction,
+        args: A,
+      ) => {
+        deleteCount++;
+        await tx.del(`/todo/${args.id}`);
+      },
+    },
   });
 
   let createCount = 0;
   let deleteCount = 0;
 
-  const createTodo = rep.register(
-    'createTodo',
-    async <A extends {id: number}>(tx: WriteTransaction, args: A) => {
-      createCount++;
-      await tx.put(`/todo/${args.id}`, args);
-    },
-  );
-
-  const deleteTodo = rep.register(
-    'deleteTodo',
-    async <A extends {id: number}>(tx: WriteTransaction, args: A) => {
-      deleteCount++;
-      await tx.del(`/todo/${args.id}`);
-    },
-  );
+  const {createTodo, deleteTodo} = rep.mutate;
 
   const id1 = 14323534;
   const id2 = 22354345;
@@ -661,14 +676,17 @@ testWithBothStores('push delay', async () => {
     pushAuth: '1',
     pushURL,
     pushDelay: 1,
+    mutators: {
+      createTodo: async <A extends {id: number}>(
+        tx: WriteTransaction,
+        args: A,
+      ) => {
+        await tx.put(`/todo/${args.id}`, args);
+      },
+    },
   });
 
-  const createTodo = rep.register(
-    'createTodo',
-    async <A extends {id: number}>(tx: WriteTransaction, args: A) => {
-      await tx.put(`/todo/${args.id}`, args);
-    },
-  );
+  const {createTodo} = rep.mutate;
 
   const id1 = 14323534;
 
@@ -696,6 +714,22 @@ testWithBothStores('pull', async () => {
   const rep = await replicacheForTesting('pull', {
     pullAuth: '1',
     pullURL,
+    mutators: {
+      createTodo: async <A extends {id: number}>(
+        tx: WriteTransaction,
+        args: A,
+      ) => {
+        createCount++;
+        await tx.put(`/todo/${args.id}`, args);
+      },
+      deleteTodo: async <A extends {id: number}>(
+        tx: WriteTransaction,
+        args: A,
+      ) => {
+        deleteCount++;
+        await tx.del(`/todo/${args.id}`);
+      },
+    },
   });
 
   let createCount = 0;
@@ -707,21 +741,7 @@ testWithBothStores('pull', async () => {
     ok: boolean;
   };
 
-  const createTodo = rep.register(
-    'createTodo',
-    async <A extends {id: number}>(tx: WriteTransaction, args: A) => {
-      createCount++;
-      await tx.put(`/todo/${args.id}`, args);
-    },
-  );
-
-  const deleteTodo = rep.register(
-    'deleteTodo',
-    async <A extends {id: number}>(tx: WriteTransaction, args: A) => {
-      deleteCount++;
-      await tx.del(`/todo/${args.id}`);
-    },
-  );
+  const {createTodo, deleteTodo} = rep.mutate;
 
   const id1 = 14323534;
   const id2 = 22354345;
@@ -895,8 +915,9 @@ testWithBothStores('HTTP status push', async () => {
   const rep = await replicacheForTesting('http-status-push', {
     pushURL,
     pushDelay: 1,
+    mutators: {addData},
   });
-  const add = rep.register('add-data', addData);
+  const add = rep.mutate.addData;
 
   let okCalled = false;
   let i = 0;
@@ -929,7 +950,13 @@ testWithBothStores('HTTP status push', async () => {
 });
 
 testWithBothStores('closed tx', async () => {
-  const rep = await replicacheForTesting('reauth');
+  const rep = await replicacheForTesting('reauth', {
+    mutators: {
+      mut: async tx => {
+        wtx = tx;
+      },
+    },
+  });
 
   let rtx: ReadTransaction;
   await rep.query(tx => (rtx = tx));
@@ -942,11 +969,8 @@ testWithBothStores('closed tx', async () => {
   );
 
   let wtx: WriteTransaction | undefined;
-  const mut = rep.register('mut', async tx => {
-    wtx = tx;
-  });
 
-  await mut();
+  await rep.mutate.mut();
   expect(wtx).to.not.be.undefined;
   await expectAsyncFuncToThrow(() => wtx?.put('z', 1), TransactionClosedError);
   await expectAsyncFuncToThrow(() => wtx?.del('w'), TransactionClosedError);
@@ -961,8 +985,8 @@ testWithBothStores('pullInterval in constructor', async () => {
 });
 
 testWithBothStores('closeTransaction after rep.scan', async () => {
-  const rep = await replicacheForTesting('test5');
-  const add = rep.register('add-data', addData);
+  const rep = await replicacheForTesting('test5', {mutators: {addData}});
+  const add = rep.mutate.addData;
   await add({
     'a/0': 0,
     'a/1': 1,
@@ -1056,9 +1080,9 @@ testWithBothStores('closeTransaction after rep.scan', async () => {
 });
 
 testWithBothStores('index', async () => {
-  const rep = await replicacheForTesting('test-index');
+  const rep = await replicacheForTesting('test-index', {mutators: {addData}});
 
-  const add = rep.register('add-data', addData);
+  const add = rep.mutate.addData;
   await add({
     'a/0': {a: '0'},
     'a/1': {a: '1'},
@@ -1122,9 +1146,9 @@ testWithBothStores('index', async () => {
 });
 
 testWithBothStores('index array', async () => {
-  const rep = await replicacheForTesting('test-index');
+  const rep = await replicacheForTesting('test-index', {mutators: {addData}});
 
-  const add = rep.register('add-data', addData);
+  const add = rep.mutate.addData;
   await add({
     'a/0': {a: []},
     'a/1': {a: ['0']},
@@ -1149,9 +1173,11 @@ testWithBothStores('index array', async () => {
 });
 
 testWithBothStores('index scan start', async () => {
-  const rep = await replicacheForTesting('test-index-scan');
+  const rep = await replicacheForTesting('test-index-scan', {
+    mutators: {addData},
+  });
 
-  const add = rep.register('add-data', addData);
+  const add = rep.mutate.addData;
   await add({
     'a/1': {a: '0'},
     'b/0': {b: 'a5'},
@@ -1275,25 +1301,32 @@ testWithBothStores('index scan start', async () => {
 
 // Only used for type checking
 test.skip('mutator optional args [type checking only]', async () => {
-  const rep = await replicacheForTesting('test-types');
-
-  const mut = rep.register('mut', async (tx: WriteTransaction, x: number) => {
-    console.log(tx);
-    return x;
+  const rep = await replicacheForTesting('test-types', {
+    mutators: {
+      mut: async (tx: WriteTransaction, x: number) => {
+        console.log(tx);
+        return x;
+      },
+      mut2: (tx: WriteTransaction, x: string) => {
+        console.log(tx);
+        return x;
+      },
+      mut3: tx => {
+        console.log(tx);
+      },
+      mut4: async tx => {
+        console.log(tx);
+      },
+    },
   });
+
+  const {mut, mut2, mut3, mut4} = rep.mutate;
   const res: number = await mut(42);
   console.log(res);
 
-  const mut2 = rep.register('mut', (tx: WriteTransaction, x: string) => {
-    console.log(tx);
-    return x;
-  });
   const res2: string = await mut2('s');
   console.log(res2);
 
-  const mut3 = rep.register('mut2', tx => {
-    console.log(tx);
-  });
   await mut3();
   //  @ts-expect-error: Expected 0 arguments, but got 1.ts(2554)
   await mut3(42);
@@ -1301,9 +1334,6 @@ test.skip('mutator optional args [type checking only]', async () => {
   const res3: number = await mut3();
   console.log(res3);
 
-  const mut4 = rep.register('mut2', async tx => {
-    console.log(tx);
-  });
   await mut4();
   //  @ts-expect-error: Expected 0 arguments, but got 1.ts(2554)
   await mut4(42);
@@ -1311,14 +1341,16 @@ test.skip('mutator optional args [type checking only]', async () => {
   const res4: number = await mut4();
   console.log(res4);
 
-  // @ts-expect-error: Types of parameters 'x' and 'args' are incompatible.
-  //   Type 'JSONValue' is not assignable to type 'Date'.
-  //     Type 'null' is not assignable to type 'Date'.ts(2769)
-  const mut5 = rep.register('mut3', (tx: WriteTransaction, x: Date) => {
-    console.log(tx);
-    return x;
-  });
-  console.log(mut5);
+  // This should be an error!
+  // await replicacheForTesting('test-types-2', {
+  //   mutators: {
+  //     // @ts-expect-error symbol is not a JSONValue
+  //     mut5: (tx: WriteTransaction, x: symbol) => {
+  //       console.log(tx, x);
+  //       return 42;
+  //     },
+  //   },
+  // });
 });
 
 testWithBothStores('logLevel', async () => {
@@ -1419,17 +1451,18 @@ test('JSON deep equal', () => {
 
 // Only used for type checking
 test.skip('Test partial JSONObject [type checking only]', async () => {
-  const rep = await replicacheForTesting('test-types');
+  const rep = await replicacheForTesting('test-types', {
+    mutators: {
+      mut: async (tx: WriteTransaction, todo: Partial<Todo>) => {
+        console.log(tx);
+        return todo;
+      },
+    },
+  });
 
   type Todo = {id: number; text: string};
 
-  const mut = rep.register(
-    'mut',
-    async (tx: WriteTransaction, todo: Partial<Todo>) => {
-      console.log(tx);
-      return todo;
-    },
-  );
+  const {mut} = rep.mutate;
   await mut({});
   await mut({id: 42});
   await mut({text: 'abc'});
@@ -1442,50 +1475,48 @@ test.skip('Test partial JSONObject [type checking only]', async () => {
 
 // Only used for type checking
 test.skip('Test register param [type checking only]', async () => {
-  const rep = await replicacheForTesting('test-types');
-
-  const mut: () => Promise<void> = rep.register(
-    'mut',
-    async (tx: WriteTransaction) => {
-      console.log(tx);
+  const rep = await replicacheForTesting('test-types', {
+    mutators: {
+      mut: async (tx: WriteTransaction) => {
+        console.log(tx);
+      },
+      mut2: async (tx: WriteTransaction, x: string) => {
+        console.log(tx, x);
+      },
+      mut3: async (tx: WriteTransaction, x: string) => {
+        console.log(tx, x);
+      },
+      mut4: async (tx: WriteTransaction) => {
+        console.log(tx);
+      },
     },
-  );
+  });
+
+  const mut: () => Promise<void> = rep.mutate.mut;
   console.log(mut);
 
   // @ts-expect-error Type 'number' is not assignable to type 'string'.ts(2322)
-  const mut2: (x: number) => Promise<void> = rep.register(
-    'mut2',
-    async (tx: WriteTransaction, x: string) => {
-      console.log(tx, x);
-    },
-  );
+  const mut2: (x: number) => Promise<void> = rep.mutate.mut2;
   console.log(mut2);
 
   // @ts-expect-error Type '(args: string) => Promise<void>' is not assignable to type '() => Promise<void>'.ts(2322)
-  const mut3: () => Promise<void> = rep.register(
-    'mut3',
-    async (tx: WriteTransaction, x: string) => {
-      console.log(tx, x);
-    },
-  );
+  const mut3: () => Promise<void> = rep.mutate.mut3;
   console.log(mut3);
 
   // This is fine according to the rules of JS/TS
-  const mut4: (x: number) => Promise<void> = rep.register(
-    'mut4',
-    async (tx: WriteTransaction) => {
-      console.log(tx);
-    },
-  );
+  const mut4: (x: number) => Promise<void> = rep.mutate.mut4;
   console.log(mut4);
 
-  rep.register(
-    'mut5',
-    // @ts-expect-error ts(2345)
-    async (tx: WriteTransaction, a: string, b: number) => {
-      console.log(tx, a, b);
+  await replicacheForTesting('test-types', {
+    mutators: {
+      // @ts-expect-error Type '(tx: WriteTransaction, a: string, b: number) =>
+      //   Promise<void>' is not assignable to type '(tx: WriteTransaction,
+      //   args?: any) => MaybePromise<void | JSONValue>'.ts(2322)
+      mut5: async (tx: WriteTransaction, a: string, b: number) => {
+        console.log(tx, a, b);
+      },
     },
-  );
+  });
 });
 
 // Only used for type checking
@@ -1532,8 +1563,11 @@ test.skip('Key type for scans [type checking only]', async () => {
 });
 
 test('mem store', async () => {
-  let rep = await replicacheForTesting('mem', {useMemstore: true});
-  const add = rep.register('addData', addData);
+  let rep = await replicacheForTesting('mem', {
+    mutators: {addData},
+    useMemstore: true,
+  });
+  const add = rep.mutate.addData;
   await add({a: 42});
   expect(await rep.query(tx => tx.get('a'))).to.equal(42);
   await rep.close();
@@ -1544,11 +1578,25 @@ test('mem store', async () => {
 });
 
 testWithBothStores('isEmpty', async () => {
-  const rep = await replicacheForTesting('test-is-empty');
-  const add = rep.register('add-data', addData);
-  const del = rep.register('del', (tx: WriteTransaction, key: string) =>
-    tx.del(key),
-  );
+  const rep = await replicacheForTesting('test-is-empty', {
+    mutators: {
+      addData,
+      del: (tx: WriteTransaction, key: string) => tx.del(key),
+      mut: async tx => {
+        expect(await tx.isEmpty()).to.eq(false);
+
+        tx.del('c');
+        expect(await tx.isEmpty()).to.eq(false);
+
+        tx.del('a');
+        expect(await tx.isEmpty()).to.eq(true);
+
+        tx.put('d', 4);
+        expect(await tx.isEmpty()).to.eq(false);
+      },
+    },
+  });
+  const {addData: add, del, mut} = rep.mutate;
 
   async function t(expected: boolean) {
     expect(await rep?.query(tx => tx.isEmpty())).to.eq(expected);
@@ -1566,18 +1614,6 @@ testWithBothStores('isEmpty', async () => {
   await del('b');
   await t(false);
 
-  const mut = rep.register('mut', async tx => {
-    expect(await tx.isEmpty()).to.eq(false);
-
-    tx.del('c');
-    expect(await tx.isEmpty()).to.eq(false);
-
-    tx.del('a');
-    expect(await tx.isEmpty()).to.eq(true);
-
-    tx.put('d', 4);
-    expect(await tx.isEmpty()).to.eq(false);
-  });
   await mut();
 
   await t(false);
@@ -1591,8 +1627,9 @@ testWithBothStores('onSync', async () => {
     pullURL,
     pushURL,
     pushDelay: 5,
+    mutators: {addData},
   });
-  const add = rep.register('add-data', addData);
+  const add = rep.mutate.addData;
 
   const onSync = sinon.fake();
   rep.onSync = onSync;
@@ -1667,10 +1704,11 @@ testWithBothStores('push timing', async () => {
     pushURL,
     pushDelay,
     useMemstore: true,
+    mutators: {addData},
   });
   const spy = spyInvoke(rep);
 
-  const add = rep.register('add-data', addData);
+  const add = rep.mutate.addData;
 
   fetchMock.post(pushURL, {});
   await add({a: 0});
@@ -1722,10 +1760,11 @@ test('push and pull concurrently', async () => {
     pushURL,
     useMemstore: true,
     pushDelay: 10,
+    mutators: {addData},
   });
   const spy = spyInvoke(rep);
 
-  const add = rep.register('add-data', addData);
+  const add = rep.mutate.addData;
 
   const reqs: string[] = [];
 
@@ -1801,9 +1840,10 @@ test('schemaVersion push', async () => {
     pushURL,
     schemaVersion,
     pushDelay: 1,
+    mutators: {addData},
   });
 
-  const add = rep.register('add-data', addData);
+  const add = rep.mutate.addData;
   await add({a: 1});
 
   fetchMock.post(pushURL, {});
@@ -1835,7 +1875,7 @@ test('clientID', async () => {
 // Only used for type checking
 test.skip('mut [type checking only]', async () => {
   const rep = new Replicache({
-    mut: {
+    mutators: {
       a: (tx: WriteTransaction) => {
         console.log(tx);
         return 42;
@@ -1879,53 +1919,53 @@ test.skip('mut [type checking only]', async () => {
     },
   });
 
-  rep.mut.a() as Promise<number>;
-  rep.mut.b(4) as Promise<string>;
+  rep.mutate.a() as Promise<number>;
+  rep.mutate.b(4) as Promise<string>;
 
-  rep.mut.c() as Promise<void>;
-  rep.mut.d(2) as Promise<void>;
+  rep.mutate.c() as Promise<void>;
+  rep.mutate.d(2) as Promise<void>;
 
-  rep.mut.e() as Promise<number>;
-  rep.mut.f(4) as Promise<string>;
+  rep.mutate.e() as Promise<number>;
+  rep.mutate.f(4) as Promise<string>;
 
-  rep.mut.g() as Promise<void>;
-  rep.mut.h(2) as Promise<void>;
+  rep.mutate.g() as Promise<void>;
+  rep.mutate.h(2) as Promise<void>;
 
   // @ts-expect-error Expected 1 arguments, but got 0.ts(2554)
-  rep.mut.b();
+  rep.mutate.b();
   //@ts-expect-error Argument of type 'null' is not assignable to parameter of type 'number'.ts(2345)
-  rep.mut.b(null);
+  rep.mutate.b(null);
 
   // @ts-expect-error Expected 1 arguments, but got 0.ts(2554)
-  rep.mut.d();
+  rep.mutate.d();
   //@ts-expect-error Argument of type 'null' is not assignable to parameter of type 'number'.ts(2345)
-  rep.mut.d(null);
+  rep.mutate.d(null);
 
   // @ts-expect-error Expected 1 arguments, but got 0.ts(2554)
-  rep.mut.f();
+  rep.mutate.f();
   //@ts-expect-error Argument of type 'null' is not assignable to parameter of type 'number'.ts(2345)
-  rep.mut.f(null);
+  rep.mutate.f(null);
 
   // @ts-expect-error Expected 1 arguments, but got 0.ts(2554)
-  rep.mut.h();
+  rep.mutate.h();
   // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'number'.ts(2345)
-  rep.mut.h(null);
+  rep.mutate.h(null);
 
   {
-    const rep = new Replicache({mut: {}});
+    const rep = new Replicache({mutators: {}});
     // @ts-expect-error Property 'abc' does not exist on type 'MakeMutators<{}>'.ts(2339)
-    rep.mut.abc(43);
+    rep.mutate.abc(43);
   }
 
   {
     const rep = new Replicache({});
     // @ts-expect-error Property 'abc' does not exist on type 'MakeMutators<{}>'.ts(2339)
-    rep.mut.abc(1, 2, 3);
+    rep.mutate.abc(1, 2, 3);
   }
 
   {
     const rep = new Replicache();
     // @ts-expect-error Property 'abc' does not exist on type 'MakeMutators<{}>'.ts(2339)
-    rep.mut.abc(1, 2, 3);
+    rep.mutate.abc(1, 2, 3);
   }
 });

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -43,8 +43,10 @@ const MAX_REAUTH_TRIES = 8;
  * The type used when implementing mutators.
  */
 export type MutatorImpl<
-  Args extends JSONValue,
-  Return extends JSONValue | void
+  // Not sure how to not use any here...
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Args extends JSONValue = any,
+  Return extends JSONValue | void = JSONValue | void
 > = (tx: WriteTransaction, args?: Args) => MaybePromise<Return>;
 
 /**
@@ -52,9 +54,7 @@ export type MutatorImpl<
  * constructor as part of the [[ReplicacheOptions]].
  */
 export type MutatorDefs = {
-  // Not sure how to not use any here...
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: MutatorImpl<any, JSONValue | void>;
+  [key: string]: MutatorImpl;
 };
 
 /**

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -140,9 +140,9 @@ export class ReadTransactionImpl implements ReadTransaction {
 }
 
 /**
- * WriteTransactions are used with
- * [[Replicache.register]] and allows read and write
- * operations on the database.
+ * WriteTransactions are used with *mutators* which are registered using
+ * [[ReplicacheOptions.mutators]] and allows read and write operations on the
+ * database.
  */
 export interface WriteTransaction extends ReadTransaction {
   /**


### PR DESCRIPTION
This adds a `mut` option to ReplicacheOptions which contains the
mutators to register.

These mutators are available as `mut` on the `Replicache` instance after
construction.

Fixes #329