### PR TITLE
Feat: Add scan().entries().toArray() etc

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -167,7 +167,7 @@ function Chat({rep}) {
       // Note: Replicache also supports secondary indexes, which can be used
       // with scan. See:
       // https://js.replicachedev/classes/replicache.html#createindex
-      const list = await tx.scanAll({prefix: 'message/'});
+      const list = await tx.scan({prefix: 'message/'}).entries().toArray();
       list.sort(([, {order: a}], [, {order: b}]) => a - b);
       return list;
     },

--- a/src/async-iterable-to-array.ts
+++ b/src/async-iterable-to-array.ts
@@ -1,0 +1,9 @@
+export async function asyncIterableToArray<T>(
+  it: AsyncIterable<T>,
+): Promise<T[]> {
+  const arr: T[] = [];
+  for await (const v of it) {
+    arr.push(v);
+  }
+  return arr;
+}

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -11,7 +11,10 @@ export type {
   ReadTransaction,
   WriteTransaction,
 } from './transactions.js';
-export type {ScanResult} from './scan-iterator.js';
+export type {
+  ScanResult,
+  AsyncIterableIteratorToArrayWrapper,
+} from './scan-iterator.js';
 export type {JSONObject, JSONValue} from './json.js';
 export type {
   KeyTypeForScanOptions,

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -211,36 +211,15 @@ async function testScanResult<K, V>(
     );
   });
 
-  // scanXxx
   await rep.query(async tx => {
     expect(await tx.scanAll(options)).to.deep.equal(entries);
   });
+
   await rep.query(async tx => {
-    expect(await tx.scanAllValues(options)).to.deep.equal(
+    expect(await tx.scan(options).toArray()).to.deep.equal(
       entries.map(([, v]) => v),
     );
   });
-  await rep.query(async tx => {
-    expect(await tx.scanAllKeys(options)).to.deep.equal(
-      entries.map(([k]) => k),
-    );
-  });
-
-  // scan().xxxArray()
-  await rep.query(async tx => {
-    expect(await tx.scan(options).entriesArray()).to.deep.equal(entries);
-  });
-  await rep.query(async tx => {
-    expect(await tx.scan(options).valuesArray()).to.deep.equal(
-      entries.map(([, v]) => v),
-    );
-  });
-  await rep.query(async tx => {
-    expect(await tx.scan(options).keysArray()).to.deep.equal(
-      entries.map(([k]) => k),
-    );
-  });
-
   // scan().xxx().toArray()
   await rep.query(async tx => {
     expect(await tx.scan(options).entries().toArray()).to.deep.equal(entries);

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -541,19 +541,6 @@ export class Replicache<MD extends MutatorDefs = {}>
     );
   }
 
-  private async _scanAll<O extends ScanOptions, R>(
-    options: O | undefined,
-    f: (tx: ReadTransactionImpl, options?: O) => Promise<R>,
-  ): Promise<R> {
-    const tx = new ReadTransactionImpl(this._invoke);
-    try {
-      await tx.open({});
-      return await f(tx, options);
-    } finally {
-      tx.close();
-    }
-  }
-
   /**
    * Convenience form of `scan()` which returns all the entries as an array.
    * @deprecated Use `scan().entries().toArray()` instead.
@@ -561,7 +548,13 @@ export class Replicache<MD extends MutatorDefs = {}>
   async scanAll<O extends ScanOptions, K extends KeyTypeForScanOptions<O>>(
     options?: O,
   ): Promise<[K, JSONValue][]> {
-    return this._scanAll(options, tx => tx.scanAll(options));
+    const tx = new ReadTransactionImpl(this._invoke);
+    try {
+      await tx.open({});
+      return await tx.scanAll(options);
+    } finally {
+      tx.close();
+    }
   }
 
   /**

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -541,19 +541,44 @@ export class Replicache<MD extends MutatorDefs = {}>
     );
   }
 
+  private async _scanAll<O extends ScanOptions, R>(
+    options: O | undefined,
+    f: (tx: ReadTransactionImpl, options?: O) => Promise<R>,
+  ): Promise<R> {
+    const tx = new ReadTransactionImpl(this._invoke);
+    try {
+      await tx.open({});
+      return await f(tx, options);
+    } finally {
+      tx.close();
+    }
+  }
+
   /**
    * Convenience form of `scan()` which returns all the entries as an array.
    */
   async scanAll<O extends ScanOptions, K extends KeyTypeForScanOptions<O>>(
     options?: O,
   ): Promise<[K, JSONValue][]> {
-    const tx = new ReadTransactionImpl(this._invoke);
-    try {
-      await tx.open({});
-      return await tx.scanAll(options);
-    } finally {
-      tx.close();
-    }
+    return this._scanAll(options, tx => tx.scanAll(options));
+  }
+
+  /**
+   * Convenience form of [[scan]] which returns all the keys as an array.
+   */
+  async scanAllKeys<O extends ScanOptions, K extends KeyTypeForScanOptions<O>>(
+    options?: O,
+  ): Promise<K[]> {
+    return this._scanAll(options, tx => tx.scanAllKeys(options));
+  }
+
+  /**
+   * Convenience form of [[scan]] which returns all the keys as an array.
+   */
+  async scanAllValues<O extends ScanOptions>(
+    options?: O,
+  ): Promise<JSONValue[]> {
+    return this._scanAll(options, tx => tx.scanAllValues(options));
   }
 
   /**

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -556,29 +556,12 @@ export class Replicache<MD extends MutatorDefs = {}>
 
   /**
    * Convenience form of `scan()` which returns all the entries as an array.
+   * @deprecated Use `scan().entries().toArray()` instead.
    */
   async scanAll<O extends ScanOptions, K extends KeyTypeForScanOptions<O>>(
     options?: O,
   ): Promise<[K, JSONValue][]> {
     return this._scanAll(options, tx => tx.scanAll(options));
-  }
-
-  /**
-   * Convenience form of [[scan]] which returns all the keys as an array.
-   */
-  async scanAllKeys<O extends ScanOptions, K extends KeyTypeForScanOptions<O>>(
-    options?: O,
-  ): Promise<K[]> {
-    return this._scanAll(options, tx => tx.scanAllKeys(options));
-  }
-
-  /**
-   * Convenience form of [[scan]] which returns all the keys as an array.
-   */
-  async scanAllValues<O extends ScanOptions>(
-    options?: O,
-  ): Promise<JSONValue[]> {
-    return this._scanAll(options, tx => tx.scanAllValues(options));
   }
 
   /**

--- a/src/scan-iterator.ts
+++ b/src/scan-iterator.ts
@@ -37,13 +37,13 @@ export class ScanResult<K> implements AsyncIterable<JSONValue> {
   }
 
   /** The default AsyncIterable. This is the same as [[values]]. */
-  [Symbol.asyncIterator](): AsyncIterableIterator<JSONValue> {
+  [Symbol.asyncIterator](): AsyncIterableIteratorToArrayWrapper<JSONValue> {
     return this.values();
   }
 
   /** Async iterator over the valus of the [[ReadTransaction.scan|scan]] call. */
-  values(): ToArrayWrapper<JSONValue> {
-    return new ToArrayWrapper(this._newIterator(VALUE));
+  values(): AsyncIterableIteratorToArrayWrapper<JSONValue> {
+    return new AsyncIterableIteratorToArrayWrapper(this._newIterator(VALUE));
   }
 
   /**
@@ -51,8 +51,8 @@ export class ScanResult<K> implements AsyncIterable<JSONValue> {
    * call. If the [[ReadTransaction.scan|scan]] is over an index the key
    * is a tuple of `[secondaryKey: string, primaryKey]`
    */
-  keys(): ToArrayWrapper<K> {
-    return new ToArrayWrapper(this._newIterator(KEY));
+  keys(): AsyncIterableIteratorToArrayWrapper<K> {
+    return new AsyncIterableIteratorToArrayWrapper(this._newIterator(KEY));
   }
 
   /**
@@ -61,8 +61,8 @@ export class ScanResult<K> implements AsyncIterable<JSONValue> {
    * [[ReadTransaction.scan|scan]] is over an index the key is a tuple of
    * `[secondaryKey: string, primaryKey]`
    */
-  entries(): ToArrayWrapper<[K, JSONValue]> {
-    return new ToArrayWrapper(this._newIterator(ENTRY));
+  entries(): AsyncIterableIteratorToArrayWrapper<[K, JSONValue]> {
+    return new AsyncIterableIteratorToArrayWrapper(this._newIterator(ENTRY));
   }
 
   valuesArray(): Promise<JSONValue[]> {
@@ -82,11 +82,21 @@ export class ScanResult<K> implements AsyncIterable<JSONValue> {
   }
 }
 
-class ToArrayWrapper<V> implements AsyncIterableIterator<V> {
+/**
+ * A class that wraps an async iterable iterator to add a [[toArray]] method.
+ *
+ * Usage:
+ *
+ * ```ts
+ * const keys: string[] = await rep.scan().keys().toArray();
+ * ```
+ */
+export class AsyncIterableIteratorToArrayWrapper<V>
+  implements AsyncIterableIterator<V> {
   private readonly _it: AsyncIterableIterator<V>;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readonly next: (v: any) => Promise<IteratorResult<V>>;
+  readonly next: (v?: any) => Promise<IteratorResult<V>>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly return?: (value?: any) => Promise<IteratorResult<V>>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/scan-iterator.ts
+++ b/src/scan-iterator.ts
@@ -65,16 +65,9 @@ export class ScanResult<K> implements AsyncIterable<JSONValue> {
     return new AsyncIterableIteratorToArrayWrapper(this._newIterator(ENTRY));
   }
 
-  valuesArray(): Promise<JSONValue[]> {
-    return asyncIterableToArray(this._newIterator(VALUE));
-  }
-
-  keysArray(): Promise<JSONValue[]> {
-    return asyncIterableToArray(this._newIterator(KEY));
-  }
-
-  entriesArray(): Promise<JSONValue[]> {
-    return asyncIterableToArray(this._newIterator(ENTRY));
+  /** Returns all the values as an array. Same as `values().toArray()` */
+  toArray(): Promise<JSONValue[]> {
+    return this.values().toArray();
   }
 
   private _newIterator<V>(kind: ScanIterableKind): AsyncIterableIterator<V> {

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -46,22 +46,11 @@ export interface ReadTransaction {
 
   /**
    * Convenience form of [[scan]] which returns all the entries as an array.
+   * @deprecated Use `scan().entries().toArray()` instead
    */
   scanAll<O extends ScanOptions, K extends KeyTypeForScanOptions<O>>(
     options?: O,
   ): Promise<[K, JSONValue][]>;
-
-  /**
-   * Convenience form of [[scan]] which returns all the keys as an array.
-   */
-  scanAllKeys<O extends ScanOptions, K extends KeyTypeForScanOptions<O>>(
-    options?: O,
-  ): Promise<K[]>;
-
-  /**
-   * Convenience form of [[scan]] which returns all the keys as an array.
-   */
-  scanAllValues<O extends ScanOptions>(options?: O): Promise<JSONValue[]>;
 }
 
 export class ReadTransactionImpl implements ReadTransaction {
@@ -121,18 +110,6 @@ export class ReadTransactionImpl implements ReadTransaction {
     return asyncIterableToArray(
       this.scan(options).entries() as AsyncIterable<[K, JSONValue]>,
     );
-  }
-
-  async scanAllKeys<O extends ScanOptions, K extends KeyTypeForScanOptions<O>>(
-    options?: O,
-  ): Promise<K[]> {
-    return asyncIterableToArray(this.scan(options).keys() as AsyncIterable<K>);
-  }
-
-  async scanAllValues<O extends ScanOptions>(
-    options?: O,
-  ): Promise<JSONValue[]> {
-    return asyncIterableToArray(this.scan(options).values());
   }
 
   get id(): number {


### PR DESCRIPTION
This adds `toArray` to scan values/keys/entries as well as ScanResult.toArray

Fixes #292