### PR TITLE
Add performance test for subscribe scale

### DIFF
--- a/perf/perf.js
+++ b/perf/perf.js
@@ -5,6 +5,7 @@ import {
   benchmarkScan,
   benchmarkSingleByteWrite,
   benchmarkWriteReadRoundTrip,
+  benchmarkSubscribe,
 } from './replicache.js';
 import {benchmarkIDBRead, benchmarkIDBWrite} from './idb.js';
 
@@ -130,6 +131,9 @@ const benchmarks = [
   benchmarkWriteReadRoundTrip(),
   benchmarkCreateIndex({numKeys: 1000}),
   benchmarkCreateIndex({numKeys: 5000}),
+  benchmarkSubscribe({count: 10}),
+  benchmarkSubscribe({count: 100}),
+  benchmarkSubscribe({count: 1000}),
 ];
 
 for (let b of [benchmarkIDBRead, benchmarkIDBWrite]) {

--- a/perf/runner.js
+++ b/perf/runner.js
@@ -32,7 +32,10 @@ async function main() {
 
   const page = await context.newPage();
   await page.goto(`http://127.0.0.1:${port}/perf/index.html`);
-  await page.waitForFunction('typeof nextTest ===  "function"');
+  await page.waitForFunction('typeof nextTest ===  "function"', null, {
+    // No need to wait 30s if failing to load
+    timeout: 1000,
+  });
   logLine('Running benchmarks please wait...');
 
   if (devtools) {


### PR DESCRIPTION
These test runs subscribe over a db with 1000 keys. It creates N
subscriptions and then mutates 10 keys. The goal is to have the
execution time only depend on the number of affected subscriptions and
not the total number of subscriptions in the app.

Towards #63