### PR TITLE
Do not run things twice durin npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/ perf/",
     "build": "rm -rf out && rollup --config rollup.config.js && CJS=1 rollup --config rollup.config.js ",
     "build:watch": "rollup --config rollup.config.js --watch",
-    "prepack": "npm run lint && tool/get-deps.sh && npm run test && npm run build",
-    "prepare": "rm -f node_modules/fetch-mock/esm/client.d.ts",
+    "prepack": "npm run lint && npm run test && npm run build",
+    "prepare": "rm -f node_modules/fetch-mock/esm/client.d.ts && tool/get-deps.sh",
     "perf": "node perf/runner.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,11 +10,10 @@
     "format": "prettier --write '{doc,src,sample,perf}/**/*.{js,jsx,json,ts,tsx,html,css,md}' '*.{js,jsx,json,ts,tsx,html,css,md}'",
     "check-format": "prettier --check '{doc,src,sample,perf}/**/*.{js,jsx,json,ts,tsx,html,css,md}' '*.{js,jsx,json,ts,tsx,html,css,md}'",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/ perf/",
-    "build": "rollup --config rollup.config.js && CJS=1 rollup --config rollup.config.js ",
+    "build": "rm -rf out && rollup --config rollup.config.js && CJS=1 rollup --config rollup.config.js ",
     "build:watch": "rollup --config rollup.config.js --watch",
-    "prepublishOnly": "npm run lint && tool/get-deps.sh && npm run test && rm -rf out && npm run build",
-    "prepack": "npm run prepublishOnly",
-    "prepare": "rm -f node_modules/fetch-mock/esm/client.d.ts && tool/get-deps.sh",
+    "prepack": "npm run lint && tool/get-deps.sh && npm run test && npm run build",
+    "prepare": "rm -f node_modules/fetch-mock/esm/client.d.ts",
     "perf": "node perf/runner.js"
   },
   "devDependencies": {


### PR DESCRIPTION
This was happening because `prepack` was calling `prepublishOnly` so we
ended up calling `prepublishOnly` twice.

Fixes #379