### PR TITLE
Update guide-poke.md

### DIFF
--- a/doc/docs/guide-poke.md
+++ b/doc/docs/guide-poke.md
@@ -5,11 +5,11 @@ slug: /guide/poke
 
 Many realtime systems use WebSockets to push live updates to clients. This has performance benefits, but comes at a steep operational cost. WebSocket-based services are more complex to scale because they have to keep state in memory for each connected client.
 
-Replicache instead uses WebSockets only to hint the client that it should pull again. No data is sent over the socket. This enables developers to build their realtime web applications in the standard stateless request/response style. You can even build Replicache-enabled apps serverlessly (as we are here with Next.js)! We have found that we can get most of the performace back with HTTP/2, anyway.
+Replicache instead uses WebSockets only to hint the client that it should pull again. No data is sent over the socket. This enables developers to build their realtime web applications in the standard stateless request/response style. You can even build Replicache-enabled apps serverlessly (as we are here with Next.js)! We have found that we can get most of the performance back with HTTP/2, anyway.
 
 We refer to this WebSocket hint as a _poke_, to go along with _push_ and _pull_. You can use any hosted WebSocket service to send pokes, such as [socket.io](https://socket.io) or [Pusher](https://pusher.com/), and it's trivial to setup.
 
-For this sample, we'll use Pusher. Get thee to [pusher.com](https://pusher.com) and setup a free project with client type "React" and server type "Node.js".
+For this sample, we'll use Pusher. Get thee to [pusher.com](https://pusher.com) and setup a free project under "Channels" with client type "React" and server type "Node.js".
 
 Store the settings from the project in the following environment variables:
 


### PR DESCRIPTION
Qualify which Pusher product to use and fix minor typo.

The Pusher top level page now has two product choices, "Beams" and "Channels",
and it wasn't obvious which to use.