### PR TITLE
FEAT: Expose requestOptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 doc/docs/api
 src/wasm
 out
+docs/

--- a/src/connection-loop.test.ts
+++ b/src/connection-loop.test.ts
@@ -3,7 +3,6 @@ import {SinonFakeTimers, useFakeTimers} from 'sinon';
 import {
   ConnectionLoop,
   ConnectionLoopDelegate,
-  CONNECTION_MEMORY_COUNT,
   DEBOUNCE_DELAY_MS,
   MAX_CONNECTIONS,
   MAX_DELAY_MS,
@@ -70,7 +69,6 @@ function createLoop(
     maxConnections: MAX_CONNECTIONS,
     maxDelayMs: MAX_DELAY_MS,
     minDelayMs: MIN_DELAY_MS,
-    connectionMemoryCount: CONNECTION_MEMORY_COUNT,
     ...partialDelegate,
   };
 
@@ -517,7 +515,6 @@ test('mutate minDelayMs', async () => {
     },
     maxDelayMs: 60_000,
     maxConnections: MAX_CONNECTIONS,
-    connectionMemoryCount: CONNECTION_MEMORY_COUNT,
     watchdogTimer: null,
   });
 

--- a/src/connection-loop.ts
+++ b/src/connection-loop.ts
@@ -21,9 +21,6 @@ export interface ConnectionLoopDelegate extends Logger {
   maxConnections: number;
   maxDelayMs: number;
   minDelayMs: number;
-  // The number of successful requests to keep in memory. This is currently used
-  // to compute the median over.
-  connectionMemoryCount: number;
 }
 
 export class ConnectionLoop {
@@ -201,7 +198,7 @@ export class ConnectionLoop {
 }
 
 // Number of connections to remember when computing the new delay.
-export const CONNECTION_MEMORY_COUNT = 9;
+const CONNECTION_MEMORY_COUNT = 9;
 
 // Computes a new delay based on the previous requests. We use the median of the
 // previous successfull request divided by `maxConnections`. When we get errors
@@ -223,7 +220,7 @@ function computeDelayAndUpdateDurations(
     return delay * 2;
   }
 
-  const {maxConnections, connectionMemoryCount, minDelayMs} = delegate;
+  const {maxConnections, minDelayMs} = delegate;
 
   if (length === 1) {
     return (duration / maxConnections) | 0;
@@ -233,7 +230,7 @@ function computeDelayAndUpdateDurations(
   const previous: SendRecord = sendRecords[sendRecords.length - 2];
 
   // Prune
-  while (sendRecords.length > connectionMemoryCount) {
+  while (sendRecords.length > CONNECTION_MEMORY_COUNT) {
     sendRecords.shift();
   }
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -2,9 +2,12 @@ export {Replicache} from './replicache.js';
 export {TransactionClosedError} from './transaction-closed-error.js';
 
 export type {
-  ReplicacheOptions,
   MaybePromise,
   MutatorDefs,
+  PullOptions,
+  PushOptions,
+  ReplicacheOptions,
+  RequestOptions,
 } from './replicache.js';
 export type {
   CreateIndexDefinition,

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -4,8 +4,6 @@ export {TransactionClosedError} from './transaction-closed-error.js';
 export type {
   MaybePromise,
   MutatorDefs,
-  PullOptions,
-  PushOptions,
   ReplicacheOptions,
   RequestOptions,
 } from './replicache.js';

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -76,7 +76,6 @@ async function replicacheForTesting<MD extends MutatorDefs = {}>(
   reps.add(rep);
   // Wait for open to be done.
   await rep.clientID;
-
   fetchMock.post(pullURL, {lastMutationID: 0, patch: []});
   fetchMock.post(pushURL, {});
   await tickAFewTimes();

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -2682,3 +2682,71 @@ testWithBothStores('subscribe pull and index update', async () => {
 
   cancel();
 });
+
+async function tickUntilTimeIs(time: number, tick = 10) {
+  while (Date.now() < time) {
+    await clock.tickAsync(tick);
+  }
+}
+
+test('pull mutate options', async () => {
+  const rep = await replicacheForTesting('pull-mutate-options', {
+    useMemstore: true,
+  });
+  const pullURL = rep.pullOptions.url;
+  const log: number[] = [];
+
+  fetchMock.post(pullURL, () => {
+    log.push(Date.now());
+    return {
+      cookie: '',
+      lastMutationID: 2,
+      patch: [],
+    };
+  });
+
+  await tickUntilTimeIs(1000);
+
+  while (Date.now() < 1150) {
+    rep.pull();
+    await clock.tickAsync(10);
+  }
+
+  rep.pullOptions.minDelayMs = 500;
+
+  while (Date.now() < 2000) {
+    rep.pull();
+    await clock.tickAsync(100);
+  }
+
+  rep.pullOptions.minDelayMs = 25;
+
+  while (Date.now() < 2500) {
+    rep.pull();
+    await clock.tickAsync(5);
+  }
+
+  expect(log).to.deep.equal([
+    1000,
+    1030,
+    1060,
+    1090,
+    1120,
+    1150,
+    1180,
+    1680,
+    2180,
+    2205,
+    2230,
+    2255,
+    2280,
+    2305,
+    2330,
+    2355,
+    2380,
+    2405,
+    2430,
+    2455,
+    2480,
+  ]);
+});


### PR DESCRIPTION
Expose options used to control the `ConnectionLoop` used by pull and push.

These can be initially passed into `ReplicacheOptions` as `requestOptions` and can be read and mutated through `replicacheInstance.requestOptions`.

For example:

```js
const rep = new Replicache({
  requestOptions: {minDelayMs: 75},
});

...
rep.requestOptions.minDelayMs = 200;
```

Fixes #395