### PR TITLE
Exit early if no subscriptions

### DIFF
--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -2230,8 +2230,6 @@ test('push and pull concurrently', async () => {
     'OpenTransaction',
     'Put',
     'CommitTransaction',
-    'OpenTransaction',
-    'CloseTransaction',
     'BeginTryPull',
     'TryPush',
   ]);
@@ -2249,8 +2247,6 @@ test('push and pull concurrently', async () => {
     'OpenTransaction',
     'Put',
     'CommitTransaction',
-    'OpenTransaction',
-    'CloseTransaction',
     'BeginTryPull',
     'TryPush',
   ]);

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -938,6 +938,10 @@ export class Replicache<MD extends MutatorDefs = {}>
     subscriptions: Iterable<Subscription<JSONValue | undefined, unknown>>,
   ) {
     const subs = [...subscriptions];
+    if (subs.length === 0) {
+      return;
+    }
+
     type R =
       | {ok: true; value: JSONValue | undefined}
       | {ok: false; error: unknown};


### PR DESCRIPTION
No need to open a read transaction if no subscriptions were effected by
the change.