### PR TITLE
FIX: Make sure online is reported correctly

### DIFF
--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -2742,7 +2742,7 @@ test('pull mutate options', async () => {
   ]);
 });
 
-testWithBothStores('online', async () => {
+test('online', async () => {
   const pushURL = 'https://diff.com/push';
   const rep = await replicacheForTesting('online', {
     useMemstore: true,

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -2769,6 +2769,7 @@ test('online', async () => {
   expect(info.callCount).to.be.greaterThan(0);
 
   info.resetHistory();
+  expect(info.callCount).to.equal(0);
 
   fetchMock.post(pushURL, 'ok');
   await rep.mutate.addData({a: 1});

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -2760,7 +2760,6 @@ test('online', async () => {
   expect(rep.online).to.equal(true);
 
   await rep.mutate.addData({a: 0});
-  expect(info.callCount).to.equal(0);
 
   await tickAFewTimes();
 

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -2775,6 +2775,9 @@ test('online', async () => {
   await rep.mutate.addData({a: 1});
 
   await tickAFewTimes();
+  if (info.callCount > 0) {
+    console.warn(info.getCalls()[0].firstArg);
+  }
   expect(info.callCount).to.equal(0);
   expect(rep.online).to.equal(true);
 });

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -25,6 +25,7 @@ import {
   reps,
   dbsToDrop,
 } from './test-util.js';
+import {sleep} from './sleep.js';
 
 let clock: SinonFakeTimers;
 setup(function () {
@@ -2753,7 +2754,8 @@ test('online', async () => {
 
   const info = sinon.stub(console, 'log');
 
-  fetchMock.post(pushURL, () => {
+  fetchMock.post(pushURL, async () => {
+    await sleep(10);
     return {throws: new Error('Simulate fetch error in push')};
   });
 
@@ -2765,8 +2767,6 @@ test('online', async () => {
 
   expect(rep.online).to.equal(false);
   expect(info.callCount).to.be.greaterThan(0);
-
-  await tickAFewTimes();
 
   info.resetHistory();
 

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -2771,7 +2771,7 @@ test('online', async () => {
   info.resetHistory();
   expect(info.callCount).to.equal(0);
 
-  fetchMock.post(pushURL, 'ok');
+  fetchMock.post(pushURL, {});
   await rep.mutate.addData({a: 1});
 
   await tickAFewTimes();

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -2767,6 +2767,8 @@ test('online', async () => {
   expect(rep.online).to.equal(false);
   expect(info.callCount).to.be.greaterThan(0);
 
+  await tickAFewTimes();
+
   info.resetHistory();
 
   fetchMock.post(pushURL, 'ok');

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -2769,15 +2769,12 @@ test('online', async () => {
   expect(info.callCount).to.be.greaterThan(0);
 
   info.resetHistory();
-  expect(info.callCount).to.equal(0);
 
   fetchMock.post(pushURL, {});
   await rep.mutate.addData({a: 1});
 
   await tickAFewTimes();
-  if (info.callCount > 0) {
-    console.warn(info.getCalls()[0].firstArg);
-  }
+
   expect(info.callCount).to.equal(0);
   expect(rep.online).to.equal(true);
 });

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -785,7 +785,12 @@ export class Replicache<MD extends MutatorDefs = {}>
       // hacky string search. (a) and (c) are not distinguishable currently
       // because repc doesn't provide sufficient information, so we treat all
       // errors that aren't (b) as (a).
-      if (e.toString().includes('JSLogInfo')) {
+
+      // TODO(arv): Use Error.prototype.cause
+      // (https://github.com/tc39/proposal-error-cause) and check for a
+      // structured error in the cause chain. On the Rust side we should create
+      // a structured error that we can instanceof check instead
+      if (e.toString().includes('FetchFailed')) {
         online = false;
       }
       this._logger.info?.(`${name} returned: ${e}`);


### PR DESCRIPTION
We were no longer getting errors with JSLogInfo in them.

For now just look for "FetchFailed"

Add a test to ensure that this continues to work if we change repc again.

Fixes #408