### PR TITLE
Wait for close in open

### DIFF
--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -2311,6 +2311,11 @@ test('clientID', async () => {
   const clientID3 = await rep.clientID;
   expect(clientID3).to.match(re);
   expect(clientID3).to.equal(clientID);
+
+  const rep4 = new Replicache({name: 'clientID4', pullInterval: null});
+  const clientID4 = await rep4.clientID;
+  expect(clientID4).to.match(re);
+  await rep4.close();
 });
 
 // Only used for type checking

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -2788,3 +2788,32 @@ test('online', async () => {
   expect(info.callCount).to.equal(0);
   expect(rep.online).to.equal(true);
 });
+
+test('overlapping open/close', async () => {
+  const pullInterval = 60_000;
+  const name = 'overlapping-open-close';
+
+  const rep = new Replicache({name, pullInterval});
+  const p = rep.close();
+
+  const rep2 = new Replicache({name, pullInterval});
+  const p2 = rep2.close();
+
+  const rep3 = new Replicache({name, pullInterval});
+  const p3 = rep3.close();
+
+  await p;
+  await p2;
+  await p3;
+
+  {
+    const rep = new Replicache({name, pullInterval});
+    await rep.clientID;
+    const p = rep.close();
+    const rep2 = new Replicache({name, pullInterval});
+    await rep2.clientID;
+    const p2 = rep2.close();
+    await p;
+    await p2;
+  }
+});


### PR DESCRIPTION
If there is a Replicache instance with the same name that is currently
closing, then we wait for that close to finish before we open a new
instance.

This fixes the issue where the developer uses the useReplicache hook and
has hot module reloading enabled.

Fixes #405