### PR TITLE
FIX: Remove unused type Mutation

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -20,7 +20,7 @@ export type {
   ScanOptionIndexedStartKey,
   ScanOptions,
 } from './scan-options.js';
-export type {HTTPRequestInfo, InitInput, Mutation} from './repm-invoker.js';
+export type {HTTPRequestInfo, InitInput} from './repm-invoker.js';
 export type {LogLevel} from './logger.js';
 export type {
   PatchOperation,

--- a/src/repm-invoker.ts
+++ b/src/repm-invoker.ts
@@ -180,13 +180,14 @@ type MaybeEndTryPullRequest = {
   syncHead: string;
 };
 
-export type Mutation = {
+/**
+ * ReplayMutation is used int the RPC between EndPull so that we can replay
+ * mutations ontop of the current state. It is never exposed to the public.
+ */
+type ReplayMutation = {
   id: number;
   name: string;
   args: string;
-};
-
-type ReplayMutation = Mutation & {
   original: string;
 };
 


### PR DESCRIPTION
And clarify ReplayMutation with a comment.

Technically, this is a breaking change from 6.3 but it is only a type
and the type is never used so hopefully we can get away with it without
doing a major release.