### PR TITLE
feat: Make more Replicache options public

### DIFF
--- a/doc/docs/design.md
+++ b/doc/docs/design.md
@@ -86,9 +86,8 @@ This API sketch is in TypeScript, for JavaScript bindings. A similar API would e
 class Replicache implements ReadTransaction {
   constructor({
     pushURL: string,
-    pushAuth: string,
     pullURL: string,
-    pullAuth: string,
+    auth: string,
     // Registers the mutators, which are used to make changes to the data.
     mutators: {[name: string]: MutatorImpl}
   });

--- a/doc/docs/launch-checklist.md
+++ b/doc/docs/launch-checklist.md
@@ -9,7 +9,9 @@ Before you launch with Replicache in your product, it's a good idea to double-ch
 
 - If you wish to change the type of a mutator (eg, the number or type of its arguments) you must choose a new name; Replicache does not handle mutator versioning.
 - At some point you will almost certainly wish to change the schema of mutations included in the `PushRequest` and the `clientView` returned in the `PullResponse`. The `ReplicacheOptions.schemaVersion` exists to facilitate this; it can be set by your app and is passed in both the `PushRequest` and `PullRequest`. Consider setting the `schemaVersion` from the start so that you don't later have to special case the "no schemaVersion" case.
-- If a user's auth token can expire during a session, causing your endpoints to return a 401, be sure that re-auth is handled for **Push** and **Pull** via `getPushAuth` and `getPullAuth`.
+- If a user's auth token can expire during a session, causing your endpoints to
+  return a 401, be sure that re-auth is handled for **Push** and **Pull** via
+  `getAuth`.
 - If you wish to store per-client state, be sure to key it by `clientID`, and not, for example, by user id which can be common to more than one client.
 
 ## All endpoints

--- a/doc/docs/server-pull.md
+++ b/doc/docs/server-pull.md
@@ -42,7 +42,7 @@ Always `application/json`.
 ### `Authorization`
 
 This is a string that can be used to authorize a user. The auth token is set
-by defining [`pullAuth`](api/interfaces/replicacheoptions#pullauth) or [`getPullAuth`](api/classes/replicache#getpullauth).
+by defining [`auth`](api/interfaces/replicacheoptions#auth).
 
 ### `X-Replicache-RequestID`
 
@@ -95,7 +95,7 @@ your instance of [`Replicache`](api/classes/replicache).
 ### HTTP Response Status
 
 - `200` for success
-- `401` for auth error — Replicache will reauthenticate using [`getPullAuth`](api/classes/replicache#getpullauth) if available
+- `401` for auth error — Replicache will reauthenticate using [`getAuth`](api/classes/replicache#getauth) if available
 - All other status codes considered errors
 
 Replicache will exponentially back off sending pushes in the case of both network level and HTTP level errors.

--- a/doc/docs/server-push.md
+++ b/doc/docs/server-push.md
@@ -43,8 +43,7 @@ Always `application/json`.
 ### `Authorization`
 
 This is a string that can be used to authorize a user. The auth token is set by
-defining [`pushAuth`](api/interfaces/replicacheoptions#pushauth) or
-[`getPushAuth`](api/classes/replicache#getpushauth).
+defining [`auth`](api/interfaces/replicacheoptions#auth).
 
 ### `X-Replicache-RequestID`
 
@@ -107,7 +106,7 @@ your instance of [`Replicache`](api/classes/replicache).
 
 - `200` for success
 - `401` for auth error — Replicache will reauthenticate using
-  [`getPushAuth`](api/classes/replicache#getpushauth) if available
+  [`getAuth`](api/classes/replicache#getauth) if available
 - All other status codes are considered to be errors
 
 Replicache will exponentially back off sending pushes in the case of both

--- a/src/replicache-options.ts
+++ b/src/replicache-options.ts
@@ -14,6 +14,7 @@ export interface ReplicacheOptions<MD extends MutatorDefs> {
    * This is the
    * [authorization](https://doc.replicache.dev/server-push#authorization) token
    * used when doing a [push](https://doc.replicache.dev/server-push).
+   * @deprecated Use [[auth]] instead.
    */
   pushAuth?: string;
 
@@ -28,8 +29,16 @@ export interface ReplicacheOptions<MD extends MutatorDefs> {
    * This is the
    * [authorization](https://doc.replicache.dev/server-pull#authorization) token
    * used when doing a [pull](https://doc.replicache.dev/server-pull).
+   * @deprecated Use [[auth]] instead.
    */
   pullAuth?: string;
+
+  /**
+   * This is the authorization token used when doing a
+   * [pull](https://doc.replicache.dev/server-pull#authorization) and
+   * [push](https://doc.replicache.dev/server-push#authorization).
+   */
+  auth?: string;
 
   /**
    * This is the URL to the server endpoint dealing with pull. See [Pull

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -1074,7 +1074,7 @@ testWithBothStores('push', async () => {
   const pushURL = 'https://push.com';
 
   const rep = await replicacheForTesting('push', {
-    pushAuth: '1',
+    auth: '1',
     pushURL,
     pushDelay: 10,
     mutators: {
@@ -1184,7 +1184,7 @@ testWithBothStores('push delay', async () => {
   const pushURL = 'https://push.com';
 
   const rep = await replicacheForTesting('push', {
-    pushAuth: '1',
+    auth: '1',
     pushURL,
     pushDelay: 1,
     mutators: {
@@ -1223,7 +1223,7 @@ testWithBothStores('pull', async () => {
   const pullURL = 'https://diff.com/pull';
 
   const rep = await replicacheForTesting('pull', {
-    pullAuth: '1',
+    auth: '1',
     pullURL,
     mutators: {
       createTodo: async <A extends {id: number}>(
@@ -1354,31 +1354,31 @@ testWithBothStores('reauth pull', async () => {
 
   const rep = await replicacheForTesting('reauth', {
     pullURL,
-    pullAuth: 'wrong',
+    auth: 'wrong',
   });
 
   fetchMock.post(pullURL, {body: 'xxx', status: httpStatusUnauthorized});
 
   const consoleErrorStub = sinon.stub(console, 'error');
 
-  const getPullAuthFake = sinon.fake.returns(null);
-  rep.getPullAuth = getPullAuthFake;
+  const getAuthFake = sinon.fake.returns(null);
+  rep.getAuth = getAuthFake;
 
   await rep.beginPull();
 
-  expect(getPullAuthFake.callCount).to.equal(1);
+  expect(getAuthFake.callCount).to.equal(1);
   expect(consoleErrorStub.firstCall.args[0]).to.equal(
     'Got error response from server (https://diff.com/pull) doing pull: 401: xxx',
   );
 
   {
     const consoleInfoStub = sinon.stub(console, 'log');
-    const getPullAuthFake = sinon.fake(() => 'boo');
-    rep.getPullAuth = getPullAuthFake;
+    const getAuthFake = sinon.fake(() => 'boo');
+    rep.getAuth = getAuthFake;
 
     expect((await rep.beginPull()).syncHead).to.equal('');
 
-    expect(getPullAuthFake.callCount).to.equal(8);
+    expect(getAuthFake.callCount).to.equal(8);
     expect(consoleInfoStub.firstCall.args[0]).to.equal(
       'Tried to reauthenticate too many times',
     );
@@ -2175,7 +2175,7 @@ testWithBothStores('onSync', async () => {
     const consoleErrorStub = sinon.stub(console, 'error');
     fetchMock.postOnce(pushURL, {body: 'xxx', status: httpStatusUnauthorized});
     onSync.resetHistory();
-    rep.getPushAuth = () => {
+    rep.getAuth = () => {
       // Next time it is going to be fine
       fetchMock.postOnce({url: pushURL, headers: {authorization: 'ok'}}, {});
       return 'ok';

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -124,14 +124,25 @@ const emptySet: ReadonlySet<string> = new Set();
 export class Replicache<MD extends MutatorDefs = {}>
   implements ReadTransaction
 {
-  private _pullAuth: string;
-  private readonly _pullURL: string;
-  private _pushAuth: string;
-  private readonly _pushURL: string;
-  private readonly _name: string;
+  /** The URL to use when doing a pull request. */
+  pullURL: string;
+
+  /** The URL to use when doing a push request. */
+  pushURL: string;
+
+  /** The authorization token used when doing a pull request. */
+  pullAuth: string;
+  /** The authorization token used when doing a push request. */
+  pushAuth: string;
+
+  /** The name of the Replicache database. */
+  readonly name: string;
+
   private readonly _repmInvoker: Invoker;
   private readonly _useMemstore: boolean;
-  private readonly _schemaVersion: string = '';
+
+  /** The schema version of the data understood by this application. */
+  schemaVersion: string;
 
   private _closed = false;
   private _online = true;
@@ -178,8 +189,17 @@ export class Replicache<MD extends MutatorDefs = {}>
   pushDelay: number;
 
   private readonly _requestOptions: Required<RequestOptions>;
-  private readonly _puller: Puller;
-  private readonly _pusher: Pusher;
+
+  /**
+   * The function to use to pull data from the server.
+   */
+  puller: Puller;
+
+  /**
+   * The function to use to push data to the server.
+   */
+  pusher: Pusher;
+
   private readonly _store: Store;
 
   /**
@@ -244,22 +264,22 @@ export class Replicache<MD extends MutatorDefs = {}>
       pusher = defaultPusher,
       experimentalKVStore,
     } = options;
-    this._pullAuth = pullAuth;
-    this._pullURL = pullURL;
-    this._pushAuth = pushAuth;
-    this._pushURL = pushURL;
-    this._name = name;
+    this.pullAuth = pullAuth;
+    this.pullURL = pullURL;
+    this.pushAuth = pushAuth;
+    this.pushURL = pushURL;
+    this.name = name;
     this._repmInvoker = new REPMWasmInvoker(wasmModule);
-    this._schemaVersion = schemaVersion;
+    this.schemaVersion = schemaVersion;
     this.pullInterval = pullInterval;
     this.pushDelay = pushDelay;
     this._useMemstore = useMemstore;
-    this._puller = puller;
-    this._pusher = pusher;
+    this.puller = puller;
+    this.pusher = pusher;
     this._store =
       experimentalKVStore || this._useMemstore
         ? new MemStore()
-        : new IDBStore(this._name);
+        : new IDBStore(this.name);
 
     // Use a promise-resolve pair so that we have a promise to use even before
     // we call the Open RPC.
@@ -298,16 +318,16 @@ export class Replicache<MD extends MutatorDefs = {}>
   private async _open(): Promise<OpenResponse> {
     // If we are currently closing a Replicache instance with the same name,
     // wait for it to finish closing.
-    await closingInstances.get(this._name);
+    await closingInstances.get(this.name);
 
-    const openResponse = await this._repmInvoker.invoke(this._name, RPC.Open, {
+    const openResponse = await this._repmInvoker.invoke(this.name, RPC.Open, {
       useMemstore: this._useMemstore,
       store: this._store,
     });
     this._openResolve(openResponse);
 
     if (hasBroadcastChannel) {
-      this._broadcastChannel = new BroadcastChannel(storageKeyName(this._name));
+      this._broadcastChannel = new BroadcastChannel(storageKeyName(this.name));
       this._broadcastChannel.onmessage = (e: MessageEvent<BroadcastData>) =>
         this._onBroadcastMessage(e.data);
     } else {
@@ -369,7 +389,7 @@ export class Replicache<MD extends MutatorDefs = {}>
   async close(): Promise<void> {
     this._closed = true;
     const p = this._invoke(RPC.Close);
-    closingInstances.set(this._name, p);
+    closingInstances.set(this.name, p);
 
     this._pullConnectionLoop.close();
     this._pushConnectionLoop.close();
@@ -388,7 +408,7 @@ export class Replicache<MD extends MutatorDefs = {}>
     this._subscriptions.clear();
 
     await p;
-    closingInstances.delete(this._name);
+    closingInstances.delete(this.name);
   }
 
   private async _getRoot(): Promise<string | undefined> {
@@ -401,7 +421,7 @@ export class Replicache<MD extends MutatorDefs = {}>
 
   private _onStorage = (e: StorageEvent) => {
     const {key, newValue} = e;
-    if (newValue && key === storageKeyName(this._name)) {
+    if (newValue && key === storageKeyName(this.name)) {
       const {root, changedKeys, index} = JSON.parse(
         newValue,
       ) as StorageBroadcastData;
@@ -452,7 +472,7 @@ export class Replicache<MD extends MutatorDefs = {}>
     } else {
       // local storage needs a string...
       const data = {root, changedKeys: [...changedKeys.entries()], index};
-      localStorage[storageKeyName(this._name)] = JSON.stringify(data);
+      localStorage[storageKeyName(this.name)] = JSON.stringify(data);
     }
   }
 
@@ -473,7 +493,7 @@ export class Replicache<MD extends MutatorDefs = {}>
     args?: JSONValue,
   ): Promise<JSONValue> => {
     await this._openResponse;
-    return await this._repmInvoker.invoke(this._name, rpc, args);
+    return await this._repmInvoker.invoke(this.name, rpc, args);
   };
 
   /** Get a single value from the database. */
@@ -686,10 +706,10 @@ export class Replicache<MD extends MutatorDefs = {}>
       try {
         this._changeSyncCounters(1, 0);
         pushResponse = await this._invoke(RPC.TryPush, {
-          pushURL: this._pushURL,
-          pushAuth: this._pushAuth,
-          schemaVersion: this._schemaVersion,
-          pusher: this._pusher,
+          pushURL: this.pushURL,
+          pushAuth: this.pushAuth,
+          schemaVersion: this.schemaVersion,
+          pusher: this.pusher,
         });
       } finally {
         this._changeSyncCounters(-1, 0);
@@ -701,7 +721,7 @@ export class Replicache<MD extends MutatorDefs = {}>
         const reauth = checkStatus(
           httpRequestInfo,
           'push',
-          this._pushURL,
+          this.pushURL,
           this._logger,
         );
 
@@ -715,7 +735,7 @@ export class Replicache<MD extends MutatorDefs = {}>
           }
           const pushAuth = await this.getPushAuth();
           if (pushAuth != null) {
-            this._pushAuth = pushAuth;
+            this.pushAuth = pushAuth;
             // Try again now instead of waiting for next push.
             return await this._invokePush(maxAuthTries - 1);
           }
@@ -751,10 +771,10 @@ export class Replicache<MD extends MutatorDefs = {}>
 
   protected async _beginPull(maxAuthTries: number): Promise<BeginPullResult> {
     const beginPullResponse = await this._invoke(RPC.BeginTryPull, {
-      pullAuth: this._pullAuth,
-      pullURL: this._pullURL,
-      schemaVersion: this._schemaVersion,
-      puller: this._puller,
+      pullAuth: this.pullAuth,
+      pullURL: this.pullURL,
+      schemaVersion: this.schemaVersion,
+      puller: this.puller,
     });
 
     const {httpRequestInfo, syncHead, requestID} = beginPullResponse;
@@ -762,7 +782,7 @@ export class Replicache<MD extends MutatorDefs = {}>
     const reauth = checkStatus(
       httpRequestInfo,
       'pull',
-      this._pullURL,
+      this.pullURL,
       this._logger,
     );
     if (reauth && this.getPullAuth) {
@@ -780,7 +800,7 @@ export class Replicache<MD extends MutatorDefs = {}>
         this._changeSyncCounters(0, 1);
       }
       if (pullAuth != null) {
-        this._pullAuth = pullAuth;
+        this.pullAuth = pullAuth;
         // Try again now instead of waiting for next pull.
         return await this._beginPull(maxAuthTries - 1);
       }


### PR DESCRIPTION
This makes a few more options from `ReplicacheOptions` public and
read/write on the `Replicache` instance. The following are now reflected
on `Replicache` and can be changed at runtime:
  - `auth`
  - `pushURL`
  - `pullURL`
  - `name` (readonly)
  - `schemaVersion`
  - `pullInterval`
  - `pushDelay`
  - `mutators` (gets reflected as mutate)
  - `requestOptions` (readonly)
  - `puller`
  - `pusher`

I decided not to reflect these readonly properties from
`ReplicacheOptions`:
  - `wasmModule`
  - `useMemstore`
  - `logLevel`

Also, deprecate `Replicache` `getPullAuth` and `getPushAuth` in favor of a single `getAuth`.

Fixes #402