### PR TITLE
chore: Enable eslint rule to find missing await

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,9 +1,13 @@
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: './tsconfig.json',
+  },
   plugins: ['@typescript-eslint'],
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
   rules: {
+    '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/naming-convention': [
       'error',
       {

--- a/src/connection-loop.ts
+++ b/src/connection-loop.ts
@@ -60,6 +60,7 @@ export class ConnectionLoop {
 
   constructor(delegate: ConnectionLoopDelegate) {
     this._delegate = delegate;
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.run();
   }
 
@@ -154,6 +155,7 @@ export class ConnectionLoop {
       }
 
       counter++;
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       (async () => {
         const start = Date.now();
         let ok: boolean;

--- a/src/kv/idb-store.test.ts
+++ b/src/kv/idb-store.test.ts
@@ -28,7 +28,7 @@ test('dropStore', async () => {
   });
 
   // Drop db
-  dropStore(name);
+  await dropStore(name);
 
   // Reopen store, verify data is gone
   idb = new IDBStore(name);

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -2059,13 +2059,13 @@ test.skip('Key type for scans [type checking only]', async () => {
   rep.scan({indexName: 'n', start: {key: ['s', 42]}});
 
   // @ts-expect-error Type 'number' is not assignable to type 'string | undefined'.ts(2322)
-  rep.scanAll({indexName: 'n', start: {key: ['s', 42]}});
+  await rep.scanAll({indexName: 'n', start: {key: ['s', 42]}});
 
   // @ts-expect-error Type '[string]' is not assignable to type 'string'.ts(2322)
   rep.scan({start: {key: ['s']}});
 
   // @ts-expect-error Type '[string]' is not assignable to type 'string'.ts(2322)
-  rep.scanAll({start: {key: ['s']}});
+  await rep.scanAll({start: {key: ['s']}});
 });
 
 test('mem store', async () => {
@@ -2091,13 +2091,13 @@ testWithBothStores('isEmpty', async () => {
       mut: async tx => {
         expect(await tx.isEmpty()).to.equal(false);
 
-        tx.del('c');
+        await tx.del('c');
         expect(await tx.isEmpty()).to.equal(false);
 
-        tx.del('a');
+        await tx.del('a');
         expect(await tx.isEmpty()).to.equal(true);
 
-        tx.put('d', 4);
+        await tx.put('d', 4);
         expect(await tx.isEmpty()).to.equal(false);
       },
     },
@@ -2441,24 +2441,24 @@ test.skip('mut [type checking only]', async () => {
   rep.mutate.h(2) as Promise<void>;
 
   // @ts-expect-error Expected 1 arguments, but got 0.ts(2554)
-  rep.mutate.b();
+  await rep.mutate.b();
   //@ts-expect-error Argument of type 'null' is not assignable to parameter of type 'number'.ts(2345)
-  rep.mutate.b(null);
+  await rep.mutate.b(null);
 
   // @ts-expect-error Expected 1 arguments, but got 0.ts(2554)
-  rep.mutate.d();
+  await rep.mutate.d();
   //@ts-expect-error Argument of type 'null' is not assignable to parameter of type 'number'.ts(2345)
-  rep.mutate.d(null);
+  await rep.mutate.d(null);
 
   // @ts-expect-error Expected 1 arguments, but got 0.ts(2554)
-  rep.mutate.f();
+  await rep.mutate.f();
   //@ts-expect-error Argument of type 'null' is not assignable to parameter of type 'number'.ts(2345)
-  rep.mutate.f(null);
+  await rep.mutate.f(null);
 
   // @ts-expect-error Expected 1 arguments, but got 0.ts(2554)
-  rep.mutate.h();
+  await rep.mutate.h();
   // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'number'.ts(2345)
-  rep.mutate.h(null);
+  await rep.mutate.h(null);
 
   {
     const rep = new Replicache({mutators: {}});
@@ -2495,7 +2495,7 @@ test.skip('scan with index [type checking only]', async () => {
   (await rep.scanAll()) as [string, JSONValue][];
   (await rep.scanAll({indexName: 'i'})) as [[string, string], JSONValue][];
 
-  rep.query(async tx => {
+  await rep.query(async tx => {
     (await tx.scan({indexName: 'a'}).keys().toArray()) as [
       secondary: string,
       primary: string,

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -432,6 +432,7 @@ export class Replicache<MD extends MutatorDefs = {}>
         newValue,
       ) as StorageBroadcastData;
 
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       this._onBroadcastMessage({
         root,
         changedKeys: new Map(changedKeys),
@@ -553,6 +554,7 @@ export class Replicache<MD extends MutatorDefs = {}>
       await tx.open({});
       return await tx.scanAll(options);
     } finally {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       closeIgnoreError(tx);
     }
   }
@@ -585,7 +587,7 @@ export class Replicache<MD extends MutatorDefs = {}>
       await tx.open({});
       await f(tx);
     } finally {
-      tx.commit();
+      await tx.commit();
     }
   }
 
@@ -828,6 +830,8 @@ export class Replicache<MD extends MutatorDefs = {}>
     const counter = this._pushCounter + this._pullCounter;
     if ((delta === 1 && counter === 1) || counter === 0) {
       const syncing = counter > 0;
+      // Run in a new microtask.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       Promise.resolve().then(() => this.onSync?.(syncing));
     }
   }
@@ -927,6 +931,7 @@ export class Replicache<MD extends MutatorDefs = {}>
     } as unknown as UnknownSubscription;
     this._subscriptions.add(s);
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this._scheduleInitialSubscriptionRun(s);
 
     return (): void => {
@@ -958,6 +963,7 @@ export class Replicache<MD extends MutatorDefs = {}>
       return await body(tx);
     } finally {
       // No need to await the response.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       closeIgnoreError(tx);
     }
   }
@@ -1048,6 +1054,7 @@ export class Replicache<MD extends MutatorDefs = {}>
       result = await mutatorImpl(tx, args);
     } catch (ex) {
       // No need to await the response.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       closeIgnoreError(tx);
       throw ex;
     }


### PR DESCRIPTION
This adds the `@typescript-eslint/no-floating-promises` rule to
mark missing await as errors.

This forces us to explicitly disable the `no-floating-promises` rule
when we do not want to await something.