### PR TITLE
Fix perf runner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "eslint": "^7.32.0",
         "fetch-mock": "^9.11.0",
         "get-port": "^5.1.1",
-        "idb": "^6.1.2",
+        "idb": "^6.1.3",
         "playwright": "^1.13.1",
         "prettier": "^2.3.2",
         "rollup": "^2.56.3",
@@ -3126,9 +3126,9 @@
       }
     },
     "node_modules/idb": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.2.tgz",
-      "integrity": "sha512-1DNDVu3yDhAZkFDlJf0t7r+GLZ248F5pTAtA7V0oVG3yjmV125qZOx3g0XpAEkGZVYQiFDAsSOnGet2bhugc3w==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.3.tgz",
+      "integrity": "sha512-oIRDpVcs5KXpI1hRnTJUwkY63RB/7iqu9nSNuzXN8TLHjs7oO20IoPFbBTsqxIL5IjzIUDi+FXlVcK4zm26J8A==",
       "dev": true
     },
     "node_modules/ieee754": {
@@ -7945,9 +7945,9 @@
       }
     },
     "idb": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.2.tgz",
-      "integrity": "sha512-1DNDVu3yDhAZkFDlJf0t7r+GLZ248F5pTAtA7V0oVG3yjmV125qZOx3g0XpAEkGZVYQiFDAsSOnGet2bhugc3w==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.3.tgz",
+      "integrity": "sha512-oIRDpVcs5KXpI1hRnTJUwkY63RB/7iqu9nSNuzXN8TLHjs7oO20IoPFbBTsqxIL5IjzIUDi+FXlVcK4zm26J8A==",
       "dev": true
     },
     "ieee754": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint": "^7.32.0",
     "fetch-mock": "^9.11.0",
     "get-port": "^5.1.1",
-    "idb": "^6.1.2",
+    "idb": "^6.1.3",
     "playwright": "^1.13.1",
     "prettier": "^2.3.2",
     "rollup": "^2.56.3",

--- a/perf/idb.js
+++ b/perf/idb.js
@@ -1,5 +1,5 @@
-import {openDB, deleteDB} from './node_modules/idb/with-async-ittr.js';
-import xbytes from './node_modules/xbytes/dist/index.mjs';
+import {openDB, deleteDB} from '../node_modules/idb/with-async-ittr.js';
+import xbytes from '../node_modules/xbytes/dist/index.mjs';
 import {randomData} from './data.js';
 
 /**

--- a/perf/package.json
+++ b/perf/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
The perf runner depends on some npm modules. It also needs to be type
module.