### PR TITLE
Fix: compare to current main commit when computing changes from pull.

### DIFF
--- a/src/sync/pull.test.ts
+++ b/src/sync/pull.test.ts
@@ -582,7 +582,7 @@ test('maybe end try pull', async () => {
       interveningSync: false,
       expReplayIDs: [],
       expErr: undefined,
-      expChangedKeys: new Map([['', ['key/1']]]),
+      expChangedKeys: new Map([['', ['key/1', 'local']]]),
     },
     {
       name: '3 pending, 2 to replay',
@@ -683,7 +683,7 @@ test('maybe end try pull', async () => {
         resp.replayMutations?.length,
         `${c.name}: expected ${c.expReplayIDs}, got ${resp.replayMutations}`,
       );
-      expect(resp.changedKeys).to.deep.equal(c.expChangedKeys);
+      expect(resp.changedKeys, c.name).to.deep.equal(c.expChangedKeys);
 
       for (let i = 0; i < c.expReplayIDs.length; i++) {
         const chainIdx = chain.length - c.numNeedingReplay + i;

--- a/src/sync/pull.ts
+++ b/src/sync/pull.ts
@@ -259,24 +259,14 @@ export async function maybeEndTryPull(
     // TODO check invariants
 
     // Compute diffs (changed keys) for value map and index maps.
-    const mainSnapshotMap = await prolly.Map.load(
-      mainSnapshot.valueHash(),
-      dagRead,
-    );
+    const mainHead = await db.Commit.fromHash(mainHeadHash, dagRead);
+    const mainHeadMap = await prolly.Map.load(mainHead.valueHash(), dagRead);
     const syncHeadMap = await prolly.Map.load(syncHead.valueHash(), dagRead);
-    const valueChangedKeys = prolly.Map.changedKeys(
-      mainSnapshotMap,
-      syncHeadMap,
-    );
+    const valueChangedKeys = prolly.Map.changedKeys(mainHeadMap, syncHeadMap);
     if (valueChangedKeys.length > 0) {
       changedKeys.set('', valueChangedKeys);
     }
-    await addChangedKeysForIndexes(
-      mainSnapshot,
-      syncHead,
-      dagRead,
-      changedKeys,
-    );
+    await addChangedKeysForIndexes(mainHead, syncHead, dagRead, changedKeys);
 
     // No mutations to replay so set the main head to the sync head and sync complete!
     await dagWrite.setHead(db.DEFAULT_HEAD_NAME, syncHeadHash);
@@ -352,8 +342,8 @@ function assertResult(v: any): asserts v is Result {
   assertHTTPRequestInfo(v.httpRequestInfo);
 }
 async function addChangedKeysForIndexes(
-  mainSnapshot: db.Commit,
-  syncHead: db.Commit,
+  mainCommit: db.Commit,
+  syncCommit: db.Commit,
   read: dag.Read,
   changedKeysMap: ChangedKeysMap,
 ) {
@@ -361,8 +351,8 @@ async function addChangedKeysForIndexes(
     return Array.from(oldMap.entries(), entry => utf8.decode(entry.key));
   }
 
-  const oldIndexes = db.readIndexes(mainSnapshot);
-  const newIndexes = db.readIndexes(syncHead);
+  const oldIndexes = db.readIndexes(mainCommit);
+  const newIndexes = db.readIndexes(syncCommit);
 
   for (const [oldIndexName, oldIndex] of oldIndexes) {
     await oldIndex.withMap(read, async oldMap => {


### PR DESCRIPTION
When computing changed keys for a pull, we were comparing the last snapshot on main to the current state of the sync branch.
    
This is not correct, because main will typically have subsequent pending changes which have not been confirmed by server yet. We need to consider these changes too when computing the diff.
    
Fixes #466