### PR TITLE
Delay using 'crypto' until runtime

### DIFF
--- a/src/sync/request-id.ts
+++ b/src/sync/request-id.ts
@@ -1,8 +1,12 @@
-const SESSION_ID = (() => {
-  const buf = new Uint8Array(4);
-  crypto.getRandomValues(buf);
-  return Array.from(buf, x => x.toString(16)).join('');
-})();
+let sessionID = '';
+function getSessionID() {
+  if (sessionID === '') {
+    const buf = new Uint8Array(4);
+    crypto.getRandomValues(buf);
+    sessionID = Array.from(buf, x => x.toString(16)).join('');
+  }
+  return sessionID;
+}
 
 const REQUEST_COUNTERS: Map<string, number> = new Map();
 
@@ -22,5 +26,5 @@ export function newRequestID(clientID: string): string {
     counter++;
     REQUEST_COUNTERS.set(clientID, counter);
   }
-  return `${clientID}-${SESSION_ID}-${counter}`;
+  return `${clientID}-${getSessionID()}-${counter}`;
 }


### PR DESCRIPTION
It's convenient to be able to import Replicache library into Next.js server-side environment, even though it's not yet usable there. Existing samples rely on this. Using 'crypto' at parse time defeats this because crypto is not defined in Next.js server env.