### PR TITLE
Use JSONValue for mutator args

### DIFF
--- a/src/db/commit.ts
+++ b/src/db/commit.ts
@@ -225,10 +225,10 @@ export class LocalMeta {
     return this.fb.mutatorName()!;
   }
 
-  mutatorArgsJSON(): Uint8Array {
+  mutatorArgsJSON(): JSONValue {
     // Already validated!
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return this.fb.mutatorArgsJsonArray()!;
+    return JSON.parse(utf8.decode(this.fb.mutatorArgsJsonArray()!));
   }
 
   originalHash(): string | undefined {
@@ -282,7 +282,7 @@ export function newLocal(
   basisHash: string | undefined,
   mutationID: number,
   mutatorName: string,
-  mutatorArgsJSON: Uint8Array,
+  mutatorArgsJSON: JSONValue,
   originalHash: string | undefined,
   valueHash: string,
   indexes: IndexRecord[],
@@ -292,7 +292,10 @@ export function newLocal(
     builder,
     flatbuffers.createLong(mutationID, 0),
     builder.createString(mutatorName),
-    LocalMetaFB.createMutatorArgsJsonVector(builder, mutatorArgsJSON),
+    LocalMetaFB.createMutatorArgsJsonVector(
+      builder,
+      utf8.encode(JSON.stringify(mutatorArgsJSON)),
+    ),
     originalHash ? builder.createString(originalHash) : 0,
   );
 

--- a/src/db/test-helpers.ts
+++ b/src/db/test-helpers.ts
@@ -49,7 +49,7 @@ export async function createLocal(
     const w = await Write.newLocal(
       whenceHead(DEFAULT_HEAD_NAME),
       `mutator_name_${i}`,
-      JSON.stringify([i]),
+      [i],
       undefined,
       dagWrite,
     );

--- a/src/db/write.ts
+++ b/src/db/write.ts
@@ -11,7 +11,6 @@ import {
 import {Read, readCommit, readIndexes, Whence} from './read';
 import {Index, IndexOperation, indexValue} from './index';
 import {scanRaw} from './scan';
-import * as utf8 from '../utf8';
 import type {LogContext} from '../logger';
 
 type IndexChangeMeta = {
@@ -22,7 +21,7 @@ type IndexChangeMeta = {
 type LocalMeta = {
   type: MetaType.Local;
   mutatorName: string;
-  mutatorArgs: string;
+  mutatorArgs: JSONValue;
   mutationID: number;
   originalHash: string | undefined;
 };
@@ -65,7 +64,7 @@ export class Write {
   static async newLocal(
     whence: Whence,
     mutatorName: string,
-    mutatorArgs: string,
+    mutatorArgs: JSONValue,
     originalHash: string | undefined,
     dagWrite: dag.Write,
   ): Promise<Write> {
@@ -309,7 +308,7 @@ export class Write {
           basisHash,
           mutationID,
           mutatorName,
-          utf8.encode(mutatorArgs),
+          mutatorArgs,
           originalHash,
           valueHash,
           indexMetas,

--- a/src/embed/connection.test.ts
+++ b/src/embed/connection.test.ts
@@ -2,7 +2,6 @@ import {expect} from '@esm-bundle/chai';
 import * as dag from '../dag/mod';
 import type * as db from '../db/mod';
 import * as sync from '../sync/mod';
-import * as utf8 from '../utf8';
 import {MemStore} from '../kv/mem-store';
 import {addGenesis, addLocal, Chain} from '../db/test-helpers';
 import {addSyncSnapshot} from '../sync/test-helpers';
@@ -31,10 +30,7 @@ test('open transaction rebase opts', async () => {
   let lm = meta.typed() as db.LocalMeta;
   const originalHash = original.chunk.hash;
   const originalName = lm.mutatorName();
-  const originalArgs = utf8.decode(lm.mutatorArgsJSON());
-
-  // drop(meta);
-  // drop(original);
+  const originalArgs = lm.mutatorArgsJSON();
 
   let result;
   try {
@@ -91,19 +87,19 @@ test('open transaction rebase opts', async () => {
     throw new Error('not local');
   }
   lm = meta.typed() as db.LocalMeta;
-  const new_local_hash = new_local.chunk.hash;
-  const new_local_name = lm.mutatorName();
-  const new_local_args = utf8.decode(lm.mutatorArgsJSON());
+  const newLocalHash = new_local.chunk.hash;
+  const newLocalName = lm.mutatorName();
+  const newLocalArgs = lm.mutatorArgsJSON();
   try {
     result = await openTransactionImpl(
       lc,
       store,
       txns,
-      new_local_name,
-      new_local_args,
+      newLocalName,
+      newLocalArgs,
       {
         basis: syncChain[0].chunk.hash,
-        original: new_local_hash,
+        original: newLocalHash,
       },
     );
   } catch (e) {

--- a/src/embed/connection.ts
+++ b/src/embed/connection.ts
@@ -142,7 +142,7 @@ async function init(store: dag.Store): Promise<void> {
 export async function openTransaction(
   dbName: string,
   name: string | undefined,
-  args: string | undefined,
+  args: JSONValue | undefined,
   rebaseOpts: RebaseOpts | undefined,
 ): Promise<number> {
   isTesting && logCall('openTransaction', dbName, name, args, rebaseOpts);
@@ -162,7 +162,7 @@ export async function openTransactionImpl(
   store: dag.Store,
   transactions: Map<number, {txn: Transaction; lc: LogContext}>,
   name: string | undefined,
-  args: string | undefined,
+  args: JSONValue | undefined,
   rebaseOpts: RebaseOpts | undefined,
 ): Promise<number> {
   const start = Date.now();
@@ -258,7 +258,7 @@ async function validateRebase(
   dagRead: dag.Read,
   mutatorName: string,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _args: string,
+  _args: JSONValue,
 ) {
   // Ensure the rebase commit is going on top of the current sync head.
   const syncHeadHash = await dagRead.getHead(sync.SYNC_HEAD_NAME);

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -607,7 +607,7 @@ export class Replicache<MD extends MutatorDefs = {}>
         syncHead,
         mutation.original,
         mutation.name,
-        JSON.parse(mutation.args),
+        mutation.args,
       );
     }
 
@@ -1023,7 +1023,7 @@ export class Replicache<MD extends MutatorDefs = {}>
     }: {invokeArgs?: OpenTransactionRequest; isReplay: boolean},
   ): Promise<{result: R; ref: string}> {
     let actualInvokeArgs: OpenTransactionRequest = {
-      args: args !== undefined ? JSON.stringify(args) : 'null',
+      args: args === undefined ? null : args,
       name,
     };
     if (invokeArgs !== undefined) {

--- a/src/repm-invoker.ts
+++ b/src/repm-invoker.ts
@@ -57,7 +57,7 @@ export type RebaseOpts = {
 
 export type OpenTransactionRequest = {
   name?: string;
-  args?: string;
+  args?: JSONValue;
   rebaseOpts?: RebaseOpts;
 };
 type OpenTransactionResponse = {

--- a/src/repm-invoker.ts
+++ b/src/repm-invoker.ts
@@ -3,6 +3,7 @@ import type {Pusher} from './pusher';
 import type * as kv from './kv/mod';
 import type * as dag from './dag/mod';
 import type * as db from './db/mod';
+import type {JSONValue} from './json';
 
 type OpenRequest = {
   useMemstore: boolean;
@@ -137,7 +138,7 @@ export type MaybeEndTryPullRequest = {
 export type ReplayMutation = {
   id: number;
   name: string;
-  args: string;
+  args: JSONValue;
   original: string;
 };
 

--- a/src/sync/pull.test.ts
+++ b/src/sync/pull.test.ts
@@ -34,7 +34,6 @@ import {
   PullRequest,
   PULL_VERSION,
 } from './pull';
-import * as utf8 from '../utf8';
 import {LogContext} from '../logger';
 import {initHasher} from '../hash';
 
@@ -634,11 +633,11 @@ test('maybe end try pull', async () => {
       const chainIndex = i + 1; // chain[0] is genesis
       const original = chain[chainIndex];
       let mutatorName: string;
-      let mutatorArgs: string;
+      let mutatorArgs: JSONValue;
       if (original.meta().isLocal()) {
         const lm = original.meta().typed() as db.LocalMeta;
         mutatorName = lm.mutatorName();
-        mutatorArgs = utf8.decode(lm.mutatorArgsJSON());
+        mutatorArgs = lm.mutatorArgsJSON();
       } else {
         throw new Error('impossible');
       }
@@ -691,7 +690,7 @@ test('maybe end try pull', async () => {
             }`,
           );
           const gotArgs = resp.replayMutations?.[i].args;
-          const expArgs = utf8.decode(lm.mutatorArgsJSON());
+          const expArgs = lm.mutatorArgsJSON();
           expect(expArgs).to.deep.equal(gotArgs);
         } else {
           throw new Error('inconceivable');

--- a/src/sync/pull.ts
+++ b/src/sync/pull.ts
@@ -1,6 +1,5 @@
 import type * as dag from '../dag/mod';
 import * as db from '../db/mod';
-import * as utf8 from '../utf8';
 import type {JSONValue} from '../json';
 import {assertPullResponse, Puller, PullError, PullResponse} from '../puller';
 import {
@@ -230,7 +229,7 @@ export async function maybeEndTryPull(
       const replayMutations: ReplayMutation[] = [];
       for (const c of pending) {
         let name: string;
-        let args: Uint8Array;
+        let args: JSONValue;
         if (c.meta().isLocal()) {
           const lm = c.meta().typed() as db.LocalMeta;
           name = lm.mutatorName();
@@ -241,7 +240,7 @@ export async function maybeEndTryPull(
         replayMutations.push({
           id: c.mutationID(),
           name,
-          args: utf8.decode(args),
+          args,
           original: c.chunk.hash,
         });
       }

--- a/src/sync/push.ts
+++ b/src/sync/push.ts
@@ -1,7 +1,6 @@
 import type {JSONValue} from '../json';
 import * as db from '../db/mod';
 import type * as dag from '../dag/mod';
-import * as utf8 from '../utf8';
 import {
   assertHTTPRequestInfo,
   HTTPRequestInfo,
@@ -38,7 +37,7 @@ export interface InternalPusher {
 }
 
 export function convert(lm: db.LocalMeta): Mutation {
-  const args = JSON.parse(utf8.decode(lm.mutatorArgsJSON()));
+  const args = lm.mutatorArgsJSON();
   return {
     id: lm.mutationID(),
     name: lm.mutatorName(),
@@ -70,17 +69,17 @@ export async function push(
 
   let httpRequestInfo: HTTPRequestInfo | undefined = undefined;
   if (pending.length > 0) {
-    const push_mutations: Mutation[] = [];
+    const pushMutations: Mutation[] = [];
     for (const commit of pending) {
       if (commit.meta().isLocal()) {
-        push_mutations.push(convert(commit.meta().typed() as db.LocalMeta));
+        pushMutations.push(convert(commit.meta().typed() as db.LocalMeta));
       } else {
         throw new Error('Internal non local pending commit');
       }
     }
     const pushReq = {
       clientID,
-      mutations: push_mutations,
+      mutations: pushMutations,
       pushVersion: PUSH_VERSION,
       schemaVersion: req.schemaVersion,
     };


### PR DESCRIPTION
We used to stringify it in JS and pass it as a string to repc. Now we
keep it as a JSONValue until we eventually write the flatbuffer.