### PR TITLE
Return deep copies of Replicache data out of read interfaces.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,14 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "replicache",
       "version": "7.0.0-beta.0",
       "license": "BSL-1.1",
       "dependencies": {
+        "@types/lodash-es": "^4.17.4",
         "flatbuffers": "^2.0.3",
-        "hash-wasm": "^4.9.0"
+        "hash-wasm": "^4.9.0",
+        "lodash-es": "^4.17.21"
       },
       "devDependencies": {
         "@esm-bundle/chai": "^4.3.4",
@@ -833,6 +836,19 @@
       "dev": true,
       "dependencies": {
         "@types/koa": "*"
+      }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.172",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.172.tgz",
+      "integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw=="
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.4.tgz",
+      "integrity": "sha512-BBz79DCJbD2CVYZH67MBeHZRX++HF+5p8Mo5MzjZi64Wac39S3diedJYHZtScbRVf4DjZyN6LzA0SB0zy+HSSQ==",
+      "dependencies": {
+        "@types/lodash": "*"
       }
     },
     "node_modules/@types/mime": {
@@ -3665,6 +3681,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -6220,6 +6241,19 @@
         "@types/koa": "*"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.172",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.172.tgz",
+      "integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw=="
+    },
+    "@types/lodash-es": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.4.tgz",
+      "integrity": "sha512-BBz79DCJbD2CVYZH67MBeHZRX++HF+5p8Mo5MzjZi64Wac39S3diedJYHZtScbRVf4DjZyN6LzA0SB0zy+HSSQ==",
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -8369,6 +8403,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
     "out/replicache.dev.wasm"
   ],
   "dependencies": {
+    "@types/lodash-es": "^4.17.4",
     "flatbuffers": "^2.0.3",
-    "hash-wasm": "^4.9.0"
+    "hash-wasm": "^4.9.0",
+    "lodash-es": "^4.17.21"
   }
 }

--- a/src/db/commit.ts
+++ b/src/db/commit.ts
@@ -9,7 +9,7 @@ import {Commit as CommitFB} from './generated/commit/commit';
 import {IndexRecord as IndexRecordFB} from './generated/commit/index-record';
 import {SnapshotMeta as SnapshotMetaFB} from './generated/commit/snapshot-meta';
 import {IndexChangeMeta as IndexChangeMetaFB} from './generated/commit/index-change-meta';
-import type {JSONValue} from '../json';
+import type {ReadonlyJSONValue, JSONValue} from '../json';
 import {assertInstanceof, assertNotNull, assertString} from '../asserts';
 import * as utf8 from '../utf8';
 
@@ -282,7 +282,7 @@ export function newLocal(
   basisHash: string | undefined,
   mutationID: number,
   mutatorName: string,
-  mutatorArgsJSON: JSONValue,
+  mutatorArgsJSON: ReadonlyJSONValue,
   originalHash: string | undefined,
   valueHash: string,
   indexes: IndexRecord[],
@@ -313,7 +313,7 @@ export function newLocal(
 export function newSnapshot(
   basisHash: string | undefined,
   lastMutationID: number,
-  cookieJSON: JSONValue,
+  cookieJSON: ReadonlyJSONValue,
   valueHash: string,
   indexes: IndexRecord[],
 ): Promise<Commit> {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,5 +1,6 @@
 import type * as dag from '../dag/mod';
-import type {JSONValue} from '../json';
+import type {DeepReadonly} from '../deep-readonly';
+import type {ReadonlyJSONValue, JSONObject} from '../json';
 import * as prolly from '../prolly/mod';
 import {RWLock} from '../rw-lock';
 import type {IndexRecord} from './commit';
@@ -53,7 +54,7 @@ export function indexValue(
   index: prolly.Map,
   op: IndexOperation,
   key: string,
-  val: JSONValue,
+  val: ReadonlyJSONValue,
   jsonPointer: string,
 ): void {
   for (const entry of getIndexKeys(key, val, jsonPointer)) {
@@ -71,7 +72,7 @@ export function indexValue(
 // Gets the set of index keys for a given primary key and value.
 export function getIndexKeys(
   primary: string,
-  value: JSONValue,
+  value: ReadonlyJSONValue,
   jsonPointer: string,
 ): string[] {
   const target = evaluateJSONPointer(value, jsonPointer);
@@ -184,9 +185,9 @@ export function decodeIndexKey(encodedIndexKey: string): IndexKey {
 }
 
 export function evaluateJSONPointer(
-  value: JSONValue,
+  value: ReadonlyJSONValue,
   pointer: string,
-): JSONValue | undefined {
+): ReadonlyJSONValue | undefined {
   function parseIndex(s: string): number | undefined {
     if (s.startsWith('+') || (s.startsWith('0') && s.length !== 1)) {
       return undefined;
@@ -218,6 +219,7 @@ export function evaluateJSONPointer(
     } else if (target === null) {
       return undefined;
     } else if (typeof target === 'object') {
+      target = target as DeepReadonly<JSONObject>;
       targetOpt = target[token];
     }
     if (targetOpt === undefined) {

--- a/src/db/read.ts
+++ b/src/db/read.ts
@@ -9,7 +9,7 @@ import {
   ScanResult,
 } from './scan';
 import {Commit} from './commit';
-import type {JSONValue} from '../json';
+import type {ReadonlyJSONValue} from '../json';
 
 export class Read {
   private readonly _dagRead: dag.Read;
@@ -26,7 +26,7 @@ export class Read {
     return this._map.has(key);
   }
 
-  get(key: string): JSONValue | undefined {
+  get(key: string): ReadonlyJSONValue | undefined {
     return this._map.get(key);
   }
 

--- a/src/db/scan.ts
+++ b/src/db/scan.ts
@@ -3,7 +3,7 @@ import type {Entry} from '../prolly/mod';
 import {PeekIterator} from '../prolly/peek-iterator';
 import {take, takeWhile} from './iter-util';
 import {decodeIndexKey, encodeIndexScanKey} from '.';
-import type {JSONValue} from '../json';
+import type {ReadonlyJSONValue} from '../json';
 
 // TODO(arv): Unify with src/scan-options.ts
 
@@ -63,7 +63,7 @@ export type ScanOptionsInternal = {
 export type ScanItem = {
   key: string;
   secondaryKey: string;
-  val: JSONValue;
+  val: ReadonlyJSONValue;
 };
 
 export const enum ScanResultType {

--- a/src/db/write.ts
+++ b/src/db/write.ts
@@ -1,5 +1,5 @@
 import type * as dag from '../dag/mod';
-import type {JSONValue} from '../json';
+import type {ReadonlyJSONValue} from '../json';
 import * as prolly from '../prolly/mod';
 import {
   Commit,
@@ -21,7 +21,7 @@ type IndexChangeMeta = {
 type LocalMeta = {
   type: MetaType.Local;
   mutatorName: string;
-  mutatorArgs: JSONValue;
+  mutatorArgs: ReadonlyJSONValue;
   mutationID: number;
   originalHash: string | undefined;
 };
@@ -29,7 +29,7 @@ type LocalMeta = {
 type SnapshotMeta = {
   type: MetaType.Snapshot;
   lastMutationID: number;
-  cookie: JSONValue;
+  cookie: ReadonlyJSONValue;
 };
 
 type Meta = SnapshotMeta | LocalMeta | IndexChangeMeta;
@@ -64,7 +64,7 @@ export class Write {
   static async newLocal(
     whence: Whence,
     mutatorName: string,
-    mutatorArgs: JSONValue,
+    mutatorArgs: ReadonlyJSONValue,
     originalHash: string | undefined,
     dagWrite: dag.Write,
   ): Promise<Write> {
@@ -89,7 +89,7 @@ export class Write {
   static async newSnapshot(
     whence: Whence,
     mutationID: number,
-    cookie: JSONValue,
+    cookie: ReadonlyJSONValue,
     dagWrite: dag.Write,
     indexes: Map<string, Index>,
   ): Promise<Write> {
@@ -130,7 +130,11 @@ export class Write {
     );
   }
 
-  async put(lc: LogContext, key: string, val: JSONValue): Promise<void> {
+  async put(
+    lc: LogContext,
+    key: string,
+    val: ReadonlyJSONValue,
+  ): Promise<void> {
     if (this._meta.type === MetaType.IndexChange) {
       throw new Error('Not allowed');
     }
@@ -368,7 +372,7 @@ async function updateIndexes(
   dagWrite: dag.Write,
   op: IndexOperation,
   key: string,
-  val: JSONValue,
+  val: ReadonlyJSONValue,
 ): Promise<void> {
   for (const idx of indexes.values()) {
     if (key.startsWith(idx.meta.definition.keyPrefix)) {

--- a/src/deep-readonly.ts
+++ b/src/deep-readonly.ts
@@ -1,0 +1,15 @@
+export type DeepReadonly<T> = T extends (infer R)[]
+  ? DeepReadonlyArray<R>
+  : // eslint-disable-next-line @typescript-eslint/ban-types
+  T extends Function
+  ? T
+  : // eslint-disable-next-line @typescript-eslint/ban-types
+  T extends object
+  ? DeepReadonlyObject<T>
+  : T;
+
+export type DeepReadonlyArray<T> = ReadonlyArray<DeepReadonly<T>>;
+
+export type DeepReadonlyObject<T> = {
+  readonly [P in keyof T]: DeepReadonly<T[P]>;
+};

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -1,5 +1,5 @@
-import {assert} from '@esm-bundle/chai';
-import {deepEqual} from './json';
+import {assert, expect} from '@esm-bundle/chai';
+import {deepEqual, deepFreeze} from './json';
 import type {JSONValue} from './json';
 
 const {fail} = assert;
@@ -53,4 +53,17 @@ test('JSON deep equal', () => {
   }
 
   t({a: 1, b: 2}, {b: 2, a: 1});
+});
+
+test('JSON deepFreeze', async () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const obj: any = deepFreeze({obj: {}, arr: []});
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const arr: any = deepFreeze([{}, []]);
+  expect(() => (obj.foo = 'bar')).throws();
+  expect(() => (obj.obj.foo = 'bar')).throws();
+  expect(() => (obj.arr[0] = 'bar')).throws();
+  expect(() => (arr[0] = 'bar')).throws();
+  expect(() => (arr[0].foo = 'bar')).throws();
+  expect(() => (arr[1][0] = 'bar')).throws();
 });

--- a/src/kv/idb-store.ts
+++ b/src/kv/idb-store.ts
@@ -1,5 +1,6 @@
 import {deleteSentinel, WriteImplBase} from './write-impl-base';
-import type {Read, Store, Write} from './store';
+import type {Read, Store, Value, Write} from './store';
+import {deepFreeze} from '../json';
 
 const RELAXED = {durability: 'relaxed'};
 const OBJECT_STORE = 'chunks';
@@ -56,8 +57,13 @@ class ReadImpl {
     return (await wrap(objectStore(this._tx).count(key))) > 0;
   }
 
-  async get(key: string): Promise<Uint8Array | undefined> {
-    return wrap(objectStore(this._tx).get(key));
+  async get(key: string): Promise<Value | undefined> {
+    const v = await wrap(objectStore(this._tx).get(key));
+    if (v instanceof Uint8Array) {
+      return v;
+    } else {
+      return deepFreeze(v);
+    }
   }
 
   release(): void {

--- a/src/kv/store.ts
+++ b/src/kv/store.ts
@@ -1,6 +1,6 @@
-import type {JSONValue} from '../json';
+import type {ReadonlyJSONValue} from '../json';
 
-export type Value = Uint8Array | JSONValue;
+export type Value = Uint8Array | ReadonlyJSONValue;
 
 /**
  * Store defines a transactional key/value store that Replicache stores all data

--- a/src/sync/pull.test.ts
+++ b/src/sync/pull.test.ts
@@ -14,7 +14,7 @@ import {
   Chain,
   createIndex,
 } from '../db/test-helpers';
-import type {JSONValue} from '../json';
+import type {ReadonlyJSONValue, JSONValue} from '../json';
 import {MemStore} from '../kv/mod';
 import {arrayCompare} from '../prolly/array-compare';
 import type {PatchOperation, PullResponse} from '../puller';
@@ -476,7 +476,9 @@ test('begin try pull', async () => {
           db.whenceHash(syncHead.chunk.hash),
           read,
         );
-        const gotValueMap: [string, JSONValue][] = Array.from(map.entries());
+        const gotValueMap: [string, ReadonlyJSONValue][] = Array.from(
+          map.entries(),
+        );
         gotValueMap.sort((a, b) => arrayCompare(a[0], b[0]));
         const expValueMap = Array.from(expSyncHead.valueMap);
         expValueMap.sort((a, b) => arrayCompare(a[0], b[0]));

--- a/src/sync/pull.ts
+++ b/src/sync/pull.ts
@@ -1,6 +1,6 @@
 import type * as dag from '../dag/mod';
 import * as db from '../db/mod';
-import type {JSONValue} from '../json';
+import {deepThaw, ReadonlyJSONValue} from '../json';
 import {assertPullResponse, Puller, PullError, PullResponse} from '../puller';
 import {
   assertHTTPRequestInfo,
@@ -22,7 +22,7 @@ export const PULL_VERSION = 0;
 
 export type PullRequest = {
   clientID: string;
-  cookie: JSONValue;
+  cookie: ReadonlyJSONValue;
   lastMutationID: number;
   pullVersion: number;
   // schema_version can optionally be used by the customer's app
@@ -229,7 +229,7 @@ export async function maybeEndTryPull(
       const replayMutations: ReplayMutation[] = [];
       for (const c of pending) {
         let name: string;
-        let args: JSONValue;
+        let args: ReadonlyJSONValue;
         if (c.meta().isLocal()) {
           const lm = c.meta().typed() as db.LocalMeta;
           name = lm.mutatorName();
@@ -240,7 +240,7 @@ export async function maybeEndTryPull(
         replayMutations.push({
           id: c.mutationID(),
           name,
-          args,
+          args: deepThaw(args),
           original: c.chunk.hash,
         });
       }

--- a/src/worker.test.ts
+++ b/src/worker.test.ts
@@ -7,7 +7,17 @@ teardown(async () => {
   deletaAllDatabases();
 });
 
-test('worker test', async () => {
+// This started failing on github only with https://github.com/rocicorp/replicache/pull/479.
+// It works fine locally. Error message is:
+// src/worker.test.ts:
+//
+// ❌ worker test (failed on Chromium)
+// Error: Timed out
+//   at src/worker.test.ts:42:42
+//   at async o.<anonymous> (src/worker.test.ts:17:17)
+//
+// Example failure: https://github.com/rocicorp/replicache/runs/3519251318
+test.skip('worker test', async () => {
   const url = new URL('./worker-test.ts', import.meta.url);
   const w = new Worker(url, {type: 'module'});
   const name = 'worker-test';


### PR DESCRIPTION
This is important because the common pattern in applications (and which we advocate) is to directly mutate the returned data and re-write it. If we are caching that data internally weird things happen.

This PR also adds some typesafety internally to try and prevent us from making similar mistakes, but it's incomplete. See follow ups:

rocicorp/replicache#480
rocicorp/mono#136