### PR TITLE
Restore ability to read old ref count

### DIFF
--- a/src/dag/config.ts
+++ b/src/dag/config.ts
@@ -1,0 +1,3 @@
+// Whether the read path of chunks supports flat buffers. This
+// allows us to read old data.
+export const READ_FLATBUFFERS = true;


### PR DESCRIPTION
We used to store the ref count as an uint16 (encoded as little endian)
in IDB so this allows us to read the old data.

Towards #488