### PR TITLE
Restore Uint8array support for client id

### DIFF
--- a/src/sync/client-id.test.ts
+++ b/src/sync/client-id.test.ts
@@ -1,6 +1,7 @@
 import {expect} from '@esm-bundle/chai';
 import {MemStore} from '../kv/mod';
-import {init} from './client-id';
+import {CID_KEY, init} from './client-id';
+import * as utf8 from '../utf8';
 
 test('init client ID', async () => {
   const ms = new MemStore();
@@ -10,4 +11,20 @@ test('init client ID', async () => {
   const ms2 = new MemStore();
   const cid3 = await init(ms2);
   expect(cid1).to.not.equal(cid3);
+});
+
+test('init client ID uint8array upgrade', async () => {
+  const ms = new MemStore();
+  const fakeClientID = 'fake-client-id';
+  await ms.withWrite(async w => {
+    await w.put(CID_KEY, utf8.encode(fakeClientID));
+    await w.commit();
+  });
+  const cid = await init(ms);
+  expect(cid).to.equal(fakeClientID);
+
+  await ms.withRead(async r => {
+    const cid2 = await r.get(CID_KEY);
+    expect(cid2).to.equal(fakeClientID);
+  });
 });

--- a/src/sync/client-id.ts
+++ b/src/sync/client-id.ts
@@ -1,19 +1,32 @@
 import type * as kv from '../kv/mod';
 import {uuid as makeUuid} from './uuid';
 import {assertString} from '../asserts';
+import {READ_FLATBUFFERS} from '../dag/config';
+import * as utf8 from '../utf8';
 
-const CID_KEY = 'sys/cid';
+export const CID_KEY = 'sys/cid';
 
-export async function init(s: kv.Store): Promise<string> {
-  const cid = await s.withRead(r => r.get(CID_KEY));
+export async function init(store: kv.Store): Promise<string> {
+  const cid = await store.withRead(r => r.get(CID_KEY));
   if (cid !== undefined) {
+    if (READ_FLATBUFFERS) {
+      if (cid instanceof Uint8Array) {
+        const str = utf8.decode(cid);
+        await writeClientID(store, str);
+        return str;
+      }
+    }
     assertString(cid);
     return cid;
   }
   const uuid = makeUuid();
-  await s.withWrite(async wt => {
+  await writeClientID(store, uuid);
+  return uuid;
+}
+
+function writeClientID(s: kv.Store, uuid: string): Promise<void> {
+  return s.withWrite(async wt => {
     await wt.put(CID_KEY, uuid);
     await wt.commit();
   });
-  return uuid;
 }


### PR DESCRIPTION
This adds code to support reading the client ID as Uint8Array. Since the
client ID is only written once, we also upgrade the value to a string.

Towards #488