### PR TITLE
Store head hashes as strings

### DIFF
--- a/src/dag/read.test.ts
+++ b/src/dag/read.test.ts
@@ -2,10 +2,11 @@ import {expect} from '@esm-bundle/chai';
 import {initHasher} from '../hash';
 import {MemStore} from '../kv/mod';
 import {Chunk} from './chunk';
-import {chunkDataKey, chunkMetaKey} from './key';
+import {chunkDataKey, chunkMetaKey, headKey} from './key';
 import {Read} from './read';
 import {Meta as MetaFB} from './generated/meta/meta';
 import * as flatbuffers from 'flatbuffers';
+import * as utf8 from '../utf8';
 
 setup(async () => {
   await initHasher();
@@ -67,6 +68,7 @@ test('get chunk', async () => {
   await t(new Uint8Array([1]), [], true);
   await t(new Uint8Array([1]), ['r1', 'r2'], false);
 });
+
 function createMeta(refs: string[]): Uint8Array {
   const builder = new flatbuffers.Builder();
   const refsOffset = MetaFB.createRefsVector(
@@ -77,3 +79,31 @@ function createMeta(refs: string[]): Uint8Array {
   builder.finish(m);
   return builder.asUint8Array();
 }
+
+test('get head with Uint8Array support', async () => {
+  const kv = new MemStore();
+  const h1 = 'v1';
+  const h2 = 'v2';
+  const h3 = 'v3';
+  await kv.withWrite(async kvw => {
+    await kvw.put(headKey(h1), 'h1');
+    await kvw.put(headKey(h2), utf8.encode('h2'));
+    await kvw.put(headKey(h3), 42);
+    await kvw.commit();
+  });
+
+  await kv.withRead(async kvr => {
+    const r = new Read(kvr);
+    expect(await r.getHead(h1)).to.equal('h1');
+    expect(await r.getHead(h2)).to.equal('h2');
+    let err;
+    try {
+      await r.getHead(h3);
+    } catch (e) {
+      err = e;
+    }
+    expect(err)
+      .to.be.instanceOf(Error)
+      .with.property('message', 'Invalid type: number `42`, expected string');
+  });
+});

--- a/src/dag/read.ts
+++ b/src/dag/read.ts
@@ -2,7 +2,7 @@ import type * as kv from '../kv/mod';
 import {assertMeta, Chunk} from './chunk';
 import {chunkDataKey, chunkMetaKey, headKey} from './key';
 import * as utf8 from '../utf8';
-import {assertInstanceof} from '../asserts';
+import {assertString} from '../asserts';
 import {READ_FLATBUFFERS} from './config';
 import * as flatbuffers from 'flatbuffers';
 import {Meta as MetaFB} from './generated/meta/meta.js';
@@ -44,8 +44,11 @@ export class Read {
     if (data === undefined) {
       return undefined;
     }
-    assertInstanceof(data, Uint8Array);
-    return utf8.decode(data);
+    if (READ_FLATBUFFERS && data instanceof Uint8Array) {
+      return utf8.decode(data);
+    }
+    assertString(data);
+    return data;
   }
 
   close(): void {

--- a/src/dag/write.test.ts
+++ b/src/dag/write.test.ts
@@ -6,7 +6,6 @@ import {toLittleEndian, Write} from './write';
 import type * as kv from '../kv/mod';
 import {Read} from './read';
 import {initHasher} from '../hash';
-import {assertString} from '../asserts';
 import type {Value} from '../kv/store';
 
 setup(async () => {

--- a/src/dag/write.test.ts
+++ b/src/dag/write.test.ts
@@ -5,9 +5,8 @@ import {chunkDataKey, chunkMetaKey, chunkRefCountKey, headKey} from './key';
 import {toLittleEndian, Write} from './write';
 import type * as kv from '../kv/mod';
 import {Read} from './read';
-import * as utf8 from '../utf8';
 import {initHasher} from '../hash';
-import {assertInstanceof} from '../asserts';
+import {assertString} from '../asserts';
 import type {Value} from '../kv/store';
 
 setup(async () => {
@@ -72,8 +71,7 @@ test('set head', async () => {
       await w.setHead(name, hash);
       if (hash !== undefined) {
         const h = await kvw.get(headKey(name));
-        assertInstanceof(h, Uint8Array);
-        expect(hash).to.equal(h && utf8.decode(h));
+        expect(h).to.equal(hash);
       } else {
         expect(await kvw.get(headKey(name))).to.be.undefined;
       }

--- a/src/dag/write.ts
+++ b/src/dag/write.ts
@@ -2,7 +2,6 @@ import type * as kv from '../kv/mod';
 import {chunkDataKey, chunkMetaKey, headKey, chunkRefCountKey} from './key';
 import {Read} from './read';
 import {assertMeta, Chunk} from './chunk';
-import * as utf8 from '../utf8';
 import {assertNumber} from '../asserts';
 import {READ_FLATBUFFERS} from './config';
 
@@ -45,7 +44,7 @@ export class Write {
     if (hash === undefined) {
       p1 = this._kvw.del(hk);
     } else {
-      p1 = this._kvw.put(hk, utf8.encode(hash));
+      p1 = this._kvw.put(hk, hash);
     }
 
     const v = this._changedHeads.get(name);


### PR DESCRIPTION
But support reading the old format as well.

Towards #488