### PR TITLE
chore: Remove support for Uint8Array in the store

### DIFF
--- a/src/dag/chunk.test.ts
+++ b/src/dag/chunk.test.ts
@@ -1,5 +1,6 @@
 import {expect} from '@esm-bundle/chai';
 import {initHasher} from '../hash';
+import type {Value} from '../kv/store';
 import {Chunk} from './chunk';
 
 setup(async () => {
@@ -7,7 +8,7 @@ setup(async () => {
 });
 
 test('round trip', async () => {
-  const t = (hash: string, data: Uint8Array, refs: string[]) => {
+  const t = (hash: string, data: Value, refs: string[]) => {
     const c = Chunk.new(data, refs);
     expect(c.hash).to.equal(hash);
     expect(c.data).to.deep.equal(data);
@@ -18,9 +19,9 @@ test('round trip', async () => {
     expect(c).to.deep.equal(c2);
   };
 
-  t('pu1u2dbutusbrsak518dcrc00vb21p05', new Uint8Array([]), []);
-  t('n0i4q0k9g7b97brr8llfhrt4pbb3qa1e', new Uint8Array([0]), ['r1']);
-  t('g19moobgrm32dn083bokhksuobulq28c', new Uint8Array([0, 1]), ['r1', 'r2']);
+  t('m9diij5krqr9t80a9guf649p0i01mo0l', [], []);
+  t('i4ua4lkdobnv4u5rdenb9jfumr4ru3k7', [0], ['r1']);
+  t('1rk961et3nqfi61oceeh6nc0sirin2lv', [0, 1], ['r1', 'r2']);
 });
 
 test('equals', async () => {
@@ -32,26 +33,13 @@ test('equals', async () => {
     expect(a).to.not.deep.equal(b);
   };
 
-  eq(Chunk.new(new Uint8Array([]), []), Chunk.new(new Uint8Array([]), []));
-  neq(Chunk.new(new Uint8Array([1]), []), Chunk.new(new Uint8Array([]), []));
-  neq(Chunk.new(new Uint8Array([0]), []), Chunk.new(new Uint8Array([1]), []));
+  eq(Chunk.new([], []), Chunk.new([], []));
+  neq(Chunk.new([1], []), Chunk.new([], []));
+  neq(Chunk.new([0], []), Chunk.new([1], []));
 
-  eq(Chunk.new(new Uint8Array([1]), []), Chunk.new(new Uint8Array([1]), []));
-  eq(
-    Chunk.new(new Uint8Array([]), ['a']),
-    Chunk.new(new Uint8Array([]), ['a']),
-  );
-  eq(
-    Chunk.new(new Uint8Array([1]), ['a']),
-    Chunk.new(new Uint8Array(new Uint8Array([0, 1]).buffer, 1), ['a']),
-  );
+  eq(Chunk.new([1], []), Chunk.new([1], []));
+  eq(Chunk.new([], ['a']), Chunk.new([], ['a']));
 
-  neq(
-    Chunk.new(new Uint8Array([]), ['a']),
-    Chunk.new(new Uint8Array([]), ['b']),
-  );
-  neq(
-    Chunk.new(new Uint8Array([]), ['a']),
-    Chunk.new(new Uint8Array([]), ['a', 'b']),
-  );
+  neq(Chunk.new([], ['a']), Chunk.new([], ['b']));
+  neq(Chunk.new([], ['a']), Chunk.new([], ['a', 'b']));
 });

--- a/src/dag/chunk.ts
+++ b/src/dag/chunk.ts
@@ -4,7 +4,6 @@ import type {Value} from '../kv/store';
 
 type Refs = readonly string[];
 
-// TODO(arv): Make this class take a type parameter for the data type?
 export class Chunk<V extends Value = Value> {
   readonly hash: string;
   readonly data: V;

--- a/src/dag/read.test.ts
+++ b/src/dag/read.test.ts
@@ -15,7 +15,7 @@ test('has chunk', async () => {
     const k = 'present';
     const kv = new MemStore();
     await kv.withWrite(async kvw => {
-      await kvw.put(chunkDataKey(k), new Uint8Array([0, 1]));
+      await kvw.put(chunkDataKey(k), [0, 1]);
       await kvw.commit();
     });
 

--- a/src/dag/write.test.ts
+++ b/src/dag/write.test.ts
@@ -35,10 +35,6 @@ test('put chunk', async () => {
     });
   };
 
-  await t(new Uint8Array([]), []);
-  await t(new Uint8Array([0]), ['r1']);
-  await t(new Uint8Array([0, 1]), ['r1', 'r2']);
-
   await t(0, []);
   await t(42, []);
   await t(true, []);
@@ -176,7 +172,7 @@ test('commit rollback', async () => {
     const kv = new MemStore();
     await kv.withWrite(async kvw => {
       const w = new Write(kvw);
-      const c = Chunk.new(new Uint8Array([0, 1]), []);
+      const c = Chunk.new([0, 1], []);
       await w.putChunk(c);
 
       key = chunkDataKey(c.hash);
@@ -205,7 +201,7 @@ test('commit rollback', async () => {
 });
 
 test('roundtrip', async () => {
-  const t = async (name: string, data: Uint8Array, refs: string[]) => {
+  const t = async (name: string, data: Value, refs: string[]) => {
     const kv = new MemStore();
     const c = Chunk.new(data, refs);
     await kv.withWrite(async kvw => {
@@ -231,7 +227,15 @@ test('roundtrip', async () => {
     });
   };
 
-  await t('', new Uint8Array([]), []);
-  await t('n1', new Uint8Array([0]), ['r1']);
-  await t('n2', new Uint8Array([0, 1]), ['r1', 'r2']);
+  await t('', 0, []);
+  await t('n1', 1, ['r1']);
+  await t('n2', 42, ['r1', 'r2']);
+
+  await t('', true, []);
+  await t('', false, []);
+  await t('', [], []);
+  await t('', {}, []);
+  await t('', null, []);
+  await t('', [0], []);
+  await t('', {a: true}, []);
 });

--- a/src/kv/idb-store.ts
+++ b/src/kv/idb-store.ts
@@ -61,12 +61,8 @@ class ReadImpl {
     return (await wrap(objectStore(this._tx).count(key))) > 0;
   }
 
-  async get(key: string): Promise<Value | undefined> {
-    const v = await wrap(objectStore(this._tx).get(key));
-    if (v instanceof Uint8Array) {
-      return v;
-    }
-    return v;
+  get(key: string): Promise<Value | undefined> {
+    return wrap(objectStore(this._tx).get(key));
   }
 
   release(): void {

--- a/src/kv/store-test-util.ts
+++ b/src/kv/store-test-util.ts
@@ -1,5 +1,4 @@
 import {expect} from '@esm-bundle/chai';
-import {b} from '../test-util';
 import type {Read, Store, Value, Write} from './store';
 
 export class TestStore implements Store {
@@ -94,8 +93,8 @@ async function simpleCommit(store: TestStore): Promise<void> {
     expect(await wt.has('bar')).to.be.false;
     await wt.put('bar', 'baz');
     expect(await wt.get('bar')).to.deep.equal('baz');
-    await wt.put('bytes', b`abc`);
-    expect(await wt.get('bytes')).to.deep.equal(b`abc`);
+    await wt.put('other', 'abc');
+    expect(await wt.get('other')).to.deep.equal('abc');
     await wt.commit();
   });
 
@@ -103,8 +102,8 @@ async function simpleCommit(store: TestStore): Promise<void> {
   await store.withRead(async rt => {
     expect(await rt.has('bar')).to.be.true;
     expect(await rt.get('bar')).to.deep.equal('baz');
-    expect(await rt.has('bytes')).to.be.true;
-    expect(await rt.get('bytes')).to.deep.equal(b`abc`);
+    expect(await rt.has('other')).to.be.true;
+    expect(await rt.get('other')).to.deep.equal('abc');
   });
 }
 
@@ -113,7 +112,7 @@ async function del(store: TestStore): Promise<void> {
   await store.withWrite(async wt => {
     expect(await wt.has('bar')).to.be.false;
     await wt.put('bar', 'baz');
-    await wt.put('bytes', b`abc`);
+    await wt.put('other', 'abc');
     await wt.commit();
   });
 
@@ -122,8 +121,8 @@ async function del(store: TestStore): Promise<void> {
     expect(await wt.has('bar')).to.be.true;
     await wt.del('bar');
     expect(await wt.has('bar')).to.be.false;
-    await wt.del('bytes');
-    expect(await wt.has('bytes')).to.be.false;
+    await wt.del('other');
+    expect(await wt.has('other')).to.be.false;
     await wt.commit();
   });
 
@@ -131,8 +130,8 @@ async function del(store: TestStore): Promise<void> {
   await store.withRead(async rt => {
     expect(await rt.has('bar')).to.be.false;
     expect(await rt.get('bar')).to.be.undefined;
-    expect(await rt.has('bytes')).to.be.false;
-    expect(await rt.get('bytes')).to.be.undefined;
+    expect(await rt.has('other')).to.be.false;
+    expect(await rt.get('other')).to.be.undefined;
   });
 }
 
@@ -153,13 +152,13 @@ async function simpleRollback(store: TestStore): Promise<void> {
   // Start a write transaction and put a value, then abort.
   await store.withWrite(async wt => {
     await wt.put('bar', 'baz');
-    await wt.put('bytes', b`abc`);
+    await wt.put('other', 'abc');
     // no commit, implicit rollback
   });
 
   await store.withRead(async rt => {
     expect(await rt.has('bar')).to.be.false;
-    expect(await rt.has('bytes')).to.be.false;
+    expect(await rt.has('other')).to.be.false;
   });
 }
 

--- a/src/kv/store.ts
+++ b/src/kv/store.ts
@@ -18,10 +18,10 @@ export type Value = ReadonlyJSONValue;
  * @experimental This interface is experimental and might be removed or changed
  * in the future without following semver versioning. Please be cautious.
  */
-export interface Store<Value = ReadonlyJSONValue> {
-  read(): Promise<Read<Value>>;
+export interface Store {
+  read(): Promise<Read>;
   withRead<R>(f: (read: Read) => R | Promise<R>): Promise<R>;
-  write(): Promise<Write<Value>>;
+  write(): Promise<Write>;
   withWrite<R>(f: (write: Write) => R | Promise<R>): Promise<R>;
   close(): Promise<void>;
 }
@@ -41,7 +41,7 @@ export interface Release {
  * @experimental This interface is experimental and might be removed or changed
  * in the future without following semver versioning. Please be cautious.
  */
-export interface Read<Value = ReadonlyJSONValue> extends Release {
+export interface Read extends Release {
   has(key: string): Promise<boolean>;
   get(key: string): Promise<Value | undefined>;
 }
@@ -49,7 +49,7 @@ export interface Read<Value = ReadonlyJSONValue> extends Release {
 /**
  * @experimental
  */
-export interface Write<Value = ReadonlyJSONValue> extends Read<Value> {
+export interface Write extends Read {
   put(key: string, value: Value): Promise<void>;
   del(key: string): Promise<void>;
   commit(): Promise<void>;

--- a/src/kv/store.ts
+++ b/src/kv/store.ts
@@ -1,7 +1,6 @@
 import type {ReadonlyJSONValue} from '../json';
 
-// TODO(arv): Remove Uint8Array
-export type Value = Uint8Array | ReadonlyJSONValue;
+export type Value = ReadonlyJSONValue;
 
 /**
  * Store defines a transactional key/value store that Replicache stores all data
@@ -19,10 +18,10 @@ export type Value = Uint8Array | ReadonlyJSONValue;
  * @experimental This interface is experimental and might be removed or changed
  * in the future without following semver versioning. Please be cautious.
  */
-export interface Store {
-  read(): Promise<Read>;
+export interface Store<Value = ReadonlyJSONValue> {
+  read(): Promise<Read<Value>>;
   withRead<R>(f: (read: Read) => R | Promise<R>): Promise<R>;
-  write(): Promise<Write>;
+  write(): Promise<Write<Value>>;
   withWrite<R>(f: (write: Write) => R | Promise<R>): Promise<R>;
   close(): Promise<void>;
 }
@@ -42,7 +41,7 @@ export interface Release {
  * @experimental This interface is experimental and might be removed or changed
  * in the future without following semver versioning. Please be cautious.
  */
-export interface Read extends Release {
+export interface Read<Value = ReadonlyJSONValue> extends Release {
   has(key: string): Promise<boolean>;
   get(key: string): Promise<Value | undefined>;
 }
@@ -50,7 +49,7 @@ export interface Read extends Release {
 /**
  * @experimental
  */
-export interface Write extends Read {
+export interface Write<Value = ReadonlyJSONValue> extends Read<Value> {
   put(key: string, value: Value): Promise<void>;
   del(key: string): Promise<void>;
   commit(): Promise<void>;

--- a/src/migrate/migrate-0-to-1.test.ts
+++ b/src/migrate/migrate-0-to-1.test.ts
@@ -46,6 +46,7 @@ test('migrateClientID', async () => {
 
   const cid = 'test-client-id';
   await kv.withWrite(async w => {
+    // @ts-expect-error - allow invalid value type
     await w.put(sync.CID_KEY, utf8.encode(cid));
     await w.commit();
   });
@@ -72,6 +73,7 @@ test('migrateMetaKeyValue', async () => {
 
     const buf = dag.metaToFlatbuffer(expected);
     await kv.withWrite(async w => {
+      // @ts-expect-error Allow writing Uint8Array
       await w.put(dag.chunkMetaKey(hash), buf);
       await w.commit();
     });
@@ -103,6 +105,7 @@ test('migrateRefCountKeyValue', async () => {
   const t = async (count: number) => {
     const buf = dag.toLittleEndian(count);
     await kv.withWrite(async w => {
+      // @ts-expect-error Allow writing Uint8Array
       await w.put(dag.chunkRefCountKey(hash), buf);
       await w.commit();
     });
@@ -126,6 +129,7 @@ test('migrateHeadKeyValue', async () => {
   const name = 'head-name';
   const hash = 'fakehash';
   await kv.withWrite(async w => {
+    // @ts-expect-error. Allow writing Uint8Array.
     await w.put(dag.headKey(name), utf8.encode(hash));
     await w.commit();
   });
@@ -146,6 +150,7 @@ test('migrateProllyMap', async () => {
 
     const buf = prolly.entriesToFlatbuffer(entries);
     await kv.withWrite(async w => {
+      // @ts-expect-error. Allow writing Uint8Array.
       await w.put(dag.chunkDataKey(hash), buf);
       await w.commit();
     });
@@ -194,13 +199,19 @@ test('migrateCommit', async () => {
   await kv.withWrite(async w => {
     await w.put(
       dag.chunkDataKey(entriesHash),
+      // @ts-expect-error. Allow writing Uint8Array.
       prolly.entriesToFlatbuffer(entries),
     );
     await w.put(
       dag.chunkDataKey(commitHash),
+      // @ts-expect-error. Allow writing Uint8Array.
       db.commitDataToFlatbuffer(commit),
     );
-    await w.put(dag.chunkMetaKey(commitHash), dag.metaToFlatbuffer(refs));
+    await w.put(
+      dag.chunkMetaKey(commitHash),
+      // @ts-expect-error. Allow writing Uint8Array.
+      dag.metaToFlatbuffer(refs),
+    );
     await w.commit();
   });
 

--- a/src/migrate/migrate.test.ts
+++ b/src/migrate/migrate.test.ts
@@ -17,7 +17,7 @@ setup(async () => {
 });
 
 async function testMigrate(
-  inputdata: Record<string, Value>,
+  inputdata: Record<string, Value | Uint8Array>,
   expected: Record<string, Value>,
 ): Promise<void> {
   const kv = new TestMemStore();
@@ -43,10 +43,11 @@ test('test data sample with index', async () => {
 
 async function writeSampleData(
   kv: Store,
-  data: Record<string, Value>,
+  data: Record<string, Value | Uint8Array>,
 ): Promise<void> {
   return kv.withWrite(async w => {
     for (const [key, value] of Object.entries(data)) {
+      // @ts-expect-error Allow writing Uint8Array
       await w.put(key, value);
     }
     await w.commit();

--- a/src/migrate/migrate.test.ts
+++ b/src/migrate/migrate.test.ts
@@ -17,7 +17,7 @@ setup(async () => {
 });
 
 async function testMigrate(
-  inputdata: Record<string, Value | Uint8Array>,
+  inputdata: Record<string, Uint8Array>,
   expected: Record<string, Value>,
 ): Promise<void> {
   const kv = new TestMemStore();

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -85,7 +85,6 @@ export class ReadTransactionImpl<Value extends ReadonlyJSONValue>
   }
 
   async get(key: string): Promise<Value | undefined> {
-    // TODO(arv): Change this to a non async function.
     throwIfClosed(this);
     return embed.get(this._transactionId, key, this._shouldClone) as
       | Value
@@ -93,7 +92,6 @@ export class ReadTransactionImpl<Value extends ReadonlyJSONValue>
   }
 
   async has(key: string): Promise<boolean> {
-    // TODO(arv): Change this to a non async function.
     throwIfClosed(this);
     return embed.has(this._transactionId, key);
   }


### PR DESCRIPTION
The migration test is allowing Uint8Array to be stored in the store by
using @ts-expect-error.