### PR TITLE
refactor: Split connection transactions

### DIFF
--- a/src/embed/connection.test.ts
+++ b/src/embed/connection.test.ts
@@ -4,7 +4,7 @@ import * as sync from '../sync/mod';
 import {MemStore} from '../kv/mem-store';
 import {addGenesis, addLocal, Chain} from '../db/test-helpers';
 import {addSyncSnapshot} from '../sync/test-helpers';
-import {commitImpl, openTransactionImpl} from './connection';
+import {commitImpl, openWriteTransactionImpl} from './connection';
 import {LogContext} from '../logger';
 import {initHasher} from '../hash';
 
@@ -33,7 +33,7 @@ test('open transaction rebase opts', async () => {
   let result;
   try {
     // Error: rebase commit's basis must be sync head.
-    result = await openTransactionImpl(
+    result = await openWriteTransactionImpl(
       lc,
       store,
       txns,
@@ -54,7 +54,7 @@ test('open transaction rebase opts', async () => {
 
   // Error: rebase commit's name should not change.
   try {
-    result = await openTransactionImpl(
+    result = await openWriteTransactionImpl(
       lc,
       store,
       txns,
@@ -88,7 +88,7 @@ test('open transaction rebase opts', async () => {
   const newLocalName = lm.mutatorName;
   const newLocalArgs = lm.mutatorArgsJSON;
   try {
-    result = await openTransactionImpl(
+    result = await openWriteTransactionImpl(
       lc,
       store,
       txns,
@@ -108,7 +108,7 @@ test('open transaction rebase opts', async () => {
   );
 
   // Correct rebase_opt (test this last because it affects the chain).
-  const otr = await openTransactionImpl(
+  const otr = await openWriteTransactionImpl(
     lc,
     store,
     txns,

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -1548,7 +1548,7 @@ testWithBothStores('closeTransaction after rep.scan', async () => {
     expect(l).to.deep.equal(log);
     const names = embed.testLog.map(({name}) => name);
     expect(names).to.deep.equal([
-      'openTransaction',
+      `openReadTransaction`,
       'scan',
       'closeTransaction',
     ]);
@@ -1939,7 +1939,9 @@ testWithBothStores('logLevel', async () => {
   expect(
     debug
       .getCalls()
-      .some(call => call.firstArg.includes('db=log-level rpc=openTransaction')),
+      .some(call =>
+        call.firstArg.includes('db=log-level rpc=openReadTransaction'),
+      ),
   ).to.equal(true);
   expect(
     debug.getCalls().some(call => call.firstArg.includes('PULL')),
@@ -2286,7 +2288,7 @@ testWithBothStores('push and pull concurrently', async () => {
 
   // Only one push at a time but we want push and pull to be concurrent.
   expect(rpcs()).to.deep.equal([
-    'openTransaction',
+    'openWriteTransaction',
     'put',
     'commitTransaction',
     'beginPull',
@@ -2303,7 +2305,7 @@ testWithBothStores('push and pull concurrently', async () => {
   expect(reqs).to.deep.equal([pullURL, pushURL]);
 
   expect(rpcs()).to.deep.equal([
-    'openTransaction',
+    'openWriteTransaction',
     'put',
     'commitTransaction',
     'beginPull',


### PR DESCRIPTION
Now there are 3 individual transactions calls (read, write and index)

This is in preparation for more refactoring.