### PR TITLE
fix: Makes sure to clone the args in mutations

### DIFF
--- a/src/kv/test-mem-store.ts
+++ b/src/kv/test-mem-store.ts
@@ -8,4 +8,8 @@ export class TestMemStore extends MemStore {
   entries(): Iterable<[string, Value]> {
     return this._map.entries();
   }
+
+  map(): Map<string, Value> {
+    return this._map;
+  }
 }

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -3015,14 +3015,15 @@ function findPropertyValue(
   propertyValue: unknown,
 ): unknown | undefined {
   if (typeof obj === 'object' && obj !== null) {
+    const rec = obj as Record<string, unknown>;
+    if (rec[propertyName] === propertyValue) {
+      return rec;
+    }
+
     let values: Iterable<unknown>;
     if (obj instanceof Set || obj instanceof Map || obj instanceof Array) {
       values = obj.values();
     } else {
-      const rec = obj as Record<string, unknown>;
-      if (rec[propertyName] === propertyValue) {
-        return rec;
-      }
       values = Object.values(rec);
     }
     for (const v of values) {

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -22,6 +22,7 @@ import {sleep} from './sleep';
 import {MemStore} from './kv/mem-store';
 import type * as kv from './kv/mod';
 import * as embed from './embed/mod';
+import {TestMemStore} from './kv/test-mem-store';
 
 let clock: SinonFakeTimers;
 setup(() => {
@@ -3006,4 +3007,52 @@ test('subscription coalescing', async () => {
   expect(store.closeCount).to.equal(0);
 
   expect(log).to.deep.equal(['d', 'e']);
+});
+
+function findPropertyValue(
+  obj: unknown,
+  propertyName: string,
+  propertyValue: unknown,
+): unknown | undefined {
+  if (typeof obj === 'object' && obj !== null) {
+    let values: Iterable<unknown>;
+    if (obj instanceof Set || obj instanceof Map || obj instanceof Array) {
+      values = obj.values();
+    } else {
+      const rec = obj as Record<string, unknown>;
+      if (rec[propertyName] === propertyValue) {
+        return rec;
+      }
+      values = Object.values(rec);
+    }
+    for (const v of values) {
+      const r = findPropertyValue(v, propertyName, propertyValue);
+      if (r) {
+        return r;
+      }
+    }
+  }
+  return undefined;
+}
+
+test('mutate args in mutation', async () => {
+  // This tests that mutating the args in a mutation does not mutate the args we
+  // store in the kv.Store.
+  const store = new TestMemStore();
+  const rep = await replicacheForTesting('mutate-args-in-mutation', {
+    experimentalKVStore: store,
+    mutators: {
+      async mutArgs(tx, args: {v: number}) {
+        args.v = 42;
+        await tx.put('v', args.v);
+      },
+    },
+  });
+
+  await rep.mutate.mutArgs({v: 1});
+
+  const o = findPropertyValue(store.map(), 'mutatorName', 'mutArgs');
+  expect((o as {mutatorArgsJSON?: unknown}).mutatorArgsJSON).to.deep.equal({
+    v: 1,
+  });
 });

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -1,4 +1,4 @@
-import {deepEqual, ReadonlyJSONValue} from './json';
+import {deepClone, deepEqual, ReadonlyJSONValue} from './json';
 import type {JSONValue} from './json';
 import type {KeyTypeForScanOptions, ScanOptions} from './scan-options';
 import {Pusher, PushError} from './pusher';
@@ -1024,7 +1024,7 @@ export class Replicache<MD extends MutatorDefs = {}>
       this.name,
       this._openResponse,
       name,
-      args ?? null,
+      deepClone(args ?? null),
       rebaseOpts,
     );
     await tx.open();


### PR DESCRIPTION
The initial call to a mutation was passed in the args object, which was
also stored in the kv.Store. This lead to mutations of the arg mutating
the store.

Fixes #480