### PR TITLE
refactor: Cleanup embed/connection

### DIFF
--- a/src/embed/connection.test.ts
+++ b/src/embed/connection.test.ts
@@ -4,7 +4,7 @@ import * as sync from '../sync/mod';
 import {MemStore} from '../kv/mem-store';
 import {addGenesis, addLocal, Chain} from '../db/test-helpers';
 import {addSyncSnapshot} from '../sync/test-helpers';
-import {commitImpl, openWriteTransactionImpl} from './connection';
+import {commitTransaction, openWriteTransactionImpl} from './connection';
 import {LogContext} from '../logger';
 import {initHasher} from '../hash';
 
@@ -115,7 +115,7 @@ test('open transaction rebase opts', async () => {
     },
   );
   const {txn} = otr;
-  const ctr = await commitImpl(txn, lc, false);
+  const ctr = await commitTransaction(txn, lc, false);
 
   await store.withWrite(async dagWrite => {
     const sync_head_hash = await dagWrite.read().getHead(sync.SYNC_HEAD_NAME);

--- a/src/embed/connection.test.ts
+++ b/src/embed/connection.test.ts
@@ -16,7 +16,6 @@ test('open transaction rebase opts', async () => {
   const store = new dag.Store(new MemStore());
   const lc = new LogContext();
 
-  const txns = new Map();
   const mainChain: Chain = [];
   await addGenesis(mainChain, store);
   await addLocal(mainChain, store);
@@ -36,7 +35,6 @@ test('open transaction rebase opts', async () => {
     result = await openWriteTransactionImpl(
       lc,
       store,
-      txns,
       originalName,
       originalArgs,
       {
@@ -57,7 +55,6 @@ test('open transaction rebase opts', async () => {
     result = await openWriteTransactionImpl(
       lc,
       store,
-      txns,
       'different',
       originalArgs,
       {
@@ -91,7 +88,6 @@ test('open transaction rebase opts', async () => {
     result = await openWriteTransactionImpl(
       lc,
       store,
-      txns,
       newLocalName,
       newLocalArgs,
       {
@@ -111,7 +107,6 @@ test('open transaction rebase opts', async () => {
   const otr = await openWriteTransactionImpl(
     lc,
     store,
-    txns,
     originalName,
     originalArgs,
     {
@@ -119,7 +114,8 @@ test('open transaction rebase opts', async () => {
       original: originalHash,
     },
   );
-  const ctr = await commitImpl(txns, otr, false);
+  const {txn} = otr;
+  const ctr = await commitImpl(txn, lc, false);
 
   await store.withWrite(async dagWrite => {
     const sync_head_hash = await dagWrite.read().getHead(sync.SYNC_HEAD_NAME);

--- a/src/embed/connection.test.ts
+++ b/src/embed/connection.test.ts
@@ -104,7 +104,7 @@ test('open transaction rebase opts', async () => {
   );
 
   // Correct rebase_opt (test this last because it affects the chain).
-  const otr = await openWriteTransactionImpl(
+  const txn = await openWriteTransactionImpl(
     lc,
     store,
     originalName,
@@ -114,11 +114,10 @@ test('open transaction rebase opts', async () => {
       original: originalHash,
     },
   );
-  const {txn} = otr;
   const ctr = await commitTransaction(txn, lc, false);
 
   await store.withWrite(async dagWrite => {
-    const sync_head_hash = await dagWrite.read().getHead(sync.SYNC_HEAD_NAME);
-    expect(ctr.ref).to.equal(sync_head_hash);
+    const syncHeadHash = await dagWrite.read().getHead(sync.SYNC_HEAD_NAME);
+    expect(ctr.ref).to.equal(syncHeadHash);
   });
 });

--- a/src/embed/connection.test.ts
+++ b/src/embed/connection.test.ts
@@ -4,7 +4,7 @@ import * as sync from '../sync/mod';
 import {MemStore} from '../kv/mem-store';
 import {addGenesis, addLocal, Chain} from '../db/test-helpers';
 import {addSyncSnapshot} from '../sync/test-helpers';
-import {commitTransaction, openWriteTransactionImpl} from './connection';
+import {commitTransaction, openWriteTransaction} from './connection';
 import {LogContext} from '../logger';
 import {initHasher} from '../hash';
 
@@ -32,15 +32,15 @@ test('open transaction rebase opts', async () => {
   let result;
   try {
     // Error: rebase commit's basis must be sync head.
-    result = await openWriteTransactionImpl(
-      lc,
-      store,
+    result = await openWriteTransaction(
       originalName,
       originalArgs,
       {
         basis: originalHash, // <-- not the sync head
         original: originalHash,
       },
+      store,
+      lc,
     );
   } catch (e) {
     result = e;
@@ -52,15 +52,15 @@ test('open transaction rebase opts', async () => {
 
   // Error: rebase commit's name should not change.
   try {
-    result = await openWriteTransactionImpl(
-      lc,
-      store,
+    result = await openWriteTransaction(
       'different',
       originalArgs,
       {
         basis: syncChain[0].chunk.hash,
         original: originalHash,
       },
+      store,
+      lc,
     );
   } catch (e) {
     result = e;
@@ -85,15 +85,15 @@ test('open transaction rebase opts', async () => {
   const newLocalName = lm.mutatorName;
   const newLocalArgs = lm.mutatorArgsJSON;
   try {
-    result = await openWriteTransactionImpl(
-      lc,
-      store,
+    result = await openWriteTransaction(
       newLocalName,
       newLocalArgs,
       {
         basis: syncChain[0].chunk.hash,
         original: newLocalHash,
       },
+      store,
+      lc,
     );
   } catch (e) {
     result = e;
@@ -104,15 +104,15 @@ test('open transaction rebase opts', async () => {
   );
 
   // Correct rebase_opt (test this last because it affects the chain).
-  const txn = await openWriteTransactionImpl(
-    lc,
-    store,
+  const txn = await openWriteTransaction(
     originalName,
     originalArgs,
     {
       basis: syncChain[0].chunk.hash,
       original: originalHash,
     },
+    store,
+    lc,
   );
   const ctr = await commitTransaction(txn, lc, false);
 

--- a/src/embed/connection.ts
+++ b/src/embed/connection.ts
@@ -34,19 +34,7 @@ function logCall(name: string, ...args: unknown[]): void {
   testLog.push({name, args});
 }
 
-// type ConnectionMap = Map<string, {store: dag.Store}>;
-
-// const connections: ConnectionMap = new Map();
-
 let transactionCounter = 0;
-
-// function getConnection(dbName: string) {
-//   const connection = connections.get(dbName);
-//   if (!connection) {
-//     throw new Error(`Database "${dbName}" is not open`);
-//   }
-//   return connection;
-// }
 
 type Transaction = db.Write | db.Read;
 
@@ -82,13 +70,9 @@ export async function open(
   return {clientID, store: dagStore};
 }
 
-export async function close(
-  dbName: string,
-  store: dag.Store,
-  lc: LogContext,
-): Promise<void> {
+export async function close(store: dag.Store, lc: LogContext): Promise<void> {
   const start = Date.now();
-  isTesting && logCall('close', dbName);
+  isTesting && logCall('close');
 
   lc = lc.addContext('rpc', 'close');
   lc.debug?.('->');
@@ -106,11 +90,10 @@ async function init(dagStore: dag.Store): Promise<void> {
 }
 
 export async function openReadTransaction(
-  dbName: string,
   store: dag.Store,
   lc: LogContext,
 ): Promise<{id: number; txn: db.Read}> {
-  isTesting && logCall('openReadTransaction', dbName);
+  isTesting && logCall('openReadTransaction');
   return openReadTransactionImpl(
     lc.addContext('rpc', 'openReadTransaction'),
     store,
@@ -118,14 +101,13 @@ export async function openReadTransaction(
 }
 
 export async function openWriteTransaction(
-  dbName: string,
   name: string,
   args: ReadonlyJSONValue,
   rebaseOpts: RebaseOpts | undefined,
   store: dag.Store,
   lc: LogContext,
 ): Promise<{id: number; txn: db.Write; lc: LogContext}> {
-  isTesting && logCall('openWriteTransaction', dbName, name, args, rebaseOpts);
+  isTesting && logCall('openWriteTransaction', name, args, rebaseOpts);
   return openWriteTransactionImpl(lc, store, name, args, rebaseOpts);
 }
 
@@ -186,12 +168,11 @@ export async function openReadTransactionImpl(
 }
 
 export async function openIndexTransaction(
-  dbName: string,
   store: dag.Store,
   lc: LogContext,
 ): Promise<{id: number; txn: db.Write; lc: LogContext}> {
   const start = Date.now();
-  isTesting && logCall('openIndexTransaction', dbName);
+  isTesting && logCall('openIndexTransaction');
 
   const transactionID = transactionCounter++;
 
@@ -310,12 +291,11 @@ export async function closeTransaction(
 }
 
 export async function getRoot(
-  dbName: string,
   store: dag.Store,
   lc: LogContext,
 ): Promise<string> {
   const start = Date.now();
-  isTesting && logCall('getRoot', dbName);
+  isTesting && logCall('getRoot');
 
   const headName = db.DEFAULT_HEAD_NAME;
 
@@ -443,14 +423,13 @@ export async function dropIndex(
 }
 
 export async function maybeEndPull(
-  dbName: string,
   requestID: string,
   syncHead: string,
   store: dag.Store,
   lc: LogContext,
 ): Promise<MaybeEndPullResponse> {
   const start = Date.now();
-  isTesting && logCall('maybeEndPull', dbName, requestID, syncHead);
+  isTesting && logCall('maybeEndPull', requestID, syncHead);
 
   const lc2 = lc
     .addContext('rpc', 'maybeEndPull')
@@ -462,14 +441,13 @@ export async function maybeEndPull(
 }
 
 export async function tryPush(
-  dbName: string,
   clientID: string,
   req: TryPushRequest,
   store: dag.Store,
   lc: LogContext,
 ): Promise<HTTPRequestInfo | undefined> {
   const start = Date.now();
-  isTesting && logCall('tryPush', dbName, req);
+  isTesting && logCall('tryPush', req);
 
   const requestID = sync.newRequestID(clientID);
   const lc2 = lc
@@ -490,14 +468,13 @@ export async function tryPush(
 }
 
 export async function beginPull(
-  dbName: string,
   clientID: string,
   req: BeginPullRequest,
   store: dag.Store,
   lc: LogContext,
 ): Promise<BeginPullResponse> {
   const start = Date.now();
-  isTesting && logCall('beginPull', dbName, req);
+  isTesting && logCall('beginPull', req);
 
   const requestID = sync.newRequestID(clientID);
   const lc2 = lc

--- a/src/embed/connection.ts
+++ b/src/embed/connection.ts
@@ -299,14 +299,7 @@ export async function commitTransaction(
   generateChangedKeys: boolean,
 ): Promise<CommitTransactionResponse> {
   isTesting && logCall('commitTransaction', generateChangedKeys);
-  return commitImpl(txn, lc, generateChangedKeys);
-}
 
-export async function commitImpl(
-  txn: db.Write,
-  lc: LogContext,
-  generateChangedKeys: boolean,
-): Promise<CommitTransactionResponse> {
   const start = Date.now();
   // const {txn, lc} = getWriteTransaction(transactionID, transactionsMap);
   const lc2 = lc.addContext('rpc', 'commitTransaction');

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -691,6 +691,7 @@ export class Replicache<MD extends MutatorDefs = {}>
         await this._openResponse;
         pushResponse = await embed.tryPush(
           this.name,
+          await this._clientIDPromise,
           {
             pushURL: this.pushURL,
             pushAuth: this.auth,
@@ -764,6 +765,7 @@ export class Replicache<MD extends MutatorDefs = {}>
     await this._openResponse;
     const beginPullResponse = await embed.beginPull(
       this.name,
+      await this._clientIDPromise,
       {
         pullAuth: this.auth,
         pullURL: this.pullURL,

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -140,7 +140,6 @@ export class Replicache<MD extends MutatorDefs = {}>
   private readonly _openResponse: Promise<OpenResponse>;
   private readonly _openResolve: (resp: OpenResponse) => void;
   private readonly _clientIDPromise: Promise<string>;
-
   private _root: Promise<string | undefined> = Promise.resolve(undefined);
   private readonly _mutatorRegistry = new Map<
     string,
@@ -517,11 +516,7 @@ export class Replicache<MD extends MutatorDefs = {}>
     return new ScanResult<Key>(
       options,
       async () => {
-        const tx = new ReadTransactionImpl(
-          this.name,
-          this._openResponse,
-          this._lc,
-        );
+        const tx = new ReadTransactionImpl(this._openResponse, this._lc);
         await tx.open();
         return tx;
       },
@@ -553,11 +548,8 @@ export class Replicache<MD extends MutatorDefs = {}>
   private async _indexOp(
     f: (tx: IndexTransactionImpl) => Promise<void>,
   ): Promise<void> {
-    const tx = new IndexTransactionImpl(
-      this.name,
-      this._openResponse,
-      this._lc,
-    );
+    // TODO(arv): Maybe pass in db.Write instead of _openResponse?
+    const tx = new IndexTransactionImpl(this._openResponse, this._lc);
     try {
       await tx.open();
       await f(tx);
@@ -947,7 +939,6 @@ export class Replicache<MD extends MutatorDefs = {}>
    */
   async query<R>(body: (tx: ReadTransaction) => Promise<R> | R): Promise<R> {
     const tx = new ReadTransactionImpl<ReadonlyJSONValue>(
-      this.name,
       this._openResponse,
       this._lc,
     );
@@ -1040,7 +1031,6 @@ export class Replicache<MD extends MutatorDefs = {}>
 
     let result: R;
     const tx = new WriteTransactionImpl(
-      this.name,
       this._openResponse,
       name,
       deepClone(args ?? null),

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -1077,9 +1077,11 @@ export class ReplicacheTest<
 
 const hasBroadcastChannel = typeof BroadcastChannel !== 'undefined';
 
-async function closeIgnoreError<Value extends ReadonlyJSONValue>(
-  tx: ReadTransactionImpl<Value>,
-) {
+interface Closer {
+  close(): Promise<void>;
+}
+
+async function closeIgnoreError(tx: Closer) {
   try {
     await tx.close();
   } catch (ex) {

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -386,7 +386,7 @@ export class Replicache<MD extends MutatorDefs = {}>
     const {promise, resolve} = resolver();
     closingInstances.set(this.name, promise);
     const {store} = await this._openResponse;
-    const p = embed.close(this.name, store, this._lc);
+    const p = embed.close(store, this._lc);
 
     this._pullConnectionLoop.close();
     this._pushConnectionLoop.close();
@@ -414,7 +414,7 @@ export class Replicache<MD extends MutatorDefs = {}>
       return undefined;
     }
     const {store} = await this._openResponse;
-    return await embed.getRoot(this.name, store, this._lc);
+    return await embed.getRoot(store, this._lc);
   }
 
   private _onStorage = (e: StorageEvent) => {
@@ -578,7 +578,6 @@ export class Replicache<MD extends MutatorDefs = {}>
 
     const {store} = await this._openResponse;
     const {replayMutations, changedKeys} = await embed.maybeEndPull(
-      this.name,
       requestID,
       syncHead,
       store,
@@ -691,10 +690,9 @@ export class Replicache<MD extends MutatorDefs = {}>
       let pushResponse;
       try {
         this._changeSyncCounters(1, 0);
-        const {store} = await this._openResponse;
+        const {clientID, store} = await this._openResponse;
         pushResponse = await embed.tryPush(
-          this.name,
-          await this._clientIDPromise,
+          clientID,
           {
             pushURL: this.pushURL,
             pushAuth: this.auth,
@@ -766,10 +764,9 @@ export class Replicache<MD extends MutatorDefs = {}>
   }
 
   protected async _beginPull(maxAuthTries: number): Promise<BeginPullResult> {
-    const {store} = await this._openResponse;
+    const {clientID, store} = await this._openResponse;
     const beginPullResponse = await embed.beginPull(
-      this.name,
-      await this._clientIDPromise,
+      clientID,
       {
         pullAuth: this.auth,
         pullURL: this.pullURL,

--- a/src/repm-invoker.ts
+++ b/src/repm-invoker.ts
@@ -1,9 +1,10 @@
 import type {Puller} from './puller';
 import type {Pusher} from './pusher';
+import type * as dag from './dag/mod';
 import type * as db from './db/mod';
 import type {JSONValue} from './json';
 
-export type OpenResponse = string;
+export type OpenResponse = {clientID: string; store: dag.Store};
 
 type TransactionRequest = {
   transactionId: number;

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -71,7 +71,6 @@ export class ReadTransactionImpl<Value extends ReadonlyJSONValue>
   implements ReadTransaction, ScanTransactionDelegate
 {
   protected _closed = false;
-  protected readonly _dbName: string;
   protected readonly _openResponse: Promise<OpenResponse>;
   protected readonly _shouldClone: boolean = false;
 
@@ -79,12 +78,10 @@ export class ReadTransactionImpl<Value extends ReadonlyJSONValue>
   readonly lc: LogContext;
 
   constructor(
-    dbName: string,
     openResponse: Promise<OpenResponse>,
     lc: LogContext,
     rpcName = 'openReadTransaction',
   ) {
-    this._dbName = dbName;
     this._openResponse = openResponse;
     this.lc = lc
       .addContext('rpc', rpcName)
@@ -238,14 +235,13 @@ export class WriteTransactionImpl
   protected _transaction: db.Write | undefined = undefined;
 
   constructor(
-    dbName: string,
     openResponse: Promise<OpenResponse>,
     name: string,
     args: JSONValue,
     rebaseOpts: RebaseOpts | undefined,
     lc: LogContext,
   ) {
-    super(dbName, openResponse, lc, 'openWriteTransaction');
+    super(openResponse, lc, 'openWriteTransaction');
     this._name = name;
     this._args = args;
     this._rebaseOpts = rebaseOpts;
@@ -342,12 +338,8 @@ export class IndexTransactionImpl
 {
   protected _transaction: db.Write | undefined = undefined;
 
-  constructor(
-    dbName: string,
-    openResponse: Promise<OpenResponse>,
-    lc: LogContext,
-  ) {
-    super(dbName, openResponse, lc, 'openIndexTransaction');
+  constructor(openResponse: Promise<OpenResponse>, lc: LogContext) {
+    super(openResponse, lc, 'openIndexTransaction');
   }
 
   async createIndex(options: CreateIndexDefinition): Promise<void> {

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -140,11 +140,7 @@ export class ReadTransactionImpl<Value extends ReadonlyJSONValue>
 
   async open(): Promise<void> {
     const {store} = await this._openResponse;
-    const {id, txn} = await embed.openReadTransaction(
-      this._dbName,
-      store,
-      this._lc,
-    );
+    const {id, txn} = await embed.openReadTransaction(store, this._lc);
     this._transactionId = id;
     this._transaction = txn;
   }
@@ -295,7 +291,6 @@ export class WriteTransactionImpl
   async open(): Promise<void> {
     const {store} = await this._openResponse;
     const {id, txn} = await embed.openWriteTransaction(
-      this._dbName,
       this._name,
       this._args,
       this._rebaseOpts,
@@ -398,11 +393,7 @@ export class IndexTransactionImpl
 
   async open(): Promise<void> {
     const {store} = await this._openResponse;
-    const {id, txn} = await embed.openIndexTransaction(
-      this._dbName,
-      store,
-      this._lc,
-    );
+    const {id, txn} = await embed.openIndexTransaction(store, this._lc);
     this._transactionId = id;
     this._transaction = txn;
   }


### PR DESCRIPTION
This removes the connections map and the transactions map.

These are now owned by Replicache and Read/Write/IndexTransactions. 