### PR TITLE
refactor: Implement isEmpty

### DIFF
--- a/src/db/read.ts
+++ b/src/db/read.ts
@@ -30,6 +30,10 @@ export class Read {
     return this._map.get(key);
   }
 
+  isEmpty(): boolean {
+    return this._map.isEmpty();
+  }
+
   async scan(
     opts: ScanOptions,
     callback: (s: ScanResult) => void,

--- a/src/prolly/map.ts
+++ b/src/prolly/map.ts
@@ -56,6 +56,10 @@ class ProllyMap {
     return this._readonlyEntries[index][1];
   }
 
+  isEmpty(): boolean {
+    return this._readonlyEntries.length === 0;
+  }
+
   put(key: string, val: ReadonlyJSONValue): void {
     const entries = this._mutableEntries;
     const index = binarySearch(key, entries);

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -105,15 +105,7 @@ export class ReadTransactionImpl<Value extends ReadonlyJSONValue>
   async isEmpty(): Promise<boolean> {
     throwIfClosed(this);
     assertNotUndefined(this._transaction);
-    let empty = true;
-    await embed.scan(
-      this._transaction.asRead(),
-      this.lc,
-      {limit: 1},
-      () => (empty = false),
-      false, // shouldClone
-    );
-    return empty;
+    return this._transaction.asRead().isEmpty();
   }
 
   scan<Options extends ScanOptions, Key extends KeyTypeForScanOptions<Options>>(


### PR DESCRIPTION
We used to use scan as a way to check if a list was empty, but this is
much more efficient.