### PR TITLE
refactor: Make db.Write extend db.Read

### DIFF
--- a/src/db/read.ts
+++ b/src/db/read.ts
@@ -13,25 +13,25 @@ import type {ReadonlyJSONValue} from '../json';
 
 export class Read {
   private readonly _dagRead: dag.Read;
-  private readonly _map: prolly.Map;
-  private readonly _indexes: Map<string, Index>;
+  map: prolly.Map;
+  readonly indexes: Map<string, Index>;
 
   constructor(dagRead: dag.Read, map: prolly.Map, indexes: Map<string, Index>) {
     this._dagRead = dagRead;
-    this._map = map;
-    this._indexes = indexes;
+    this.map = map;
+    this.indexes = indexes;
   }
 
   has(key: string): boolean {
-    return this._map.has(key);
+    return this.map.has(key);
   }
 
   get(key: string): ReadonlyJSONValue | undefined {
-    return this._map.get(key);
+    return this.map.get(key);
   }
 
   isEmpty(): boolean {
-    return this._map.isEmpty();
+    return this.map.isEmpty();
   }
 
   async scan(
@@ -41,7 +41,7 @@ export class Read {
     const optsInternal: ScanOptionsInternal = convert(opts);
     if (optsInternal.indexName !== undefined) {
       const name = optsInternal.indexName;
-      const idx = this._indexes.get(name);
+      const idx = this.indexes.get(name);
       if (idx === undefined) {
         throw new Error(`Unknown index name: ${name}`);
       }
@@ -52,7 +52,7 @@ export class Read {
         }
       });
     } else {
-      for (const item of scan(this._map, optsInternal)) {
+      for (const item of scan(this.map, optsInternal)) {
         callback(item);
       }
     }
@@ -60,10 +60,6 @@ export class Read {
 
   close(): void {
     this._dagRead.close();
-  }
-
-  asRead(): this {
-    return this;
   }
 }
 

--- a/src/db/write.test.ts
+++ b/src/db/write.test.ts
@@ -29,9 +29,8 @@ test('basics', async () => {
       dagWrite,
     );
     await w.put(lc, 'foo', 'bar');
-    // Assert we can read the same value from within this transaction.
-    const r = w.asRead();
-    const val = r.get('foo');
+    // Assert we can read the same value from within this transaction.;
+    const val = w.get('foo');
     expect(val).to.deep.equal('bar');
     await w.commit(DEFAULT_HEAD_NAME);
   });
@@ -45,8 +44,7 @@ test('basics', async () => {
       null,
       dagWrite,
     );
-    const r = w.asRead();
-    const val = r.get('foo');
+    const val = w.get('foo');
     expect(val).to.deep.equal('bar');
   });
 
@@ -61,8 +59,7 @@ test('basics', async () => {
     );
     await w.del(lc, 'foo');
     // Assert it is gone while still within this transaction.
-    const r = w.asRead();
-    const val = r.get('foo');
+    const val = w.get('foo');
     expect(val).to.be.undefined;
     await w.commit(DEFAULT_HEAD_NAME);
   });
@@ -76,8 +73,7 @@ test('basics', async () => {
       null,
       dagWrite,
     );
-    const r = w.asRead();
-    const val = r.get(`foo`);
+    const val = w.get(`foo`);
     expect(val).to.be.undefined;
   });
 });

--- a/src/db/write.ts
+++ b/src/db/write.ts
@@ -41,12 +41,10 @@ const enum MetaType {
   Snapshot,
 }
 
-export class Write {
+export class Write extends Read {
   private readonly _dagWrite: dag.Write;
-  map: prolly.Map;
   private readonly _basis: Commit | undefined;
   private readonly _meta: Meta;
-  readonly indexes: Map<string, Index>;
 
   constructor(
     dagWrite: dag.Write,
@@ -55,11 +53,10 @@ export class Write {
     meta: Meta,
     indexes: Map<string, Index>,
   ) {
+    super(dagWrite.read(), map, indexes);
     this._dagWrite = dagWrite;
-    this.map = map;
     this._basis = basis;
     this._meta = meta;
-    this.indexes = indexes;
   }
 
   static async newLocal(
@@ -118,10 +115,6 @@ export class Write {
       {type: MetaType.IndexChange, lastMutationID},
       indexes,
     );
-  }
-
-  asRead(): Read {
-    return new Read(this._dagWrite.read(), this.map, this.indexes);
   }
 
   isRebase(): boolean {

--- a/src/embed/connection.ts
+++ b/src/embed/connection.ts
@@ -236,10 +236,6 @@ export async function commitTransaction(
   const lc2 = lc.addContext('rpc', 'commitTransaction');
   lc2.debug?.('->', generateChangedKeys);
 
-  if (txn instanceof db.Read) {
-    throw new Error('Transaction is read-only');
-  }
-
   const headName = txn.isRebase() ? sync.SYNC_HEAD_NAME : db.DEFAULT_HEAD_NAME;
   const [hash, changedKeys] = await txn.commitWithChangedKeys(
     headName,
@@ -292,7 +288,7 @@ export function has(txn: Transaction, lc: LogContext, key: string): boolean {
 
   const lc2 = lc.addContext('rpc', 'has');
   lc2.debug?.('->', key);
-  const result = txn.asRead().has(key);
+  const result = txn.has(key);
   lc2.debug?.('<- elapsed=', Date.now() - start, 'ms, result=', result);
   return result;
 }
@@ -308,7 +304,7 @@ export function get(
 
   const lc2 = lc.addContext('rpc', 'get');
   lc2.debug?.('->', key);
-  const value = txn.asRead().get(key);
+  const value = txn.get(key);
 
   const result = value && (shouldClone ? deepClone(value) : value);
   lc2.debug?.('<- elapsed=', Date.now() - start, 'ms, result=', result);
@@ -367,7 +363,7 @@ export async function del(
 
   const lc2 = lc.addContext('rpc', 'del');
   lc2.debug?.('->', key);
-  const had = await txn.asRead().has(key);
+  const had = await txn.has(key);
   await txn.del(lc, key);
   lc2.debug?.('<- elapsed=', Date.now() - start, 'ms, result=', had);
   return had;

--- a/src/sync/patch.test.ts
+++ b/src/sync/patch.test.ts
@@ -188,10 +188,10 @@ test('patch', async () => {
 
       if (c.expMap !== undefined) {
         for (const [k, v] of c.expMap) {
-          expect(v).to.deep.equal(dbWrite.asRead().get(k));
+          expect(v).to.deep.equal(dbWrite.get(k));
         }
         if (c.expMap.size === 0) {
-          expect(dbWrite.asRead().has('key')).to.be.false;
+          expect(dbWrite.has('key')).to.be.false;
         }
       }
     });

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -105,7 +105,7 @@ export class ReadTransactionImpl<Value extends ReadonlyJSONValue>
   async isEmpty(): Promise<boolean> {
     throwIfClosed(this);
     assertNotUndefined(this._transaction);
-    return this._transaction.asRead().isEmpty();
+    return this._transaction.isEmpty();
   }
 
   scan<Options extends ScanOptions, Key extends KeyTypeForScanOptions<Options>>(
@@ -135,8 +135,9 @@ export class ReadTransactionImpl<Value extends ReadonlyJSONValue>
   }
 
   get dbRead(): db.Read {
+    // TODO(arv): Remove?
     assertNotUndefined(this._transaction);
-    return this._transaction.asRead();
+    return this._transaction;
   }
 }
 


### PR DESCRIPTION
This removes the need for the asRead() indirection.