### PR TITLE
refactore: Make dag.Write extend dag.Read

### DIFF
--- a/src/dag/write.test.ts
+++ b/src/dag/write.test.ts
@@ -210,8 +210,8 @@ test('roundtrip', async () => {
       await w.setHead(name, c.hash);
 
       // Read the changes inside the tx.
-      const c2 = await w.read().getChunk(c.hash);
-      const h = await w.read().getHead(name);
+      const c2 = await w.getChunk(c.hash);
+      const h = await w.getHead(name);
       expect(c2).to.deep.equal(c);
       expect(c.hash).to.equal(h);
       await w.commit();

--- a/src/dag/write.ts
+++ b/src/dag/write.ts
@@ -9,17 +9,14 @@ type HeadChange = {
   old: string | undefined;
 };
 
-export class Write {
+export class Write extends Read {
   private readonly _kvw: kv.Write;
   private readonly _newChunks = new Set<string>();
   private readonly _changedHeads = new Map<string, HeadChange>();
 
   constructor(kvw: kv.Write) {
+    super(kvw);
     this._kvw = kvw;
-  }
-
-  read(): Read {
-    return new Read(this._kvw);
   }
 
   async putChunk(c: Chunk): Promise<void> {
@@ -47,7 +44,7 @@ export class Write {
     name: string,
     hash: string | undefined,
   ): Promise<void> {
-    const oldHash = await this.read().getHead(name);
+    const oldHash = await this.getHead(name);
     const hk = headKey(name);
 
     let p1: Promise<void>;

--- a/src/db/write.test.ts
+++ b/src/db/write.test.ts
@@ -149,7 +149,7 @@ test('clear', async () => {
     expect([...w.map]).to.have.lengthOf(2);
     let index = w.indexes.get('idx');
     assertNotUndefined(index);
-    await index.withMap(dagWrite.read(), map => {
+    await index.withMap(dagWrite, map => {
       expect([...map]).to.have.lengthOf(2);
     });
 
@@ -157,7 +157,7 @@ test('clear', async () => {
     expect([...w.map]).to.have.lengthOf(0);
     index = w.indexes.get('idx');
     assertNotUndefined(index);
-    await index.withMap(dagWrite.read(), map => {
+    await index.withMap(dagWrite, map => {
       expect([...map]).to.have.lengthOf(0);
     });
 
@@ -249,10 +249,7 @@ test('create and drop index', async () => {
       );
       await w.dropIndex(indexName);
       await w.commit(DEFAULT_HEAD_NAME);
-      const [, c] = await readCommit(
-        whenceHead(DEFAULT_HEAD_NAME),
-        dagWrite.read(),
-      );
+      const [, c] = await readCommit(whenceHead(DEFAULT_HEAD_NAME), dagWrite);
       const indexes = c.indexes;
       expect(indexes).to.be.empty;
     });

--- a/src/embed/connection.test.ts
+++ b/src/embed/connection.test.ts
@@ -117,7 +117,7 @@ test('open transaction rebase opts', async () => {
   const ctr = await commitTransaction(txn, lc, false);
 
   await store.withWrite(async dagWrite => {
-    const syncHeadHash = await dagWrite.read().getHead(sync.SYNC_HEAD_NAME);
+    const syncHeadHash = await dagWrite.getHead(sync.SYNC_HEAD_NAME);
     expect(ctr.ref).to.equal(syncHeadHash);
   });
 });

--- a/src/embed/connection.ts
+++ b/src/embed/connection.ts
@@ -80,7 +80,7 @@ export async function close(store: dag.Store, lc: LogContext): Promise<void> {
 
 async function init(dagStore: dag.Store): Promise<void> {
   await dagStore.withWrite(async dagWrite => {
-    const head = await dagWrite.read().getHead(db.DEFAULT_HEAD_NAME);
+    const head = await dagWrite.getHead(db.DEFAULT_HEAD_NAME);
     if (!head) {
       await db.initDB(dagWrite, db.DEFAULT_HEAD_NAME);
     }
@@ -127,7 +127,7 @@ export async function openWriteTransaction(
     if (rebaseOpts === undefined) {
       whence = db.whenceHead(db.DEFAULT_HEAD_NAME);
     } else {
-      await validateRebase(rebaseOpts, dagWrite.read(), name, args);
+      await validateRebase(rebaseOpts, dagWrite, name, args);
       whence = db.whenceHash(rebaseOpts.basis);
       originalHash = rebaseOpts.original;
     }

--- a/src/sync/pull.ts
+++ b/src/sync/pull.ts
@@ -96,7 +96,7 @@ export async function beginPull(
   // It is possible that another sync completed while we were pulling. Ensure
   // that is not the case by re-checking the base snapshot.
   return await store.withWrite(async dagWrite => {
-    const dagRead = dagWrite.read();
+    const dagRead = dagWrite;
     const mainHeadPostPull = await dagRead.getHead(db.DEFAULT_HEAD_NAME);
 
     if (mainHeadPostPull === undefined) {
@@ -185,7 +185,7 @@ export async function maybeEndPull(
 ): Promise<MaybeEndPullResponse> {
   // Ensure sync head is what the caller thinks it is.
   return await store.withWrite(async dagWrite => {
-    const dagRead = dagWrite.read();
+    const dagRead = dagWrite;
     const syncHeadHash = await dagRead.getHead(SYNC_HEAD_NAME);
     if (syncHeadHash === undefined) {
       throw new Error('Missing sync head');


### PR DESCRIPTION
This removes the need to have a read() indirection.