### PR TITLE
chore: Fix perf runner for webkit

### DIFF
--- a/perf/runner.js
+++ b/perf/runner.js
@@ -112,7 +112,7 @@ async function main() {
       rootDir: process.cwd(),
       port,
       watch: false,
-      plugins: [esbuildPlugin({ts: true})],
+      plugins: [esbuildPlugin({ts: true, target: 'esnext'})],
     },
     readCliArgs: false,
     readFileConfig: false,
@@ -150,7 +150,7 @@ async function runInBrowser(browser, page, options) {
   async function waitForBenchmarks() {
     await page.waitForFunction('typeof benchmarks !==  "undefined"', null, {
       // No need to wait 30s if failing to load
-      timeout: 1000,
+      timeout: 5000,
     });
   }
 

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -8,7 +8,7 @@ const firefox = playwrightLauncher({product: 'firefox'});
 export default {
   concurrentBrowsers: 3,
   nodeResolve: true,
-  plugins: [esbuildPlugin({ts: true})],
+  plugins: [esbuildPlugin({ts: true, target: 'esnext'})],
   testFramework: {
     config: {
       ui: 'tdd',


### PR DESCRIPTION
target: auto does not work correctly so lets just use esnext!