### PR TITLE
Fix broken link to integration guide

### DIFF
--- a/doc/docs/sample-chat.md
+++ b/doc/docs/sample-chat.md
@@ -3,7 +3,7 @@ title: Chat
 slug: /samples/chat
 ---
 
-The chat sample is the result of the [Integration Guide](guide/intro). You can
+The chat sample is the result of the [Integration Guide](/guide/intro). You can
 also check it out from [Replicache Sample
 Chat](https://github.com/rocicorp/replicache-sample-chat) repo.
 


### PR DESCRIPTION
Haven't been able to test locally, but I think this should fix the broken `[Integration Guide]` link on https://doc.replicache.dev/samples/chat