### PR TITLE
Database Setup guide tweaks

### DIFF
--- a/doc/docs/guide-database-setup.md
+++ b/doc/docs/guide-database-setup.md
@@ -9,10 +9,10 @@ Each mutation is identified with a `mutationID` which is a per-client incrementi
 
 For this demo, we're using [Supabase](https://supabase.io), a very nice hosted Postgres database with a snazzy name. But you can use any datastore as long as it can transactionally update the `lastMutationID`. See [Backend Requirements](#TODO) for precise details of what your backend needs to support Replicache.
 
-Head over to [Supabase](https://supabase.io) and create a free account and an empty database. Then add Supabase's Postgres connection string to your environment. You can get it from your Supabase project by clicking on ⚙️ (Gear/Cog) > Database > Connection String.
+Head over to [Supabase](https://supabase.io) and create a free account and an empty database. Then add Supabase's PSQL connection string to your environment. You can get it from your Supabase project by clicking on ⚙️ (Gear/Cog) > Database > Connection String.
 
 ```bash
-export REPLICHAT_DB_CONNECTION_STRING=<your connnection string>
+export REPLICHAT_DB_CONNECTION_STRING='<your connection string>'
 ```
 
 Then, create a new file `db.js` with this code:


### PR DESCRIPTION
* Say `PSQL` to match the tab in the current Supabase connection string UI
* When exporting the DB connection string, remove extra `n` and enclose in single quotes to avoid choking on any special characters in the DB password