### PR TITLE
Add a couple perf tests for small localStorage I/O.

### DIFF
--- a/perf/data.ts
+++ b/perf/data.ts
@@ -40,7 +40,7 @@ export function makeRandomStrings(
   return Array.from({length: numStrings}, () => randomString(strLen));
 }
 
-function randomString(len: number): string {
+export function randomString(len: number): string {
   const arr = randomUint8Array(len);
   return new TextDecoder('ascii').decode(arr);
 }

--- a/perf/perf.ts
+++ b/perf/perf.ts
@@ -2,6 +2,7 @@ import {benchmarks as replicacheBenchmarks} from './replicache';
 import {benchmarkIDBRead, benchmarkIDBWrite} from './idb';
 import {benchmarks as lockBenchmarks} from './lock';
 import {benchmarks as hashBenchmarks} from './hash';
+import {benchmarks as storageBenchmarks} from './storage';
 import type {RandomDataType} from './data';
 
 export type Benchmark = {
@@ -119,6 +120,7 @@ export const benchmarks = [
   ...replicacheBenchmarks(),
   ...lockBenchmarks(),
   ...hashBenchmarks(),
+  ...storageBenchmarks(),
 ];
 
 for (const b of [benchmarkIDBRead, benchmarkIDBWrite]) {

--- a/perf/runner.js
+++ b/perf/runner.js
@@ -10,7 +10,7 @@ import * as os from 'os';
 import * as path from 'path';
 import {promises as fs} from 'fs';
 
-const allBrowsers = ['chromium', 'webkit', 'firefox'];
+const allBrowsers = ['chromium', 'firefox', 'webkit'];
 
 function browser(arg) {
   arg = arg.toLowerCase();

--- a/perf/storage.ts
+++ b/perf/storage.ts
@@ -1,0 +1,46 @@
+import {uuid} from '../src/sync/uuid';
+import {randomString} from './data';
+import type {Benchmark} from './perf';
+
+export function benchmarks(): Benchmark[] {
+  return [localStorageRead(), localStorageWrite()];
+}
+
+function localStorageRead() {
+  return {
+    name: 'localStorage read',
+    group: 'storage',
+    key: '',
+    value: <string | null>null,
+    async setup() {
+      this.key = uuid();
+      localStorage.setItem(this.key, randomString(100));
+    },
+    async teardown() {
+      localStorage.removeItem(this.key);
+    },
+    async run() {
+      // Assign to ensure this read isn't optimized away.
+      this.value = localStorage.getItem(this.key);
+    },
+  };
+}
+
+function localStorageWrite() {
+  return {
+    name: 'localStorage write',
+    group: 'storage',
+    key: '',
+    value: '',
+    async setup() {
+      this.key = uuid();
+      this.value = randomString(100);
+    },
+    async teardown() {
+      localStorage.removeItem(this.key);
+    },
+    async run() {
+      localStorage.setItem(this.key, this.value);
+    },
+  };
+}


### PR DESCRIPTION
I swapped the order of firefox and webkit in the allBrowsers list
because runner.js would fail to start Firefox in the third position when
running with --browsers all, but it runs fine in the second. ¯\_(ツ)_/¯