### PR TITLE
fix: Fix deadlock/transaction issues with expose clientID on Read/WriteTransaction

### DIFF
--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -2805,16 +2805,15 @@ test('mutate args in mutation', async () => {
     v: 1,
   });
 });
-
-test('client ID is set correctly on transactions', async () => {
+testWithBothStores('client ID is set correctly on transactions', async () => {
   const store = new TestMemStore();
   const rep = await replicacheForTesting(
     'client-id-is-set-correctly-on-transactions',
     {
       experimentalKVStore: store,
       mutators: {
-        async expectClientID(tx, args: {expectedClientID: string}) {
-          expect(tx.clientID).to.equal(args.expectedClientID);
+        async expectClientID(tx, expectedClientID: string) {
+          expect(tx.clientID).to.equal(expectedClientID);
         },
       },
     },
@@ -2826,5 +2825,5 @@ test('client ID is set correctly on transactions', async () => {
     expect(tx.clientID).to.equal(repClientID);
   });
 
-  await rep.mutate.expectClientID({expectedClientID: repClientID});
+  await rep.mutate.expectClientID(repClientID);
 });

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -142,7 +142,6 @@ export class Replicache<MD extends MutatorDefs = {}> {
   private _online = true;
   private readonly _logger: Logger;
   private readonly _ready: Promise<void>;
-  private readonly _resolveReady: () => void;
   private readonly _clientIDPromise: Promise<string>;
   private _root: Promise<string | undefined> = Promise.resolve(undefined);
   private readonly _mutatorRegistry = new Map<
@@ -289,9 +288,8 @@ export class Replicache<MD extends MutatorDefs = {}> {
 
     // Use a promise-resolve pair so that we have a promise to use even before
     // we call the Open RPC.
-    const {promise, resolve} = resolver<void>();
-    this._ready = promise;
-    this._resolveReady = resolve;
+    const readyResolver = resolver<void>();
+    this._ready = readyResolver.promise;
 
     const {minDelayMs = MIN_DELAY_MS, maxDelayMs = MAX_DELAY_MS} =
       requestOptions;
@@ -319,10 +317,16 @@ export class Replicache<MD extends MutatorDefs = {}> {
 
     this._lc = new LogContext(logLevel).addContext('db', name);
 
-    this._clientIDPromise = this._open();
+    const clientIDResolver = resolver<string>();
+    this._clientIDPromise = clientIDResolver.promise;
+
+    void this._open(clientIDResolver.resolve, readyResolver.resolve);
   }
 
-  private async _open(): Promise<string> {
+  private async _open(
+    resolveClientID: (clientID: string) => void,
+    resolveReady: () => void,
+  ): Promise<void> {
     // If we are currently closing a Replicache instance with the same name,
     // wait for it to finish closing.
     await closingInstances.get(this.name);
@@ -333,9 +337,10 @@ export class Replicache<MD extends MutatorDefs = {}> {
       sync.initClientID(this._kvStore),
       db.maybeInitDefaultDB(this._dagStore),
     ]);
+    resolveClientID(clientID);
 
     // Now we have both a clientID and DB!
-    this._resolveReady();
+    resolveReady();
 
     if (hasBroadcastChannel) {
       this._broadcastChannel = new BroadcastChannel(storageKeyName(this.name));
@@ -349,7 +354,6 @@ export class Replicache<MD extends MutatorDefs = {}> {
 
     this.pull();
     this._push();
-    return clientID;
   }
 
   /**
@@ -573,13 +577,14 @@ export class Replicache<MD extends MutatorDefs = {}> {
     f: (tx: IndexTransactionImpl) => Promise<void>,
   ): Promise<void> {
     await this._ready;
+    // clientID must be awaited ouside dag transaction to avoid a premature
+    // auto-commit of the idb transaction.
+    const clientID = await this._clientIDPromise;
     await this._dagStore.withWrite(async dagWrite => {
-      const clientID = await this._clientIDPromise;
       const dbWrite = await db.Write.newIndexChange(
         db.whenceHead(db.DEFAULT_HEAD_NAME),
         dagWrite,
       );
-
       const tx = new IndexTransactionImpl(clientID, dbWrite, this._lc);
       await f(tx);
       await tx.commit();
@@ -983,9 +988,11 @@ export class Replicache<MD extends MutatorDefs = {}> {
    */
   async query<R>(body: (tx: ReadTransaction) => Promise<R> | R): Promise<R> {
     await this._ready;
+    // clientID must be awaited ouside dag transaction to avoid a premature
+    // auto-commit of the idb transaction.
+    const clientID = await this._clientIDPromise;
     return await this._dagStore.withRead(async dagRead => {
       const dbRead = await db.readFromDefaultHead(dagRead);
-      const clientID = await this._clientIDPromise;
       const tx = new ReadTransactionImpl(clientID, dbRead, this._lc);
       return await body(tx);
     });
@@ -1069,6 +1076,9 @@ export class Replicache<MD extends MutatorDefs = {}> {
     }
 
     await this._ready;
+    // clientID must be awaited ouside dag transaction to avoid a premature
+    // auto-commit of the idb transaction.
+    const clientID = await this._clientIDPromise;
     return await this._dagStore.withWrite(async dagWrite => {
       let whence: db.Whence | undefined;
       let originalHash: string | null = null;
@@ -1080,7 +1090,6 @@ export class Replicache<MD extends MutatorDefs = {}> {
         originalHash = rebaseOpts.original;
       }
 
-      const clientID = await this._clientIDPromise;
       const dbWrite = await db.Write.newLocal(
         whence,
         name,

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -334,7 +334,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
     await Promise.all([initHasher(), migrate(this._kvStore, this._lc)]);
 
     await Promise.all([
-      sync.initClientID(this._kvStore).then((clientID) => {
+      sync.initClientID(this._kvStore).then(clientID => {
         resolveClientID(clientID);
       }),
       db.maybeInitDefaultDB(this._dagStore),

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -333,11 +333,8 @@ export class Replicache<MD extends MutatorDefs = {}> {
 
     await Promise.all([initHasher(), migrate(this._kvStore, this._lc)]);
 
-    const [clientID] = await Promise.all([
-      sync.initClientID(this._kvStore),
-      db.maybeInitDefaultDB(this._dagStore),
-    ]);
-    resolveClientID(clientID);
+    resolveClientID(await sync.initClientID(this._kvStore));
+    await db.maybeInitDefaultDB(this._dagStore);
 
     // Now we have both a clientID and DB!
     resolveReady();

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -333,8 +333,12 @@ export class Replicache<MD extends MutatorDefs = {}> {
 
     await Promise.all([initHasher(), migrate(this._kvStore, this._lc)]);
 
-    resolveClientID(await sync.initClientID(this._kvStore));
-    await db.maybeInitDefaultDB(this._dagStore);
+    await Promise.all([
+      sync.initClientID(this._kvStore).then((clientID) => {
+        resolveClientID(clientID);
+      }),
+      db.maybeInitDefaultDB(this._dagStore),
+    ]);
 
     // Now we have both a clientID and DB!
     resolveReady();


### PR DESCRIPTION
This change

1. Addresses arv's feedback on PR #613
2. Fixes issue where awaiting clientID inside a dag transaction was causing deadlocks and/or prematurely closing idb transactions.
3. Restructures `Replicache#_open` to avoid unnecessarily delaying the resolution of _clientIDPromise (currently blocks on db initialization and `this._getRoot`).

Closes #541 
