### PR TITLE
fix: Do not send push or pull requests when pushURL/pullURL are not provided

### DIFF
--- a/src/connection-loop.test.ts
+++ b/src/connection-loop.test.ts
@@ -1,12 +1,13 @@
 import {expect} from '@esm-bundle/chai';
 import {SinonFakeTimers, useFakeTimers} from 'sinon';
 import {
-  ConnectionLoop,
   ConnectionLoopDelegate,
+  createConnectionLoop,
   DEBOUNCE_DELAY_MS,
   MAX_DELAY_MS,
   MIN_DELAY_MS,
 } from './connection-loop';
+import type {ConnectionLoop} from './connection-loop';
 import {sleep} from './sleep';
 
 let clock: SinonFakeTimers;
@@ -76,7 +77,7 @@ function createLoop(
     },
   };
 
-  return (loop = new ConnectionLoop(delegate));
+  return (loop = createConnectionLoop(delegate));
 }
 
 test('basic sequential by awaiting', async () => {
@@ -578,7 +579,7 @@ test('watchdog timer again', async () => {
 test('mutate minDelayMs', async () => {
   let minDelayMs = 50;
   const log: number[] = [];
-  loop = new ConnectionLoop({
+  loop = createConnectionLoop({
     async invokeSend() {
       log.push(Date.now());
       return true;

--- a/src/connection-loop.ts
+++ b/src/connection-loop.ts
@@ -31,7 +31,7 @@ export function createConnectionLoop(
   return new ConnectionLoopImpl(delegate);
 }
 
-export function createNullConnectionLoop() {
+export function createNullConnectionLoop(): ConnectionLoop {
   return new NullConnectionLoop();
 }
 

--- a/src/connection-loop.ts
+++ b/src/connection-loop.ts
@@ -19,7 +19,35 @@ export interface ConnectionLoopDelegate extends Logger {
   minDelayMs: number;
 }
 
-export class ConnectionLoop {
+export interface ConnectionLoop {
+  close(): void;
+  send(): void;
+  run(): Promise<void>;
+}
+
+export function createConnectionLoop(
+  delegate: ConnectionLoopDelegate,
+): ConnectionLoop {
+  return new ConnectionLoopImpl(delegate);
+}
+
+export function createNullConnectionLoop() {
+  return new NullConnectionLoop();
+}
+
+class NullConnectionLoop implements ConnectionLoop {
+  close(): void {
+    return;
+  }
+  send(): void {
+    return;
+  }
+  run(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class ConnectionLoopImpl implements ConnectionLoop {
   // ConnectionLoop runs a loop sending network requests (either pushes or
   // pulls) to the server. Our goal, generally, is to send requests as fast as
   // we can, but to adjust in case of slowness, network errors, etc. We will

--- a/src/replicache-options.ts
+++ b/src/replicache-options.ts
@@ -21,6 +21,8 @@ export interface ReplicacheOptions<MD extends MutatorDefs> {
    * This is the URL to the server endpoint dealing with the push updates. See
    * [Push Endpoint Reference](https://doc.replicache.dev/server-push) for more
    * details.
+   *
+   * If not provided, push requests will not be made.
    */
   pushURL?: string;
 
@@ -43,6 +45,8 @@ export interface ReplicacheOptions<MD extends MutatorDefs> {
    * This is the URL to the server endpoint dealing with pull. See [Pull
    * Endpoint Reference](https://doc.replicache.dev/server-pull) for more
    * details.
+   *
+   * If not provided, pull requests will not be made.
    */
   pullURL?: string;
 

--- a/src/replicache-options.ts
+++ b/src/replicache-options.ts
@@ -22,7 +22,8 @@ export interface ReplicacheOptions<MD extends MutatorDefs> {
    * [Push Endpoint Reference](https://doc.replicache.dev/server-push) for more
    * details.
    *
-   * If not provided, push requests will not be made.
+   * If not provided, push requests will not be made unless a custom
+   * [[ReplicacheOptions.pusher]] is provided.
    */
   pushURL?: string;
 
@@ -46,7 +47,8 @@ export interface ReplicacheOptions<MD extends MutatorDefs> {
    * Endpoint Reference](https://doc.replicache.dev/server-pull) for more
    * details.
    *
-   * If not provided, pull requests will not be made.
+   * If not provided, pull requests will not be made unless a custom
+   * [[ReplicacheOptions.puller]] is provided.
    */
   pullURL?: string;
 

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -68,6 +68,7 @@ async function replicacheForTesting<MD extends MutatorDefs = {}>(
   });
 }
 
+// eslint-disable-next-line @typescript-eslint/ban-types
 async function replicacheForTestingNoDefaultURLs<MD extends MutatorDefs = {}>(
   name: string,
   {

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -303,25 +303,27 @@ export class Replicache<MD extends MutatorDefs = {}> {
       requestOptions;
     this._requestOptions = {maxDelayMs, minDelayMs};
 
-    this._pullConnectionLoop = this.pullURL
-      ? createConnectionLoop(
-          new PullDelegate(
-            this,
-            () => this._invokePull(),
-            getLogger(['PULL'], logLevel),
-          ),
-        )
-      : createNullConnectionLoop();
+    this._pullConnectionLoop =
+      options.pullURL || options.puller
+        ? createConnectionLoop(
+            new PullDelegate(
+              this,
+              () => this._invokePull(),
+              getLogger(['PULL'], logLevel),
+            ),
+          )
+        : createNullConnectionLoop();
 
-    this._pushConnectionLoop = this.pushURL
-      ? createConnectionLoop(
-          new PushDelegate(
-            this,
-            () => this._invokePush(MAX_REAUTH_TRIES),
-            getLogger(['PUSH'], logLevel),
-          ),
-        )
-      : createNullConnectionLoop();
+    this._pushConnectionLoop =
+      options.pushURL || options.pusher
+        ? createConnectionLoop(
+            new PushDelegate(
+              this,
+              () => this._invokePush(MAX_REAUTH_TRIES),
+              getLogger(['PUSH'], logLevel),
+            ),
+          )
+        : createNullConnectionLoop();
 
     this._logger = getLogger([], logLevel);
 


### PR DESCRIPTION
Updates `Replicache`s logic to not send push requests when `ReplicacheOptions.pushURL` is not provided (unless `ReplicacheOptions.pusher` is provided), and similarly to not send pull requests when `ReplicacheOptions.pullURL` is not provided (unless `ReplicacheOptions.puller` is provided).

Implementation uses the null object pattern , using a `NullConnectionLoop` when the corresponding url is not specified.

This fixes an issue where push and pull requests were being sent in the performance tests, unintentionally impacting the timing results. 

This made a very large difference in the persistent store tests for read and scan. 

Prior to this change
```
read tx 1024x1000 x 9.74 MB/s ±78.9% (7 runs sampled)
read tx 1024x5000 x 9.05 MB/s ±83.0% (5 runs sampled)
scan 1024x1000 x 9.84 MB/s ±80.2% (8 runs sampled)
scan 1024x5000 x 57.11 MB/s ±593.0% (5 runs sampled)
```

After this change
```
read tx 1024x1000 x 70.77 MB/s ±37.0% (35 runs sampled)
read tx 1024x5000 x 85.97 MB/s ±36.4% (9 runs sampled)
scan 1024x1000 x 72.34 MB/s ±66.7% (36 runs sampled)
scan 1024x5000 x 95.74 MB/s ±52.9% (10 runs sampled)
```

Closes #625 