### PR TITLE
refactor: Use TextEncoder encodeInto if available

### DIFF
--- a/src/hash.test.ts
+++ b/src/hash.test.ts
@@ -1,6 +1,5 @@
 import {expect} from '@esm-bundle/chai';
 import {Hash, initHasher} from './hash';
-import * as utf8 from './utf8';
 
 setup(async () => {
   await initHasher();
@@ -11,7 +10,7 @@ test('test of', async () => {
   expect(h.isEmpty()).to.be.true;
   expect(h.toString()).to.equal('00000000000000000000000000000000');
 
-  const h2 = Hash.of(utf8.encode('abc'));
+  const h2 = Hash.of('abc');
   expect(h2.isEmpty()).to.be.false;
   expect(h2.toString()).to.equal('rmnjb8cjc5tblj21ed4qs821649eduie');
 

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -5,10 +5,11 @@ export const BYTE_LENGTH = 20;
 
 const charTable = '0123456789abcdefghijklmnopqrstuv';
 
-let mem = new Uint8Array(1024);
+let mem = new Uint8Array(1024 * 1024);
 const encoder = new TextEncoder();
 
 function ensureCapacity(s: string) {
+  // JS strings are UTF16 but we encode to UTF8.
   if (s.length * 2 > mem.length) {
     mem = new Uint8Array(mem.length * 2);
     ensureCapacity(s);


### PR DESCRIPTION
When computing the hash we need a Uint8Array. Instead of creating a new
one every time we can reuse the memory across calls.