### PR TITLE
fix: Allow reusing references in deepClone

### DIFF
--- a/src/has-own.ts
+++ b/src/has-own.ts
@@ -1,0 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const objectPrototypeHasOwnProperty = Object.prototype.hasOwnProperty;
+
+/**
+ * Object.hasOwn polyfill
+ */
+export const hasOwn: (object: any, key: PropertyKey) => boolean =
+  (Object as any).hasOwn ||
+  ((object, key) => objectPrototypeHasOwnProperty.call(object, key));

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -99,3 +99,13 @@ test('deepClone', () => {
     .to.throw(Error)
     .with.property('message', 'Invalid type: symbol');
 });
+
+test('deepClone - reuse references', () => {
+  const t = (v: ReadonlyJSONValue) => expect(deepClone(v)).to.deep.equal(v);
+  const arr: number[] = [0, 1];
+
+  t({a: arr, b: arr});
+  t(['a', [arr, arr]]);
+  t(['a', arr, {a: arr}]);
+  t(['a', arr, {a: [arr]}]);
+});


### PR DESCRIPTION
We used to incorrectly mark reused objects as cycles even though there
was no cycle in the JSON value.

Fixes #643