### PR TITLE
fix: update perf tests with ops/sec units to output median rather than mean

### DIFF
--- a/perf/perf.ts
+++ b/perf/perf.ts
@@ -94,7 +94,8 @@ async function runBenchmark(
     return formatAsBenchmarkJS({
       name: benchmark.name,
       value:
-        medianBytesPerSecond || `${((1 / medianTime) * 1000).toFixed(2)} ops/sec `,
+        medianBytesPerSecond ||
+        `${((1 / medianTime) * 1000).toFixed(2)} ops/sec `,
       variance: `${(variance * 100).toFixed(1)}%`,
       runs,
     });

--- a/perf/perf.ts
+++ b/perf/perf.ts
@@ -86,7 +86,7 @@ async function runBenchmark(
       .map(p => String(p * 100))
       .join('/')}%=${ptiles.map(p =>
       times[Math.floor(runs * p)].toFixed(2),
-    )}ms/op avg=${sum / runs}ms/op ${bytesPerSecond && `p50=bytesPerSecond `}(${runs} runs sampled)`;
+    )}ms/op ${bytesPerSecond}(${runs} runs sampled)`;
   } else {
     const variance =
       Math.max(medianTime - times[0], times[times.length - 1] - medianTime) /

--- a/perf/perf.ts
+++ b/perf/perf.ts
@@ -86,14 +86,14 @@ async function runBenchmark(
       .map(p => String(p * 100))
       .join('/')}%=${ptiles.map(p =>
       times[Math.floor(runs * p)].toFixed(2),
-    )}ms/op ${bytesPerSecond}(${runs} runs sampled)`;
+    )}ms/op avg=${sum / runs}ms/op ${bytesPerSecond && `p50=bytesPerSecond `}(${runs} runs sampled)`;
   } else {
     const variance =
       Math.max(medianTime - times[0], times[times.length - 1] - medianTime) /
       medianTime;
     return formatAsBenchmarkJS({
       name: benchmark.name,
-      value: bytesPerSecond || `${((runs / sum) * 1000).toFixed(2)} ops/sec `,
+      value: bytesPerSecond || `${(1.0 / medianTime * 1000).toFixed(2)} ops/sec `,
       variance: `${(variance * 100).toFixed(1)}%`,
       runs,
     });

--- a/perf/perf.ts
+++ b/perf/perf.ts
@@ -76,7 +76,7 @@ async function runBenchmark(
 
   const median = 0.5;
   const medianTime = times[Math.floor(runs * median)];
-  const bytesPerSecond = benchmark.byteSize
+  const medianBytesPerSecond = benchmark.byteSize
     ? `${formatToMBPerSecond(benchmark.byteSize, medianTime)} `
     : '';
 
@@ -86,7 +86,7 @@ async function runBenchmark(
       .map(p => String(p * 100))
       .join('/')}%=${ptiles.map(p =>
       times[Math.floor(runs * p)].toFixed(2),
-    )}ms/op ${bytesPerSecond}(${runs} runs sampled)`;
+    )}ms/op ${medianBytesPerSecond}(${runs} runs sampled)`;
   } else {
     const variance =
       Math.max(medianTime - times[0], times[times.length - 1] - medianTime) /
@@ -94,7 +94,7 @@ async function runBenchmark(
     return formatAsBenchmarkJS({
       name: benchmark.name,
       value:
-        bytesPerSecond || `${((1.0 / medianTime) * 1000).toFixed(2)} ops/sec `,
+        medianBytesPerSecond || `${((1 / medianTime) * 1000).toFixed(2)} ops/sec `,
       variance: `${(variance * 100).toFixed(1)}%`,
       runs,
     });

--- a/perf/perf.ts
+++ b/perf/perf.ts
@@ -93,7 +93,8 @@ async function runBenchmark(
       medianTime;
     return formatAsBenchmarkJS({
       name: benchmark.name,
-      value: bytesPerSecond || `${(1.0 / medianTime * 1000).toFixed(2)} ops/sec `,
+      value:
+        bytesPerSecond || `${((1.0 / medianTime) * 1000).toFixed(2)} ops/sec `,
       variance: `${(variance * 100).toFixed(1)}%`,
       runs,
     });


### PR DESCRIPTION
This makes them more consistent with tests with MBs/sec output (which already use median), and should also make them more stable as results can't be greatly skewed by a small number of outliers.  