### PR TITLE
feat: Create new perf dashboard where all measures are median ms (and thus smaller is better)

### DIFF
--- a/.github/workflows/perf-v2.js.yml
+++ b/.github/workflows/perf-v2.js.yml
@@ -3,6 +3,8 @@ name: Perf Test V2
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   benchmark:
@@ -24,13 +26,6 @@ jobs:
       - name: Run benchmark
         run: node perf/runner.js --format=json | tee perf-v2-output.json
 
-      # Download previous benchmark result from cache (if exists)
-      - name: Download previous benchmark data
-        uses: actions/cache@v1
-        with:
-          path: ./cache
-          key: ${{ runner.os }}-benchmark
-
       # Run `github-action-benchmark` action
       - name: Store benchmark result
         uses: rhysd/github-action-benchmark@v1
@@ -39,13 +34,11 @@ jobs:
           tool: 'customSmallerIsBetter'
           # Where the output from the benchmark tool is stored
           output-file-path: perf-v2-output.json
-          # Where the previous data file is stored
-          # external-data-json-path: ./cache/benchmark-data.json
           # Workflow will fail when an alert happens
           fail-on-alert: true
           github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           benchmark-data-dir-path: perf-v2
-          auto-push: true
+          auto-push: false
           alert-threshold: '130%'
           comment-on-alert: true
 #       - name: Deploy perf data

--- a/.github/workflows/perf-v2.js.yml
+++ b/.github/workflows/perf-v2.js.yml
@@ -44,7 +44,7 @@ jobs:
           # Workflow will fail when an alert happens
           fail-on-alert: true
           github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
-          benchmark-data-dir-path: perf
+          benchmark-data-dir-path: perf-v2
           auto-push: true
           alert-threshold: '130%'
           comment-on-alert: true

--- a/.github/workflows/perf-v2.js.yml
+++ b/.github/workflows/perf-v2.js.yml
@@ -1,0 +1,52 @@
+name: Perf Test V2
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  benchmark:
+    name: Performance regression check
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+
+      # Clear out potential user data dirs left over from previous failures.
+      - run: rm -rf /tmp/replicache-playwright-*
+      - run: npm ci
+      - run: npx playwright install-deps
+      - run: npm run build --if-present
+
+      # Run benchmark and stores the output to a file
+      - name: Run benchmark
+        run: node perf/runner.js --format=json | tee perf-v2-output.json
+
+      # Download previous benchmark result from cache (if exists)
+      - name: Download previous benchmark data
+        uses: actions/cache@v1
+        with:
+          path: ./cache
+          key: ${{ runner.os }}-benchmark
+
+      # Run `github-action-benchmark` action
+      - name: Store benchmark result
+        uses: rhysd/github-action-benchmark@v1
+        with:
+          # What benchmark tool the output.json came from
+          tool: 'customSmallerIsBetter'
+          # Where the output from the benchmark tool is stored
+          output-file-path: perf-v2-output.json
+          # Where the previous data file is stored
+          # external-data-json-path: ./cache/benchmark-data.json
+          # Workflow will fail when an alert happens
+          fail-on-alert: true
+          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          benchmark-data-dir-path: perf
+          auto-push: true
+          alert-threshold: '130%'
+          comment-on-alert: true
+#       - name: Deploy perf data
+#         run: curl -X POST ${{ secrets.VERCEL_DEPLOY_PERF_DATA_URL }}

--- a/.github/workflows/perf-v2.js.yml
+++ b/.github/workflows/perf-v2.js.yml
@@ -3,8 +3,6 @@ name: Perf Test V2
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 jobs:
   benchmark:
@@ -38,7 +36,7 @@ jobs:
           fail-on-alert: true
           github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           benchmark-data-dir-path: perf-v2
-          auto-push: false
+          auto-push: true
           alert-threshold: '130%'
           comment-on-alert: true
 #       - name: Deploy perf data

--- a/.github/workflows/perf.js.yml
+++ b/.github/workflows/perf.js.yml
@@ -3,8 +3,6 @@ name: Perf Test
 on:
   push:
     branches: [main]
-  pull_request:
-      branches: [main]
 
 jobs:
   benchmark:
@@ -38,7 +36,7 @@ jobs:
           fail-on-alert: true
           github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           benchmark-data-dir-path: perf
-          auto-push: false
+          auto-push: true
           alert-threshold: '130%'
           comment-on-alert: true
 #       - name: Deploy perf data

--- a/.github/workflows/perf.js.yml
+++ b/.github/workflows/perf.js.yml
@@ -3,6 +3,8 @@ name: Perf Test
 on:
   push:
     branches: [main]
+  pull_request:
+      branches: [main]
 
 jobs:
   benchmark:
@@ -24,13 +26,6 @@ jobs:
       - name: Run benchmark
         run: node perf/runner.js | tee output.txt
 
-      # Download previous benchmark result from cache (if exists)
-      - name: Download previous benchmark data
-        uses: actions/cache@v1
-        with:
-          path: ./cache
-          key: ${{ runner.os }}-benchmark
-
       # Run `github-action-benchmark` action
       - name: Store benchmark result
         uses: rhysd/github-action-benchmark@v1
@@ -39,13 +34,11 @@ jobs:
           tool: 'benchmarkjs'
           # Where the output from the benchmark tool is stored
           output-file-path: output.txt
-          # Where the previous data file is stored
-          # external-data-json-path: ./cache/benchmark-data.json
           # Workflow will fail when an alert happens
           fail-on-alert: true
           github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           benchmark-data-dir-path: perf
-          auto-push: true
+          auto-push: false
           alert-threshold: '130%'
           comment-on-alert: true
 #       - name: Deploy perf data

--- a/perf/format.ts
+++ b/perf/format.ts
@@ -19,11 +19,13 @@ export function formatAsBenchmarkJS(results: BenchmarkResult): string {
   const value = results.byteSize
     ? formatToMBPerSecond(results.byteSize, medianMs)
     : `${((1 / medianMs) * 1000).toFixed(2)} ops/sec`;
-  return `${name} x ${value}${formatVariance(stats.variance)} (${runs.length} runs sampled)`;
+  return `${name} x ${value}${formatVariance(stats.variance)} (${
+    runs.length
+  } runs sampled)`;
 }
 
 export function formatVariance(variance: number): string {
-  return `±${variance.toFixed(1)}%`
+  return `±${variance.toFixed(1)}%`;
 }
 
 function formatToMBPerSecond(size: number, timeMS: number): string {

--- a/perf/format.ts
+++ b/perf/format.ts
@@ -19,8 +19,11 @@ export function formatAsBenchmarkJS(results: BenchmarkResult): string {
   const value = results.byteSize
     ? formatToMBPerSecond(results.byteSize, medianMs)
     : `${((1 / medianMs) * 1000).toFixed(2)} ops/sec`;
-  const variance = results.runTimesStatistics.variance.toFixed(1);
-  return `${name} x ${value}±${variance}% (${runs.length} runs sampled)`;
+  return `${name} x ${value}${formatVariance(stats.variance)} (${runs.length} runs sampled)`;
+}
+
+export function formatVariance(variance: number): string {
+  return `±${variance.toFixed(1)}%`
 }
 
 function formatToMBPerSecond(size: number, timeMS: number): string {

--- a/perf/format.ts
+++ b/perf/format.ts
@@ -1,0 +1,29 @@
+import type {BenchmarkResult} from './perf';
+
+export function formatAsReplicache(results: BenchmarkResult): string {
+  const {name, runTimesStatistics: stats, sortedRunTimesMs: runs} = results;
+  const f = (n: number) => n.toFixed(2);
+  return `${name} 50/75/90/95%=${f(stats.medianMs)}/${f(stats.p75Ms)}/${f(
+    stats.p90Ms,
+  )}/${f(stats.p95Ms)} ms avg=${f(stats.meanMs)} ms (${
+    runs.length
+  } runs sampled)`;
+}
+
+export function formatAsBenchmarkJS(results: BenchmarkResult): string {
+  const {name, runTimesStatistics: stats, sortedRunTimesMs: runs} = results;
+  // Example:
+  //   fib(20) x 11,465 ops/sec ±1.12% (91 runs sampled)
+  //   createObjectBuffer with 200 comments x 81.61 ops/sec ±1.70% (69 runs sampled)
+  const {medianMs} = stats;
+  const value = results.byteSize
+    ? formatToMBPerSecond(results.byteSize, medianMs)
+    : `${((1 / medianMs) * 1000).toFixed(2)} ops/sec`;
+  const variance = results.runTimesStatistics.variance.toFixed(1);
+  return `${name} x ${value}±${variance}% (${runs.length} runs sampled)`;
+}
+
+function formatToMBPerSecond(size: number, timeMS: number): string {
+  const bytes = (size / timeMS) * 1000;
+  return (bytes / 2 ** 20).toFixed(2) + ' MB/s';
+}

--- a/perf/format.ts
+++ b/perf/format.ts
@@ -19,7 +19,7 @@ export function formatAsBenchmarkJS(results: BenchmarkResult): string {
   const value = results.byteSize
     ? formatToMBPerSecond(results.byteSize, medianMs)
     : `${((1 / medianMs) * 1000).toFixed(2)} ops/sec`;
-  return `${name} x ${value}${formatVariance(stats.variance)} (${
+  return `${name} x ${value} ${formatVariance(stats.variance)} (${
     runs.length
   } runs sampled)`;
 }

--- a/perf/perf.ts
+++ b/perf/perf.ts
@@ -3,7 +3,11 @@ import {benchmarkIDBRead, benchmarkIDBWrite} from './idb';
 import {benchmarks as lockBenchmarks} from './lock';
 import {benchmarks as hashBenchmarks} from './hash';
 import {benchmarks as storageBenchmarks} from './storage';
-import {formatAsBenchmarkJS, formatAsReplicache, formatVariance} from './format';
+import {
+  formatAsBenchmarkJS,
+  formatAsReplicache,
+  formatVariance,
+} from './format';
 import type {RandomDataType} from './data';
 
 export type Benchmark = {

--- a/perf/perf.ts
+++ b/perf/perf.ts
@@ -175,7 +175,7 @@ export async function runBenchmarkByNameAndGroup(
       return undefined;
     }
     return {
-      jsonEntry: createGithubActionBenchmarkJsonEntry(result),
+      jsonEntry: createGithubActionBenchmarkJSONEntry(result),
       text:
         format === 'replicache'
           ? formatAsReplicache(result)
@@ -220,7 +220,7 @@ type Entry = {
   extra?: string;
 };
 
-function createGithubActionBenchmarkJsonEntry(result: BenchmarkResult): Entry {
+function createGithubActionBenchmarkJSONEntry(result: BenchmarkResult): Entry {
   return {
     name: result.name,
     unit: 'median ms',

--- a/perf/perf.ts
+++ b/perf/perf.ts
@@ -3,7 +3,7 @@ import {benchmarkIDBRead, benchmarkIDBWrite} from './idb';
 import {benchmarks as lockBenchmarks} from './lock';
 import {benchmarks as hashBenchmarks} from './hash';
 import {benchmarks as storageBenchmarks} from './storage';
-import {formatAsBenchmarkJS, formatAsReplicache} from './format';
+import {formatAsBenchmarkJS, formatAsReplicache, formatVariance} from './format';
 import type {RandomDataType} from './data';
 
 export type Benchmark = {
@@ -221,7 +221,7 @@ function createGithubActionBenchmarkJsonEntry(result: BenchmarkResult): Entry {
     name: result.name,
     unit: 'median ms',
     value: result.runTimesStatistics.medianMs,
-    range: result.runTimesStatistics.variance.toFixed(2).toString(),
+    range: formatVariance(result.runTimesStatistics.variance),
     extra: formatAsReplicache(result),
   };
 }

--- a/perf/runner.js
+++ b/perf/runner.js
@@ -235,11 +235,11 @@ async function runInBrowser(browser, page, options) {
     if (result) {
       if (result.error) {
         process.stderr.write(result.error + '\n');
-        return;
-      }
-      jsonEntries.push(result.jsonEntry);
-      if (options.format !== 'json') {
-        logLine(result.text);
+      } else {
+        jsonEntries.push(result.jsonEntry);
+        if (options.format !== 'json') {
+          logLine(result.text);
+        }
       }
     }
     await page.reload();

--- a/perf/runner.js
+++ b/perf/runner.js
@@ -147,7 +147,7 @@ async function main() {
   let first = true;
   for (const browser of options.browsers) {
     if (!first) {
-      logLine('');
+      logLine('', options);
     }
     first = false;
     const context = await playwright[browser].launchPersistentContext(
@@ -173,8 +173,8 @@ async function main() {
     }
   }
 
-  if (!options.list && options.format !== 'json') {
-    logLine('Done!');
+  if (!options.list) {
+    logLine('Done!', options);
   }
   await fs.rm(userDataDir, {recursive: true});
   await server.stop();
@@ -220,11 +220,10 @@ async function runInBrowser(browser, page, options) {
   }
 
   const jsonEntries = [];
-  if (options.format !== 'json') {
-    logLine(
-      `Running ${benchmarks.length} benchmarks on ${browserName(browser)}...`,
-    );
-  }
+  logLine(
+    `Running ${benchmarks.length} benchmarks on ${browserName(browser)}...`,
+    options,
+  );
   for (const benchmark of benchmarks) {
     const result = await page.evaluate(
       ({name, group, format}) =>
@@ -237,9 +236,7 @@ async function runInBrowser(browser, page, options) {
         process.stderr.write(result.error + '\n');
       } else {
         jsonEntries.push(result.jsonEntry);
-        if (options.format !== 'json') {
-          logLine(result.text);
-        }
+        logLine(result.text, options);
       }
     }
     await page.reload();
@@ -256,8 +253,10 @@ main().catch(err => {
 });
 
 /** @param {string} s */
-function logLine(s) {
-  process.stdout.write(s + '\n');
+function logLine(s, options) {
+  if (options.format !== 'json') {
+    process.stdout.write(s + '\n');
+  }
 }
 
 /** @param {number} n */


### PR DESCRIPTION
This does not get rid of the existing perf dashboard at https://rocicorp.github.io/replicache/perf/ and the alerts based on that, but rather adds a new one at https://rocicorp.github.io/replicache/perf-v2/ with corresponding alerts.  This ensures we have continuity of our benchmark data.  Once sufficient history is built up on the new dashbaord, we can clean up the old one (which will also allow some simplification/cleanup of the related code).  In the meantime we will get double alerts.

This utilizes the `customSmallerIsBetter` tool option of github-action-benchmark (see https://github.com/benchmark-action/github-action-benchmark#examples).

We have been using the `benchmarkjs` tool option, and emulating the output of that library https://github.com/bestiejs/benchmark.js, though we are not actually using the library.  Rather we are using our own custom benchmark implementation.

Example JSON output:

```
Gregorys-MacBook-Pro:replicache greg$ node perf/runner.js --format=json --run "scan"
[
  {
    "name": "scan 1024x1000",
    "unit": "median ms",
    "value": 52.5,
    "range": "8.70",
    "extra": "scan 1024x1000 50/75/90/95%=52.50/54.40/59.30/59.30 ms avg=51.34 ms (10 runs sampled)"
  },
  {
    "name": "scan 1024x5000",
    "unit": "median ms",
    "value": 236.5,
    "range": "27.50",
    "extra": "scan 1024x5000 50/75/90/95%=236.50/246.40/264.00/264.00 ms avg=242.74 ms (5 runs sampled)"
  },
  {
    "name": "[MemStore] scan 1024x1000",
    "unit": "median ms",
    "value": 1.7000000178813934,
    "range": "4.10",
    "extra": "[MemStore] scan 1024x1000 50/75/90/95%=1.70/2.00/2.20/2.30 ms avg=1.86 ms (269 runs sampled)"
  },
  {
    "name": "[MemStore] scan 1024x5000",
    "unit": "median ms",
    "value": 10.300000011920929,
    "range": "7.10",
    "extra": "[MemStore] scan 1024x5000 50/75/90/95%=10.30/10.60/11.20/11.30 ms avg=10.53 ms (48 runs sampled)"
  }
]
```
