### PR TITLE
chore: Fix index perf tests

### DIFF
--- a/perf/data.ts
+++ b/perf/data.ts
@@ -53,7 +53,8 @@ export function randomASCIIString(len: number): string {
 function randomStringInternal(len: number, max: number): string {
   let s = '';
   for (let i = 0; i < len; i++) {
-    s += String.fromCharCode((Math.random() * max) | 0);
+    // We use random strings for index map keys and those cannot contain \0.
+    s += String.fromCharCode(((Math.random() * (max - 1)) | 0) + 1);
   }
   return s;
 }

--- a/perf/replicache.ts
+++ b/perf/replicache.ts
@@ -35,7 +35,7 @@ export function benchmarkPopulate(opts: {
       for (let i = 0; i < (opts.indexes || 0); i++) {
         await rep.createIndex({
           name: `idx${i}`,
-          jsonPointer: '',
+          jsonPointer: '/ascii',
         });
       }
       const randomValues = jsonArrayTestData(opts.numKeys, valSize);
@@ -138,7 +138,7 @@ export function benchmarkCreateIndex(opts: {
       bencher.reset();
       await rep.createIndex({
         name: `idx`,
-        jsonPointer: '',
+        jsonPointer: '/ascii',
       });
       bencher.stop();
       await rep.close();


### PR DESCRIPTION
An index value needs to be a string and that string cannot contain \0
characters.