### PR TITLE
fix: Correct how benchmarkWriteSubRead sets up its subscriptions and picks keys to invalidate

### DIFF
--- a/perf/perf.ts
+++ b/perf/perf.ts
@@ -60,7 +60,12 @@ async function runBenchmark(
     await benchmark.setup();
   }
 
-  for (let i = 0; i < minRuns /*|| sum < minTime*/; i++) {
+  const totalTimeStart = performance.now();
+  for (let i = 0; (i < minRuns || sum < minTime) && i < maxRuns; i++) {
+    if (i >= minRuns && performance.now() - totalTimeStart > maxTotalTime) {
+      break;
+    }
+
     let t0 = 0;
     let t1 = 0;
     const reset = () => {
@@ -69,7 +74,6 @@ async function runBenchmark(
     };
     const stop = () => {
       t1 = performance.now();
-      performance.mark('end-mark-' + i);
       performance.measure(benchmark.name, 'mark-' + i);
     };
     reset();

--- a/perf/perf.ts
+++ b/perf/perf.ts
@@ -60,12 +60,7 @@ async function runBenchmark(
     await benchmark.setup();
   }
 
-  const totalTimeStart = performance.now();
-  for (let i = 0; (i < minRuns || sum < minTime) && i < maxRuns; i++) {
-    if (i >= minRuns && performance.now() - totalTimeStart > maxTotalTime) {
-      break;
-    }
-
+  for (let i = 0; i < minRuns /*|| sum < minTime*/; i++) {
     let t0 = 0;
     let t1 = 0;
     const reset = () => {

--- a/perf/perf.ts
+++ b/perf/perf.ts
@@ -69,6 +69,7 @@ async function runBenchmark(
     };
     const stop = () => {
       t1 = performance.now();
+      performance.mark('end-mark-' + i);
       performance.measure(benchmark.name, 'mark-' + i);
     };
     reset();

--- a/perf/replicache.ts
+++ b/perf/replicache.ts
@@ -195,8 +195,8 @@ export function benchmarkWriteSubRead(opts: {
   const numKeys = keysPerSub * numSubsTotal;
   const cacheSizeMB = (numKeys * valueSize) / 1024 / 1024;
   const kbReadPerSub = (keysWatchedPerSub * valueSize) / 1024;
-  const key = (k: number) => `key${k}`;
-  //const key = (k: number) => `key${k.toString().padStart(10, '0')}`;
+  //const key = (k: number) => `key${k}`;
+  const key = (k: number) => `key${k.toString().padStart(10, '0')}`;
   const indexFromKey = (k: string) => parseInt(k.substring('key'.length));
   const createRandomValueForKey = (key: string) => {
     return {


### PR DESCRIPTION
benchmarkWriteSubRead uses keys like:
key0, key1, key2, key3, key4, key5, key6, key7, key8, key9, key10, key11, key12, etc

the logic it uses for setting up its subscription ranges assumed the keys were sorted as above, but they are actually sorted lexicographically like:
key0, key1, key10, key11, key12, key2, key3, key4, key5, key6, key7, key8, key9, 

**Existing**
Based on the above assumption about key ordering it used the following logic for subscriptions and invalidations

_Subscriptions_
scan start `k${i * keysPerSub }` limit keysWatchedPerSub, for 0 <= i < numSubsTotal 

_Invalidations_
`k${i * keysPerSub}` for 0 <= i < numDirtySubs

**New**
This change updates the logic for setting up subscriptions and picking keys to invalidate to use a sorted array of keys.

The new logic is:

_Subscriptions_
scan start sortedKeys[i * keysPerSub ] limit keysWatchedPerSub, for 0 <= i < numSubsTotal 

_Invalidations_
sortedKeys[i * keysPerSub] for 0 <= i < numDirtySubs


These changes make the test performance more consistent as the data size increase.  In debugging i discovered the tests runtime mainly varies based on the sort of the keys invalidated.  The higher the invalidated keys sort order, the higher the latency.   With the old logic, the invalidated keys sort order varied a good deal based on the size of the test.   With the new code they are consistently low in the sort order (though they do increase some as numKeysPerSub increases).  

We should update these tests to invalidate a random numDirtySubs subs (rather than the first numDirtySubs in sort order) and fix scans performance.  

### Perf On my M1 Max

**Existing**
[MemStore] writeSubRead 2MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=5.00/5.80/6.00/6.00 ms avg=6.34 ms (7 runs sampled)
[MemStore] writeSubRead 3MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=6.20/6.40/7.70/7.70 ms avg=7.94 ms (7 runs sampled)
[MemStore] writeSubRead 4MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=6.20/6.30/8.00/8.00 ms avg=8.13 ms (7 runs sampled)
[MemStore] writeSubRead 5MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=5.90/6.60/8.10/8.10 ms avg=7.90 ms (7 runs sampled)
[MemStore] writeSubRead 6MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=6.50/6.60/9.10/9.10 ms avg=8.56 ms (7 runs sampled)
[MemStore] writeSubRead 7MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=5.50/5.60/7.20/7.20 ms avg=6.94 ms (7 runs sampled)
[MemStore] writeSubRead 8MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=5.60/5.70/7.20/7.20 ms avg=7.04 ms (7 runs sampled)
[MemStore] writeSubRead 9MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=5.10/5.50/7.20/7.20 ms avg=6.77 ms (7 runs sampled)
[MemStore] writeSubRead 10MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=5.60/5.80/7.10/7.10 ms avg=7.19 ms (7 runs sampled)
[MemStore] writeSubRead 11MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=6.30/6.70/8.70/8.70 ms avg=8.29 ms (7 runs sampled)
[MemStore] writeSubRead 12MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=7.10/7.40/9.50/9.50 ms avg=9.23 ms (7 runs sampled)
[MemStore] writeSubRead 13MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=4.40/4.70/5.50/5.50 ms avg=5.49 ms (7 runs sampled)
[MemStore] writeSubRead 14MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=5.10/5.50/6.50/6.50 ms avg=6.47 ms (7 runs sampled)
[MemStore] writeSubRead 15MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=5.00/5.80/6.40/6.40 ms avg=6.54 ms (7 runs sampled)
[MemStore] writeSubRead 16MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=4.90/5.90/6.50/6.50 ms avg=6.61 ms (7 runs sampled)
[MemStore] writeSubRead 17MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=5.90/6.30/7.80/7.80 ms avg=7.50 ms (7 runs sampled)
[MemStore] writeSubRead 18MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=5.90/6.40/7.20/7.20 ms avg=7.33 ms (7 runs sampled)
[MemStore] writeSubRead 19MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=6.00/6.80/8.00/8.00 ms avg=7.97 ms (7 runs sampled)
[MemStore] writeSubRead 20MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=6.10/8.40/8.40/8.40 ms avg=8.13 ms (7 runs sampled)


**New**
[MemStore] writeSubRead 2MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.60/1.80/2.10/2.10 ms avg=1.97 ms (7 runs sampled)
[MemStore] writeSubRead 3MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.50/1.80/2.10/2.10 ms avg=1.89 ms (7 runs sampled)
[MemStore] writeSubRead 4MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.30/1.50/2.10/2.10 ms avg=1.76 ms (7 runs sampled)
[MemStore] writeSubRead 5MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.50/1.70/2.00/2.00 ms avg=1.90 ms (7 runs sampled)
[MemStore] writeSubRead 6MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.40/1.60/3.70/3.70 ms avg=2.14 ms (7 runs sampled)
[MemStore] writeSubRead 7MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.40/1.50/2.10/2.10 ms avg=1.81 ms (7 runs sampled)
[MemStore] writeSubRead 8MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.50/1.60/2.10/2.10 ms avg=1.86 ms (7 runs sampled)
[MemStore] writeSubRead 9MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.50/1.50/2.00/2.00 ms avg=1.87 ms (7 runs sampled)
[MemStore] writeSubRead 10MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.70/1.80/2.00/2.00 ms avg=1.96 ms (7 runs sampled)
[MemStore] writeSubRead 11MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.40/1.50/2.20/2.20 ms avg=1.90 ms (7 runs sampled)
[MemStore] writeSubRead 12MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.40/1.50/2.10/2.10 ms avg=1.81 ms (7 runs sampled)
[MemStore] writeSubRead 13MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.50/1.70/2.20/2.20 ms avg=1.94 ms (7 runs sampled)
[MemStore] writeSubRead 14MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.50/1.60/2.00/2.00 ms avg=1.86 ms (7 runs sampled)
[MemStore] writeSubRead 15MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.40/1.70/2.10/2.10 ms avg=1.86 ms (7 runs sampled)
[MemStore] writeSubRead 16MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.40/1.60/2.00/2.00 ms avg=1.86 ms (7 runs sampled)
[MemStore] writeSubRead 17MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.50/1.50/2.20/2.20 ms avg=1.90 ms (7 runs sampled)
[MemStore] writeSubRead 18MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.50/1.70/2.20/2.20 ms avg=1.96 ms (7 runs sampled)
[MemStore] writeSubRead 19MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.60/1.80/2.10/2.10 ms avg=2.04 ms (7 runs sampled)
[MemStore] writeSubRead 20MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.50/2.70/4.00/4.00 ms avg=2.39 ms (7 runs sampled)