### PR TITLE
refactor: Make scan lazy

### DIFF
--- a/src/db/mod.ts
+++ b/src/db/mod.ts
@@ -19,7 +19,6 @@ export {
   newSnapshot,
 } from './commit';
 export {getRoot} from './root';
-export {ScanResultType} from './scan';
 export {decodeIndexKey} from './index';
 export type {LocalMeta, IndexRecord} from './commit';
 export type {ScanOptions} from './scan';

--- a/src/db/scan.test.ts
+++ b/src/db/scan.test.ts
@@ -1,5 +1,5 @@
 import {expect} from '@esm-bundle/chai';
-import {convert, scan, ScanItem, ScanOptions, ScanResultType} from './scan';
+import {convert, scan, ScanItem, ScanOptions} from './scan';
 import * as kv from '../kv/mod';
 import * as dag from '../dag/mod';
 import {encodeIndexKey} from './index';
@@ -23,11 +23,8 @@ test('scan', async () => {
       await map.put('baz', 'baz');
       const optsInternal = convert(opts);
       const actual = [];
-      for await (const sr of scan(map, optsInternal)) {
-        if (sr.type === ScanResultType.Error) {
-          throw sr.error;
-        }
-        actual.push(sr.item.key);
+      for await (const item of scan(map, optsInternal)) {
+        actual.push(item.primaryKey);
       }
       const expected2 = expected;
       expect(actual).to.deep.equal(expected2, testDesc);
@@ -344,11 +341,8 @@ test('exclusive regular map', async () => {
       const convertedOpts = convert(opts);
       const got = [];
 
-      for await (const sr of scan(map, convertedOpts)) {
-        if (sr.type === ScanResultType.Error) {
-          throw sr.error;
-        }
-        got.push(sr.item.key);
+      for await (const item of scan(map, convertedOpts)) {
+        got.push(item.primaryKey);
       }
       expect(got).to.deep.equal(expected, testDesc);
     });
@@ -387,11 +381,8 @@ test('exclusive index map', async () => {
         indexName: 'index',
       };
       const got = [];
-      for await (const sr of scan(map, convert(opts))) {
-        if (sr.type === ScanResultType.Error) {
-          throw sr.error;
-        }
-        got.push([sr.item.secondaryKey, sr.item.key]);
+      for await (const item of scan(map, convert(opts))) {
+        got.push([item.secondaryKey, item.primaryKey]);
       }
       expect(got).to.deep.equal(expected, testDesc);
     });
@@ -614,11 +605,8 @@ test('scan index startKey', async () => {
       const testDesc = `opts: ${opts}, expected: ${expected}`;
 
       const actual: ScanItem[] = [];
-      for await (const sr of scan(map, convert(opts))) {
-        if (sr.type === ScanResultType.Error) {
-          throw sr.error;
-        }
-        actual.push(sr.item);
+      for await (const item of scan(map, convert(opts))) {
+        actual.push(item);
       }
 
       expect(actual).to.deep.equal(expected, testDesc);
@@ -641,12 +629,12 @@ test('scan index startKey', async () => {
     },
     [
       {
-        key: 'b',
+        primaryKey: 'b',
         secondaryKey: '',
         val: '2',
       },
       {
-        key: 'c',
+        primaryKey: 'c',
         secondaryKey: '',
         val: '3',
       },
@@ -669,7 +657,7 @@ test('scan index startKey', async () => {
     },
     [
       {
-        key: 'c',
+        primaryKey: 'c',
         secondaryKey: '',
         val: '3',
       },
@@ -692,12 +680,12 @@ test('scan index startKey', async () => {
     },
     [
       {
-        key: 'bp',
+        primaryKey: 'bp',
         secondaryKey: 'bs',
         val: '2',
       },
       {
-        key: 'cp',
+        primaryKey: 'cp',
         secondaryKey: 'cs',
         val: '3',
       },
@@ -720,7 +708,7 @@ test('scan index startKey', async () => {
     },
     [
       {
-        key: 'cp',
+        primaryKey: 'cp',
         secondaryKey: 'cs',
         val: '3',
       },
@@ -744,12 +732,12 @@ test('scan index startKey', async () => {
     },
     [
       {
-        key: 'bp2',
+        primaryKey: 'bp2',
         secondaryKey: 'bs',
         val: '3',
       },
       {
-        key: 'cp',
+        primaryKey: 'cp',
         secondaryKey: 'cs',
         val: '4',
       },
@@ -773,7 +761,7 @@ test('scan index startKey', async () => {
     },
     [
       {
-        key: 'cp',
+        primaryKey: 'cp',
         secondaryKey: 'cs',
         val: '4',
       },

--- a/src/scan-item.ts
+++ b/src/scan-item.ts
@@ -1,7 +1,0 @@
-import type {JSONValue} from './json';
-
-export type ScanItem = {
-  primaryKey: string;
-  secondaryKey: string | null;
-  value: JSONValue;
-};

--- a/src/sync/pull.test.ts
+++ b/src/sync/pull.test.ts
@@ -391,15 +391,15 @@ test('begin try pull', async () => {
         );
         let got = false;
 
-        await read.scan(
-          {
-            prefix: '',
-            indexName: '2',
-          },
-          () => {
-            got = true;
-          },
-        );
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        for await (const _ of read.scan({
+          prefix: '',
+          indexName: '2',
+        })) {
+          got = true;
+          break;
+        }
+
         expect(got, c.name).to.be.true;
       });
     }
@@ -492,16 +492,14 @@ test('begin try pull', async () => {
               db.whenceHead(SYNC_HEAD_NAME),
               dagRead,
             );
-            await read.scan(
-              {
-                prefix: '',
-                indexName: '2',
-              },
-              () => {
-                expect(false).to.be.true;
-                // assert!(false, "{}: expected no values, got {:?}", c.name, sr);
-              },
-            );
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            for await (const _ of read.scan({
+              prefix: '',
+              indexName: '2',
+            })) {
+              expect(false).to.be.true;
+              // assert!(false, "{}: expected no values, got {:?}", c.name, sr);
+            }
           });
 
           assertObject(result);

--- a/src/sync/pull.test.ts
+++ b/src/sync/pull.test.ts
@@ -498,7 +498,6 @@ test('begin try pull', async () => {
               indexName: '2',
             })) {
               expect(false).to.be.true;
-              // assert!(false, "{}: expected no values, got {:?}", c.name, sr);
             }
           });
 

--- a/src/sync/push.test.ts
+++ b/src/sync/push.test.ts
@@ -204,9 +204,11 @@ test('try push', async () => {
         const read = await fromWhence(whenceHead(DEFAULT_HEAD_NAME), dagRead);
         let got = false;
 
-        await read.scan({prefix: '', indexName: '2'}, () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        for await (const _ of read.scan({prefix: '', indexName: '2'})) {
           got = true;
-        });
+          break;
+        }
         expect(got).to.be.true;
       });
     }


### PR DESCRIPTION
We had async iterators all the way up to ScanIterator which accumulated
all the items in memory.

Now we have the async iterator all the way...