### PR TITLE
refactor: Only convert scan item once (at most)

### DIFF
--- a/src/btree/mod.ts
+++ b/src/btree/mod.ts
@@ -1,4 +1,4 @@
 export {BTreeRead} from './read';
 export {BTreeWrite} from './write';
-
 export {changedKeys} from './changed-keys';
+export type {Entry} from './node';

--- a/src/sync/pull.test.ts
+++ b/src/sync/pull.test.ts
@@ -392,10 +392,13 @@ test('begin try pull', async () => {
         let got = false;
 
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        for await (const _ of read.scan({
-          prefix: '',
-          indexName: '2',
-        })) {
+        for await (const _ of read.scan(
+          {
+            prefix: '',
+            indexName: '2',
+          },
+          e => e,
+        )) {
           got = true;
           break;
         }
@@ -493,10 +496,13 @@ test('begin try pull', async () => {
               dagRead,
             );
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            for await (const _ of read.scan({
-              prefix: '',
-              indexName: '2',
-            })) {
+            for await (const _ of read.scan(
+              {
+                prefix: '',
+                indexName: '2',
+              },
+              e => e,
+            )) {
               expect(false).to.be.true;
             }
           });

--- a/src/sync/push.test.ts
+++ b/src/sync/push.test.ts
@@ -205,7 +205,7 @@ test('try push', async () => {
         let got = false;
 
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        for await (const _ of read.scan({prefix: '', indexName: '2'})) {
+        for await (const _ of read.scan({prefix: '', indexName: '2'}, e => e)) {
           got = true;
           break;
         }


### PR DESCRIPTION
We used to generate a ScanItem from an Entry and then extract the info
we needed from the ScanItem. Now we just extract the info we need from
the Entry, which in non index scans requires no work.