### PR TITLE
perf: Optimize subscriptions for scans with a limit

### DIFF
--- a/perf/replicache.ts
+++ b/perf/replicache.ts
@@ -351,7 +351,7 @@ export function benchmarks(): Benchmark[] {
     benchmarkWriteSubRead({
       valueSize: 1024,
       numSubsTotal: 128,
-      keysPerSub: 128,
+      keysPerSub: 800,
       keysWatchedPerSub: 16,
       numSubsDirty: 5,
       useMemstore,
@@ -360,7 +360,7 @@ export function benchmarks(): Benchmark[] {
     benchmarkWriteSubRead({
       valueSize: 1024,
       numSubsTotal: 128,
-      keysPerSub: 128,
+      keysPerSub: 800,
       keysWatchedPerSub: 16,
       numSubsDirty: 5,
       useMemstore,

--- a/perf/replicache.ts
+++ b/perf/replicache.ts
@@ -160,9 +160,16 @@ export function benchmarkWriteSubRead(opts: {
   keysWatchedPerSub: number;
   numSubsDirty: number;
   useMemstore: boolean;
+  randomInvalidates?: boolean;
 }): Benchmark {
-  const {valueSize, numSubsTotal, keysPerSub, keysWatchedPerSub, numSubsDirty} =
-    opts;
+  const {
+    valueSize,
+    numSubsTotal,
+    keysPerSub,
+    keysWatchedPerSub,
+    numSubsDirty,
+    randomInvalidates,
+  } = opts;
 
   const numKeys = keysPerSub * numSubsTotal;
   const cacheSizeMB = (numKeys * valueSize) / 1024 / 1024;
@@ -172,7 +179,7 @@ export function benchmarkWriteSubRead(opts: {
   return {
     name: `${
       opts.useMemstore ? '[MemStore] ' : ''
-    }writeSubRead ${cacheSizeMB}MB total, ${numSubsTotal} subs total, ${numSubsDirty} subs dirty, ${kbReadPerSub}kb read per sub`,
+    }writeSubRead randomInvalidates ${randomInvalidates} ${cacheSizeMB}MB total, ${numSubsTotal} subs total, ${numSubsDirty} subs dirty, ${kbReadPerSub}kb read per sub`,
     group: 'replicache',
     async run(bencher: Bencher) {
       const keys = Array.from({length: numKeys}, (_, index) => makeKey(index));
@@ -235,11 +242,21 @@ export function benchmarkWriteSubRead(opts: {
 
       // Build our random changes ahead of time, outside the timed window.
       // invalidate numSubsDirty different subscriptions by writing to the first key each is scanning.
+      const invalidates: Set<number> = new Set();
       const changes = new Map(
-        Array.from({length: numSubsDirty}).map((_, i) => [
-          sortedKeys[i * keysPerSub],
-          jsonObjectTestData(valueSize),
-        ]),
+        Array.from({length: numSubsDirty}).map((_, i) => {
+          let index = i;
+          if (randomInvalidates) {
+            do {
+              index = Math.floor(Math.random() * numSubsTotal);
+            } while (invalidates.has(index));
+            invalidates.add(index);
+          }
+          return [
+            sortedKeys[index * keysPerSub],
+            jsonObjectTestData(valueSize),
+          ];
+        }),
       );
 
       // OK time the below!
@@ -310,23 +327,23 @@ async function makeRepWithPopulate(useMemstore: boolean) {
 export function benchmarks(): Benchmark[] {
   const bs = (useMemstore: boolean) => [
     // write/sub/read 1mb
-    benchmarkWriteSubRead({
-      valueSize: 1024,
-      numSubsTotal: 64,
-      keysPerSub: 16,
-      keysWatchedPerSub: 16,
-      numSubsDirty: 5,
-      useMemstore,
-    }),
-    // write/sub/read 4mb
-    benchmarkWriteSubRead({
-      valueSize: 1024,
-      numSubsTotal: 128,
-      keysPerSub: 32,
-      keysWatchedPerSub: 16,
-      numSubsDirty: 5,
-      useMemstore,
-    }),
+    // benchmarkWriteSubRead({
+    //   valueSize: 1024,
+    //   numSubsTotal: 64,
+    //   keysPerSub: 16,
+    //   keysWatchedPerSub: 16,
+    //   numSubsDirty: 5,
+    //   useMemstore,
+    // }),
+    // // write/sub/read 4mb
+    // benchmarkWriteSubRead({
+    //   valueSize: 1024,
+    //   numSubsTotal: 128,
+    //   keysPerSub: 32,
+    //   keysWatchedPerSub: 16,
+    //   numSubsDirty: 5,
+    //   useMemstore,
+    // }),
     // write/sub/read 16mb
     benchmarkWriteSubRead({
       valueSize: 1024,
@@ -335,13 +352,23 @@ export function benchmarks(): Benchmark[] {
       keysWatchedPerSub: 16,
       numSubsDirty: 5,
       useMemstore,
+      randomInvalidates: false,
+    }),
+    benchmarkWriteSubRead({
+      valueSize: 1024,
+      numSubsTotal: 128,
+      keysPerSub: 128,
+      keysWatchedPerSub: 16,
+      numSubsDirty: 5,
+      useMemstore,
+      randomInvalidates: true,
     }),
     // 128 mb is unusable
-    benchmarkPopulate({numKeys: 1000, clean: true, useMemstore}),
-    benchmarkPopulate({numKeys: 1000, clean: true, indexes: 1, useMemstore}),
-    benchmarkPopulate({numKeys: 1000, clean: true, indexes: 2, useMemstore}),
-    benchmarkScan({numKeys: 1000, useMemstore}),
-    benchmarkCreateIndex({numKeys: 5000, useMemstore}),
+    // benchmarkPopulate({numKeys: 1000, clean: true, useMemstore}),
+    // benchmarkPopulate({numKeys: 1000, clean: true, indexes: 1, useMemstore}),
+    // benchmarkPopulate({numKeys: 1000, clean: true, indexes: 2, useMemstore}),
+    // benchmarkScan({numKeys: 1000, useMemstore}),
+    // benchmarkCreateIndex({numKeys: 5000, useMemstore}),
   ];
   return [...bs(true)];
 }

--- a/perf/replicache.ts
+++ b/perf/replicache.ts
@@ -182,6 +182,7 @@ export function benchmarkWriteSubRead(opts: {
     }writeSubRead randomInvalidates ${randomInvalidates} ${cacheSizeMB}MB total, ${numSubsTotal} subs total, ${numSubsDirty} subs dirty, ${kbReadPerSub}kb read per sub`,
     group: 'replicache',
     async run(bencher: Bencher) {
+      console.log(`run randomInvalidates ${randomInvalidates}`);
       const keys = Array.from({length: numKeys}, (_, index) => makeKey(index));
       const sortedKeys = keys.sort();
       const data: Map<string, TestDataObject> = new Map(
@@ -202,6 +203,7 @@ export function benchmarkWriteSubRead(opts: {
             changes: Map<string, TestDataObject>,
           ) {
             for (const [key, value] of changes) {
+              console.log(`invalidate`);
               await tx.put(key, value);
             }
           },
@@ -216,6 +218,7 @@ export function benchmarkWriteSubRead(opts: {
         return rep.subscribe(
           async tx => {
             const startKey = sortedKeys[startKeyIndex];
+            console.log(`scan`);
             return await tx
               .scan({
                 start: {key: startKey},

--- a/src/btree/node.test.ts
+++ b/src/btree/node.test.ts
@@ -1237,8 +1237,7 @@ test('scan', async () => {
       }
       expect(res).to.deep.equal(expectedEntries);
       if (options.limit !== undefined) {
-        expect(res.length).to.be.lessThanOrEqual(options.limit);
-        if (res.length === options.limit && options.limit !== 0) {
+        if (options.limit > 0 && res.length === options.limit) {
           expect(onLimitKeyCalls.length).to.equal(1);
           expect(onLimitKeyCalls[0]).to.equal(res[res.length - 1][0]);
         } else {

--- a/src/btree/node.test.ts
+++ b/src/btree/node.test.ts
@@ -1228,7 +1228,7 @@ test('scan', async () => {
 
     await doRead(rootHash, dagStore, async r => {
       const res: Entry<ReadonlyJSONValue>[] = [];
-      const onKeyCalls: {key: string, isInclusiveLimit: boolean}[] = [];
+      const onKeyCalls: {key: string; isInclusiveLimit: boolean}[] = [];
       const scanResult = r.scan(options, (key, isInclusiveLimit) => {
         onKeyCalls.push({key, isInclusiveLimit});
       });
@@ -1236,14 +1236,17 @@ test('scan', async () => {
       for await (const e of scanResult) {
         entriesReadCount++;
         res.push(e);
-        expect(onKeyCalls.length, 'onKey is called when entry is read').to.equal(entriesReadCount);
+        expect(
+          onKeyCalls.length,
+          'onKey is called when entry is read',
+        ).to.equal(entriesReadCount);
       }
       expect(res).to.deep.equal(expectedEntries);
-      const expectedOnKeyCalls: {key: string, isInclusiveLimit: boolean}[] = [];
+      const expectedOnKeyCalls: {key: string; isInclusiveLimit: boolean}[] = [];
       for (let i = 0; i < expectedEntries.length; i++) {
         expectedOnKeyCalls.push({
-          key: expectedEntries[i][0], 
-          isInclusiveLimit: options.limit === i + 1
+          key: expectedEntries[i][0],
+          isInclusiveLimit: options.limit === i + 1,
         });
       }
       expect(onKeyCalls).to.deep.equal(expectedOnKeyCalls);

--- a/src/btree/node.ts
+++ b/src/btree/node.ts
@@ -221,7 +221,7 @@ export class DataNodeImpl extends NodeImpl<ReadonlyJSONValue> {
     prefix: string,
     fromKey: string,
     limit: number,
-    onLimitKey?: (key: string) => void,
+    onLimitKey?: (inclusiveLimitKey: string) => void,
   ): AsyncGenerator<Entry<ReadonlyJSONValue>, number, unknown> {
     const {entries} = this;
     let i = binarySearch(fromKey, entries);
@@ -439,7 +439,7 @@ export class InternalNodeImpl extends NodeImpl<Hash> {
     prefix: string,
     fromKey: string,
     limit: number,
-    onLimitKey?: (key: string) => void,
+    onLimitKey?: (inclusiveLimitKey: string) => void,
   ): AsyncGenerator<Entry<ReadonlyJSONValue>, number> {
     const {entries} = this;
     let i = binarySearch(fromKey, entries);
@@ -451,7 +451,7 @@ export class InternalNodeImpl extends NodeImpl<Hash> {
     }
     for (; i < entries.length && limit > 0; i++) {
       const childNode = await tree.getNode(entries[i][1]);
-      limit = yield* childNode.scan(tree, prefix, fromKey, limit, onKey);
+      limit = yield* childNode.scan(tree, prefix, fromKey, limit, onLimitKey);
     }
     return limit;
   }

--- a/src/btree/node.ts
+++ b/src/btree/node.ts
@@ -221,11 +221,7 @@ export class DataNodeImpl extends NodeImpl<ReadonlyJSONValue> {
     prefix: string,
     fromKey: string,
     limit: number,
-    onKey?: (
-      key: string,
-      isLastBeforeLimit: boolean,
-      isLastEntry: boolean,
-    ) => void,
+    onKey?: (key: string, isInclusiveLimit: boolean) => void,
   ): AsyncGenerator<Entry<ReadonlyJSONValue>, number, unknown> {
     const {entries} = this;
     let i = binarySearch(fromKey, entries);
@@ -238,7 +234,7 @@ export class DataNodeImpl extends NodeImpl<ReadonlyJSONValue> {
       limit--, i++
     ) {
       if (onKey) {
-        onKey(entries[i][0], limit === 1, i === entries.length - 1);
+        onKey(entries[i][0], limit === 1);
       }
       yield entries[i];
     }
@@ -443,11 +439,7 @@ export class InternalNodeImpl extends NodeImpl<Hash> {
     prefix: string,
     fromKey: string,
     limit: number,
-    onKey?: (
-      key: string,
-      isLastBeforeLimit: boolean,
-      isLastEntry: boolean,
-    ) => void,
+    onKey?: (key: string, isInclusiveLimit: boolean) => void,
   ): AsyncGenerator<Entry<ReadonlyJSONValue>, number> {
     const {entries} = this;
     let i = binarySearch(fromKey, entries);

--- a/src/btree/node.ts
+++ b/src/btree/node.ts
@@ -221,7 +221,7 @@ export class DataNodeImpl extends NodeImpl<ReadonlyJSONValue> {
     prefix: string,
     fromKey: string,
     limit: number,
-    onKey?: (key: string, isInclusiveLimit: boolean) => void,
+    onLimitKey?: (key: string) => void,
   ): AsyncGenerator<Entry<ReadonlyJSONValue>, number, unknown> {
     const {entries} = this;
     let i = binarySearch(fromKey, entries);
@@ -233,8 +233,8 @@ export class DataNodeImpl extends NodeImpl<ReadonlyJSONValue> {
       limit > 0 && i < entries.length && entries[i][0].startsWith(prefix);
       limit--, i++
     ) {
-      if (onKey) {
-        onKey(entries[i][0], limit === 1);
+      if (onLimitKey && limit === 1) {
+        onLimitKey(entries[i][0]);
       }
       yield entries[i];
     }
@@ -439,7 +439,7 @@ export class InternalNodeImpl extends NodeImpl<Hash> {
     prefix: string,
     fromKey: string,
     limit: number,
-    onKey?: (key: string, isInclusiveLimit: boolean) => void,
+    onLimitKey?: (key: string) => void,
   ): AsyncGenerator<Entry<ReadonlyJSONValue>, number> {
     const {entries} = this;
     let i = binarySearch(fromKey, entries);

--- a/src/btree/node.ts
+++ b/src/btree/node.ts
@@ -221,6 +221,11 @@ export class DataNodeImpl extends NodeImpl<ReadonlyJSONValue> {
     prefix: string,
     fromKey: string,
     limit: number,
+    onKey?: (
+      key: string,
+      isLastBeforeLimit: boolean,
+      isLastEntry: boolean,
+    ) => void,
   ): AsyncGenerator<Entry<ReadonlyJSONValue>, number, unknown> {
     const {entries} = this;
     let i = binarySearch(fromKey, entries);
@@ -232,6 +237,9 @@ export class DataNodeImpl extends NodeImpl<ReadonlyJSONValue> {
       limit > 0 && i < entries.length && entries[i][0].startsWith(prefix);
       limit--, i++
     ) {
+      if (onKey) {
+        onKey(entries[i][0], limit === 1, i === entries.length - 1);
+      }
       yield entries[i];
     }
     return limit;

--- a/src/btree/node.ts
+++ b/src/btree/node.ts
@@ -443,6 +443,11 @@ export class InternalNodeImpl extends NodeImpl<Hash> {
     prefix: string,
     fromKey: string,
     limit: number,
+    onKey?: (
+      key: string,
+      isLastBeforeLimit: boolean,
+      isLastEntry: boolean,
+    ) => void,
   ): AsyncGenerator<Entry<ReadonlyJSONValue>, number> {
     const {entries} = this;
     let i = binarySearch(fromKey, entries);
@@ -454,7 +459,7 @@ export class InternalNodeImpl extends NodeImpl<Hash> {
     }
     for (; i < entries.length && limit > 0; i++) {
       const childNode = await tree.getNode(entries[i][1]);
-      limit = yield* childNode.scan(tree, prefix, fromKey, limit);
+      limit = yield* childNode.scan(tree, prefix, fromKey, limit, onKey);
     }
     return limit;
   }

--- a/src/btree/read.ts
+++ b/src/btree/read.ts
@@ -95,7 +95,7 @@ export class BTreeRead {
 
   async *scan(
     options: ScanOptionsInternal,
-    onKey?: (key: string, isInclusiveLimit: boolean) => void,
+    onLimitKey?: (key: string) => void,
   ): AsyncGenerator<Entry<ReadonlyJSONValue>> {
     const node = await this.getNode(this.rootHash);
     const {prefix = '', limit = Infinity, startKey} = options;

--- a/src/btree/read.ts
+++ b/src/btree/read.ts
@@ -95,6 +95,11 @@ export class BTreeRead {
 
   async *scan(
     options: ScanOptionsInternal,
+    onKey?: (
+      key: string,
+      isLastBeforeLimit: boolean,
+      isLastEntry: boolean,
+    ) => void,
   ): AsyncGenerator<Entry<ReadonlyJSONValue>> {
     const node = await this.getNode(this.rootHash);
     const {prefix = '', limit = Infinity, startKey} = options;
@@ -105,7 +110,7 @@ export class BTreeRead {
       }
     }
 
-    yield* node.scan(this, prefix, fromKey, limit);
+    yield* node.scan(this, prefix, fromKey, limit, onKey);
   }
 
   async *keys(): AsyncGenerator<string, void> {

--- a/src/btree/read.ts
+++ b/src/btree/read.ts
@@ -95,7 +95,7 @@ export class BTreeRead {
 
   async *scan(
     options: ScanOptionsInternal,
-    onLimitKey?: (key: string) => void,
+    onLimitKey?: (inclusiveLimitKey: string) => void,
   ): AsyncGenerator<Entry<ReadonlyJSONValue>> {
     const node = await this.getNode(this.rootHash);
     const {prefix = '', limit = Infinity, startKey} = options;
@@ -106,7 +106,7 @@ export class BTreeRead {
       }
     }
 
-    yield* node.scan(this, prefix, fromKey, limit, onKey);
+    yield* node.scan(this, prefix, fromKey, limit, onLimitKey);
   }
 
   async *keys(): AsyncGenerator<string, void> {

--- a/src/btree/read.ts
+++ b/src/btree/read.ts
@@ -95,11 +95,7 @@ export class BTreeRead {
 
   async *scan(
     options: ScanOptionsInternal,
-    onKey?: (
-      key: string,
-      isLastBeforeLimit: boolean,
-      isLastEntry: boolean,
-    ) => void,
+    onKey?: (key: string, isInclusiveLimit: boolean) => void,
   ): AsyncGenerator<Entry<ReadonlyJSONValue>> {
     const node = await this.getNode(this.rootHash);
     const {prefix = '', limit = Infinity, startKey} = options;

--- a/src/db/read.ts
+++ b/src/db/read.ts
@@ -36,11 +36,7 @@ export class Read {
   async *scan<R>(
     opts: ScanOptions,
     convertEntry: (entry: Entry<ReadonlyJSONValue>) => R,
-    onKey?: (
-      key: string,
-      isLastBeforeLimit: boolean,
-      isLastEntry: boolean,
-    ) => void,
+    onKey?: (key: string, isInclusiveLimit: boolean) => void,
   ): AsyncIterableIterator<R> {
     const optsInternal: ScanOptionsInternal = convert(opts);
     if (optsInternal.indexName !== undefined) {

--- a/src/db/read.ts
+++ b/src/db/read.ts
@@ -36,7 +36,7 @@ export class Read {
   async *scan<R>(
     opts: ScanOptions,
     convertEntry: (entry: Entry<ReadonlyJSONValue>) => R,
-    onKey?: (key: string, isInclusiveLimit: boolean) => void,
+    onLimitKey?: (key: string) => void,
   ): AsyncIterableIterator<R> {
     const optsInternal: ScanOptionsInternal = convert(opts);
     if (optsInternal.indexName !== undefined) {

--- a/src/db/read.ts
+++ b/src/db/read.ts
@@ -36,6 +36,11 @@ export class Read {
   async *scan<R>(
     opts: ScanOptions,
     convertEntry: (entry: Entry<ReadonlyJSONValue>) => R,
+    onKey?: (
+      key: string,
+      isLastBeforeLimit: boolean,
+      isLastEntry: boolean,
+    ) => void,
   ): AsyncIterableIterator<R> {
     const optsInternal: ScanOptionsInternal = convert(opts);
     if (optsInternal.indexName !== undefined) {
@@ -45,10 +50,10 @@ export class Read {
         throw new Error(`Unknown index name: ${name}`);
       }
       yield* await idx.withMap(this._dagRead, map =>
-        scan(map, optsInternal, convertEntry),
+        scan(map, optsInternal, convertEntry, onKey),
       );
     } else {
-      yield* scan(this.map, optsInternal, convertEntry);
+      yield* scan(this.map, optsInternal, convertEntry, onKey);
     }
   }
 

--- a/src/db/read.ts
+++ b/src/db/read.ts
@@ -36,7 +36,7 @@ export class Read {
   async *scan<R>(
     opts: ScanOptions,
     convertEntry: (entry: Entry<ReadonlyJSONValue>) => R,
-    onLimitKey?: (key: string) => void,
+    onLimitKey?: (inclusiveLimitKey: string) => void,
   ): AsyncIterableIterator<R> {
     const optsInternal: ScanOptionsInternal = convert(opts);
     if (optsInternal.indexName !== undefined) {
@@ -46,10 +46,10 @@ export class Read {
         throw new Error(`Unknown index name: ${name}`);
       }
       yield* await idx.withMap(this._dagRead, map =>
-        scan(map, optsInternal, convertEntry, onKey),
+        scan(map, optsInternal, convertEntry, onLimitKey),
       );
     } else {
-      yield* scan(this.map, optsInternal, convertEntry, onKey);
+      yield* scan(this.map, optsInternal, convertEntry, onLimitKey);
     }
   }
 

--- a/src/db/scan.ts
+++ b/src/db/scan.ts
@@ -67,13 +67,18 @@ export async function* scan<R>(
   map: BTreeRead,
   opts: ScanOptionsInternal,
   convertEntry: (entry: Entry<ReadonlyJSONValue>) => R,
+  onKey?: (
+    key: string,
+    isLastBeforeLimit: boolean,
+    isLastEntry: boolean,
+  ) => void,
 ): AsyncIterableIterator<R> {
   // We don't do any encoding of the key in regular prolly maps, so we have no
   // way of determining from an entry.key alone whether it is a regular prolly
   // map key or an encoded IndexKey in an index map. Without encoding regular
   // prolly map keys we need to rely on the opts to tell us what we expect.
 
-  for await (const entry of map.scan(opts)) {
+  for await (const entry of map.scan(opts, onKey)) {
     yield convertEntry(entry);
   }
 }

--- a/src/db/scan.ts
+++ b/src/db/scan.ts
@@ -67,11 +67,7 @@ export async function* scan<R>(
   map: BTreeRead,
   opts: ScanOptionsInternal,
   convertEntry: (entry: Entry<ReadonlyJSONValue>) => R,
-  onKey?: (
-    key: string,
-    isLastBeforeLimit: boolean,
-    isLastEntry: boolean,
-  ) => void,
+  onKey?: (key: string, isInclusiveLimit: boolean) => void,
 ): AsyncIterableIterator<R> {
   // We don't do any encoding of the key in regular prolly maps, so we have no
   // way of determining from an entry.key alone whether it is a regular prolly

--- a/src/db/scan.ts
+++ b/src/db/scan.ts
@@ -67,14 +67,14 @@ export async function* scan<R>(
   map: BTreeRead,
   opts: ScanOptionsInternal,
   convertEntry: (entry: Entry<ReadonlyJSONValue>) => R,
-  onLimitKey?: (key: string) => void,
+  onLimitKey?: (inclusiveLimitKey: string) => void,
 ): AsyncIterableIterator<R> {
   // We don't do any encoding of the key in regular prolly maps, so we have no
   // way of determining from an entry.key alone whether it is a regular prolly
   // map key or an encoded IndexKey in an index map. Without encoding regular
   // prolly map keys we need to rely on the opts to tell us what we expect.
 
-  for await (const entry of map.scan(opts, onKey)) {
+  for await (const entry of map.scan(opts, onLimitKey)) {
     yield convertEntry(entry);
   }
 }

--- a/src/db/scan.ts
+++ b/src/db/scan.ts
@@ -67,7 +67,7 @@ export async function* scan<R>(
   map: BTreeRead,
   opts: ScanOptionsInternal,
   convertEntry: (entry: Entry<ReadonlyJSONValue>) => R,
-  onKey?: (key: string, isInclusiveLimit: boolean) => void,
+  onLimitKey?: (key: string) => void,
 ): AsyncIterableIterator<R> {
   // We don't do any encoding of the key in regular prolly maps, so we have no
   // way of determining from an entry.key alone whether it is a regular prolly

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -910,7 +910,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
     type R =
       | {ok: true; value: JSONValue | undefined}
       | {ok: false; error: unknown};
-    const results = await this.query(async tx => {
+    const results = await this._queryInternal(async tx => {
       const promises = subs.map(async s => {
         // Tag the result so we can deal with success vs error below.
         try {
@@ -1000,6 +1000,12 @@ export class Replicache<MD extends MutatorDefs = {}> {
    * and `scan`.
    */
   async query<R>(body: (tx: ReadTransaction) => Promise<R> | R): Promise<R> {
+    return this._queryInternal(body);
+  }
+
+  private async _queryInternal<R>(
+    body: (tx: ReadTransactionImpl) => Promise<R> | R,
+  ): Promise<R> {
     await this._ready;
     // clientID must be awaited ouside dag transaction to avoid a premature
     // auto-commit of the idb transaction.

--- a/src/scan-iterator.ts
+++ b/src/scan-iterator.ts
@@ -17,6 +17,11 @@ type Args = [
   getTransaction: () => Promise<db.Read> | db.Read,
   shouldCloseTransaction: boolean,
   shouldClone: boolean,
+  onKey?: (
+    key: string,
+    isLastBeforeLimit: boolean,
+    isLastEntry: boolean,
+  ) => void,
 ];
 
 /**
@@ -121,6 +126,11 @@ async function* scanIterator<V>(
   getTransaction: () => MaybePromise<db.Read>,
   shouldCloseTransaction: boolean,
   shouldClone: boolean,
+  onKey?: (
+    key: string,
+    isLastBeforeLimit: boolean,
+    isLastEntry: boolean,
+  ) => void,
 ): AsyncIterableIterator<V> {
   const dbRead = await getTransaction();
   throwIfClosed(dbRead);
@@ -148,7 +158,7 @@ async function* scanIterator<V>(
   }
 
   try {
-    yield* dbRead.scan(toDbScanOptions(options), convertEntry);
+    yield* dbRead.scan(toDbScanOptions(options), convertEntry, onKey);
   } finally {
     if (shouldCloseTransaction && !dbRead.closed) {
       dbRead.close();

--- a/src/scan-iterator.ts
+++ b/src/scan-iterator.ts
@@ -17,7 +17,7 @@ type Args = [
   getTransaction: () => Promise<db.Read> | db.Read,
   shouldCloseTransaction: boolean,
   shouldClone: boolean,
-  onKey?: (key: string, isInclusiveLimit: boolean) => void,
+  onLimitKey?: (key: string) => void,
 ];
 
 /**
@@ -122,7 +122,7 @@ async function* scanIterator<V>(
   getTransaction: () => MaybePromise<db.Read>,
   shouldCloseTransaction: boolean,
   shouldClone: boolean,
-  onKey?: (key: string, isInclusiveLimit: boolean) => void,
+  onLimitKey?: (key: string) => void,
 ): AsyncIterableIterator<V> {
   const dbRead = await getTransaction();
   throwIfClosed(dbRead);

--- a/src/scan-iterator.ts
+++ b/src/scan-iterator.ts
@@ -17,11 +17,7 @@ type Args = [
   getTransaction: () => Promise<db.Read> | db.Read,
   shouldCloseTransaction: boolean,
   shouldClone: boolean,
-  onKey?: (
-    key: string,
-    isLastBeforeLimit: boolean,
-    isLastEntry: boolean,
-  ) => void,
+  onKey?: (key: string, isInclusiveLimit: boolean) => void,
 ];
 
 /**
@@ -126,11 +122,7 @@ async function* scanIterator<V>(
   getTransaction: () => MaybePromise<db.Read>,
   shouldCloseTransaction: boolean,
   shouldClone: boolean,
-  onKey?: (
-    key: string,
-    isLastBeforeLimit: boolean,
-    isLastEntry: boolean,
-  ) => void,
+  onKey?: (key: string, isInclusiveLimit: boolean) => void,
 ): AsyncIterableIterator<V> {
   const dbRead = await getTransaction();
   throwIfClosed(dbRead);

--- a/src/scan-iterator.ts
+++ b/src/scan-iterator.ts
@@ -17,7 +17,7 @@ type Args = [
   getTransaction: () => Promise<db.Read> | db.Read,
   shouldCloseTransaction: boolean,
   shouldClone: boolean,
-  onLimitKey?: (key: string) => void,
+  onLimitKey?: (inclusiveLimitKey: string) => void,
 ];
 
 /**
@@ -122,7 +122,7 @@ async function* scanIterator<V>(
   getTransaction: () => MaybePromise<db.Read>,
   shouldCloseTransaction: boolean,
   shouldClone: boolean,
-  onLimitKey?: (key: string) => void,
+  onLimitKey?: (inclusiveLimitKey: string) => void,
 ): AsyncIterableIterator<V> {
   const dbRead = await getTransaction();
   throwIfClosed(dbRead);
@@ -150,7 +150,7 @@ async function* scanIterator<V>(
   }
 
   try {
-    yield* dbRead.scan(toDbScanOptions(options), convertEntry, onKey);
+    yield* dbRead.scan(toDbScanOptions(options), convertEntry, onLimitKey);
   } finally {
     if (shouldCloseTransaction && !dbRead.closed) {
       dbRead.close();

--- a/src/subscriptions.test.ts
+++ b/src/subscriptions.test.ts
@@ -288,7 +288,7 @@ test('scanInfoMatchesKey limit optimizations', () => {
     ),
   ).to.be.true;
 
-  // Changed key matches prefix and equals nclusive limit key
+  // Changed key matches prefix and equals inclusive limit key
   expect(
     scanInfoMatchesKey(
       {

--- a/src/subscriptions.test.ts
+++ b/src/subscriptions.test.ts
@@ -1,103 +1,432 @@
 import {expect} from '@esm-bundle/chai';
+import type {ScanOptions} from './db/mod';
 import {scanInfoMatchesKey} from './subscriptions';
 
 test('scanInfoMatchesKey', () => {
-  expect(true).to.be.true;
-  scanInfoMatchesKey;
-  // expect(scanInfoMatchesKey({}, '', 'a')).to.be.true;
-  // expect(scanInfoMatchesKey({indexName: 'idx'}, 'idx', 'a')).to.be.true;
-  // expect(scanInfoMatchesKey({indexName: 'idx'}, '', 'a')).to.be.false;
-  // expect(scanInfoMatchesKey({}, 'idx', 'a')).to.be.false;
+  expect(scanInfoMatchesKey({options: {}}, '', 'a')).to.be.true;
+  expect(scanInfoMatchesKey({options: {indexName: 'idx'}}, 'idx', 'a')).to.be
+    .true;
+  expect(scanInfoMatchesKey({options: {indexName: 'idx'}}, '', 'a')).to.be
+    .false;
+  expect(scanInfoMatchesKey({options: {}}, 'idx', 'a')).to.be.false;
 
-  // expect(scanInfoMatchesKey({prefix: 'p'}, '', 'a')).to.be.false;
+  expect(scanInfoMatchesKey({options: {prefix: 'p'}}, '', 'a')).to.be.false;
 
-  // expect(scanInfoMatchesKey({startKey: 'sk'}, '', 'a')).to.be.false;
-  // expect(scanInfoMatchesKey({startKey: 'sk'}, '', 'skate')).to.be.true;
-  // expect(scanInfoMatchesKey({startKey: 'a'}, '', 'b')).to.be.true;
+  expect(scanInfoMatchesKey({options: {startKey: 'sk'}}, '', 'a')).to.be.false;
+  expect(scanInfoMatchesKey({options: {startKey: 'sk'}}, '', 'skate')).to.be
+    .true;
+  expect(scanInfoMatchesKey({options: {startKey: 'a'}}, '', 'b')).to.be.true;
 
-  // expect(
-  //   scanInfoMatchesKey(
-  //     {prefix: 'a', indexName: 'idx'},
-  //     'idx',
-  //     '\u0000a\u0000b',
-  //   ),
-  // ).to.be.true;
-  // expect(
-  //   scanInfoMatchesKey(
-  //     {prefix: 'sb', indexName: 'idx'},
-  //     'idx',
-  //     '\u0000sa\u0000p',
-  //   ),
-  // ).to.be.false;
+  expect(
+    scanInfoMatchesKey(
+      {options: {prefix: 'a', indexName: 'idx'}},
+      'idx',
+      '\u0000a\u0000b',
+    ),
+  ).to.be.true;
+  expect(
+    scanInfoMatchesKey(
+      {options: {prefix: 'sb', indexName: 'idx'}},
+      'idx',
+      '\u0000sa\u0000p',
+    ),
+  ).to.be.false;
 
-  // expect(
-  //   scanInfoMatchesKey(
-  //     {prefix: 'sa', indexName: 'idx', startSecondaryKey: 'sab'},
-  //     'idx',
-  //     '\u0000sab\u0000p',
-  //   ),
-  // ).to.be.true;
-  // expect(
-  //   scanInfoMatchesKey(
-  //     {prefix: 'sa', indexName: 'idx', startSecondaryKey: 'sab'},
-  //     'idx',
-  //     '\u0000sac\u0000p',
-  //   ),
-  // ).to.be.true;
-  // expect(
-  //   scanInfoMatchesKey(
-  //     {prefix: 'sa', indexName: 'idx', startSecondaryKey: 'sac'},
-  //     'idx',
-  //     '\u0000sab\u0000p',
-  //   ),
-  // ).to.be.false;
+  expect(
+    scanInfoMatchesKey(
+      {options: {prefix: 'sa', indexName: 'idx', startSecondaryKey: 'sab'}},
+      'idx',
+      '\u0000sab\u0000p',
+    ),
+  ).to.be.true;
+  expect(
+    scanInfoMatchesKey(
+      {options: {prefix: 'sa', indexName: 'idx', startSecondaryKey: 'sab'}},
+      'idx',
+      '\u0000sac\u0000p',
+    ),
+  ).to.be.true;
+  expect(
+    scanInfoMatchesKey(
+      {options: {prefix: 'sa', indexName: 'idx', startSecondaryKey: 'sac'}},
+      'idx',
+      '\u0000sab\u0000p',
+    ),
+  ).to.be.false;
 
-  // expect(
-  //   scanInfoMatchesKey(
-  //     {
-  //       prefix: 'sa',
-  //       indexName: 'idx',
-  //       startSecondaryKey: 'sab',
-  //       startKey: 'pa',
-  //     },
-  //     'idx',
-  //     '\u0000sac\u0000pa',
-  //   ),
-  // ).to.be.true;
-  // expect(
-  //   scanInfoMatchesKey(
-  //     {
-  //       prefix: 'sa',
-  //       indexName: 'idx',
-  //       startSecondaryKey: 'sab',
-  //       startKey: 'pab',
-  //     },
-  //     'idx',
-  //     '\u0000sac\u0000pab',
-  //   ),
-  // ).to.be.true;
-  // expect(
-  //   scanInfoMatchesKey(
-  //     {
-  //       prefix: 'sa',
-  //       indexName: 'idx',
-  //       startSecondaryKey: 'sab',
-  //       startKey: 'pab',
-  //     },
-  //     'idx',
-  //     '\u0000sac\u0000pac',
-  //   ),
-  // ).to.be.true;
-  // expect(
-  //   scanInfoMatchesKey(
-  //     {
-  //       prefix: 'sa',
-  //       indexName: 'idx',
-  //       startSecondaryKey: 'sab',
-  //       startKey: 'pac',
-  //     },
-  //     'idx',
-  //     '\u0000sac\u0000pab',
-  //   ),
-  // ).to.be.false;
+  expect(
+    scanInfoMatchesKey(
+      {
+        options: {
+          prefix: 'sa',
+          indexName: 'idx',
+          startSecondaryKey: 'sab',
+          startKey: 'pa',
+        },
+      },
+      'idx',
+      '\u0000sac\u0000pa',
+    ),
+  ).to.be.true;
+  expect(
+    scanInfoMatchesKey(
+      {
+        options: {
+          prefix: 'sa',
+          indexName: 'idx',
+          startSecondaryKey: 'sab',
+          startKey: 'pab',
+        },
+      },
+      'idx',
+      '\u0000sac\u0000pab',
+    ),
+  ).to.be.true;
+  expect(
+    scanInfoMatchesKey(
+      {
+        options: {
+          prefix: 'sa',
+          indexName: 'idx',
+          startSecondaryKey: 'sab',
+          startKey: 'pab',
+        },
+      },
+      'idx',
+      '\u0000sac\u0000pac',
+    ),
+  ).to.be.true;
+  expect(
+    scanInfoMatchesKey(
+      {
+        options: {
+          prefix: 'sa',
+          indexName: 'idx',
+          startSecondaryKey: 'sab',
+          startKey: 'pac',
+        },
+      },
+      'idx',
+      '\u0000sac\u0000pab',
+    ),
+  ).to.be.false;
+});
+
+function testScanLimitOptimizations({
+  options,
+  lastKeyReadInfo,
+  changedKey,
+  expected,
+}: {
+  options: ScanOptions;
+  lastKeyReadInfo: {
+    key: string;
+    isInclusiveLimit?: boolean;
+  };
+  changedKey: string;
+  expected: boolean;
+}) {
+  const isInclusiveLimitValuesToTest = lastKeyReadInfo.isInclusiveLimit
+    ? [lastKeyReadInfo.isInclusiveLimit]
+    : [true, false];
+  for (const isInclusiveLimit of isInclusiveLimitValuesToTest) {
+    const info = {
+      options,
+      lastKeyReadInfo: {
+        key: lastKeyReadInfo.key,
+        isInclusiveLimit,
+      },
+    };
+    expect(
+      scanInfoMatchesKey(info, '', changedKey),
+      `scanInfoMatchesKey(${JSON.stringify(
+        info,
+      )}, "", "${changedKey}"") should be ${expected}`,
+    ).to.equal(expected);
+  }
+}
+
+test('scanInfoMatchesKey limit optimizations', () => {
+  // Start key tests
+
+  testScanLimitOptimizations({
+    options: {
+      startKey: 'pac2',
+      limit: 10,
+    },
+    lastKeyReadInfo: {
+      key: 'pac8',
+      // expected for both isInclusiveLimit true and false
+    },
+    changedKey: 'pac2',
+    expected: true,
+  });
+
+  testScanLimitOptimizations({
+    options: {
+      startKey: 'pac2',
+      limit: 10,
+    },
+    lastKeyReadInfo: {
+      key: 'pac8',
+      // expected for both isInclusiveLimit true and false
+    },
+    changedKey: 'pac4',
+    expected: true,
+  });
+
+  testScanLimitOptimizations({
+    options: {
+      startKey: 'pac2',
+      limit: 10,
+    },
+    lastKeyReadInfo: {
+      key: 'pac8',
+      // expected for both isInclusiveLimit true and false
+    },
+    changedKey: 'pac8',
+    expected: true,
+  });
+
+  // Changed key is after inclusive limit
+  testScanLimitOptimizations({
+    options: {
+      startKey: 'pac2',
+      limit: 10,
+    },
+    lastKeyReadInfo: {
+      key: 'pac8',
+      isInclusiveLimit: true,
+    },
+    changedKey: 'pac9',
+    expected: false,
+  });
+
+  // Changed key is before start key
+  testScanLimitOptimizations({
+    options: {
+      startKey: 'pac2',
+      limit: 10,
+    },
+    lastKeyReadInfo: {
+      key: 'pac8',
+      // expected for both isInclusiveLimit true and false
+    },
+    changedKey: 'pac1',
+    expected: false,
+  });
+
+  // Changed key is equal to exclusive start key
+  testScanLimitOptimizations({
+    options: {
+      startKey: 'pac2',
+      startExclusive: true,
+      limit: 10,
+    },
+    lastKeyReadInfo: {
+      key: 'pac8',
+      // expected for both isInclusiveLimit true and false
+    },
+    changedKey: 'pac2',
+    expected: false,
+  });
+
+  // No limit
+  testScanLimitOptimizations({
+    options: {
+      startKey: 'pac2'
+    },
+    lastKeyReadInfo: {
+      key: 'pac8',
+    },
+    changedKey: 'pac9',
+    expected: true,
+  });
+
+  // Prefix test
+
+  testScanLimitOptimizations({
+    options: {
+      prefix: 'pac',
+      limit: 10,
+    },
+    lastKeyReadInfo: {
+      key: 'pac8',
+      // expected for both isInclusiveLimit true and false
+    },
+    changedKey: 'pac1',
+    expected: true,
+  });
+
+  testScanLimitOptimizations({
+    options: {
+      prefix: 'pac',
+      limit: 10,
+    },
+    lastKeyReadInfo: {
+      key: 'pac8',
+      // expected for both isInclusiveLimit true and false
+    },
+    changedKey: 'pac8',
+    expected: true,
+  });
+
+  // Changed key is after inclusive limit
+  testScanLimitOptimizations({
+    options: {
+      prefix: 'pac',
+      limit: 10,
+    },
+    lastKeyReadInfo: {
+      key: 'pac8',
+      isInclusiveLimit: true,
+    },
+    changedKey: 'pac9',
+    expected: false,
+  });
+
+  // Changed key doesn't match prefix
+  testScanLimitOptimizations({
+    options: {
+      prefix: 'pac',
+      limit: 10,
+    },
+    lastKeyReadInfo: {
+      key: 'pac8',
+      // expected for both isInclusiveLimit true and false
+    },
+    changedKey: 'pab',
+    expected: false,
+  });
+
+  // No limit
+  testScanLimitOptimizations({
+    options: {
+      prefix: 'pac'
+    },
+    lastKeyReadInfo: {
+      key: 'pac8'
+    },
+    changedKey: 'pac9',
+    expected: true,
+  });
+
+  // Start and prefix
+
+  testScanLimitOptimizations({
+    options: {
+      prefix: 'pac2',
+      startKey: 'pac22',
+      limit: 10,
+    },
+    lastKeyReadInfo: {
+      key: 'pac28',
+      // expected for both isInclusiveLimit true and false
+    },
+    changedKey: 'pac22',
+    expected: true,
+  });
+
+  testScanLimitOptimizations({
+    options: {
+      prefix: 'pac2',
+      startKey: 'pac22',
+      limit: 10,
+    },
+    lastKeyReadInfo: {
+      key: 'pac28',
+      // expected for both isInclusiveLimit true and false
+    },
+    changedKey: 'pac24',
+    expected: true,
+  });
+
+  testScanLimitOptimizations({
+    options: {
+      prefix: 'pac2',
+      startKey: 'pac22',
+      limit: 10,
+    },
+    lastKeyReadInfo: {
+      key: 'pac28',
+      // expected for both isInclusiveLimit true and false
+    },
+    changedKey: 'pac28',
+    expected: true,
+  });
+
+  // Changed key is after inclusive limit
+  testScanLimitOptimizations({
+    options: {
+      prefix: 'pac2',
+      startKey: 'pac22',
+      limit: 10,
+    },
+    lastKeyReadInfo: {
+      key: 'pac28',
+      isInclusiveLimit: true,
+    },
+    changedKey: 'pac29',
+    expected: false,
+  });
+
+  // Changed key is before start key
+  testScanLimitOptimizations({
+    options: {
+      prefix: 'pac2',
+      startKey: 'pac22',
+      limit: 10,
+    },
+    lastKeyReadInfo: {
+      key: 'pac28',
+      // expected for both isInclusiveLimit true and false
+    },
+    changedKey: 'pac21',
+    expected: false,
+  });
+
+  // Changed key is equal to exclusive start key
+  testScanLimitOptimizations({
+    options: {
+      prefix: 'pac2',
+      startKey: 'pac22',
+      startExclusive: true,
+      limit: 10,
+    },
+    lastKeyReadInfo: {
+      key: 'pac28',
+      // expected for both isInclusiveLimit true and false
+    },
+    changedKey: 'pac22',
+    expected: false,
+  });
+
+  // No limit
+  testScanLimitOptimizations({
+    options: {
+      prefix: 'pac2',
+      startKey: 'pac22'
+    },
+    lastKeyReadInfo: {
+      key: 'pac28',
+    },
+    changedKey: 'pac29',
+    expected: true,
+  });
+
+  // Changed key is between startKey and lastKey inclusive, but doesnt match prefix
+  testScanLimitOptimizations({
+    options: {
+      prefix: 'pac2',
+      startKey: 'pab1',
+      limit: 10,
+    },
+    lastKeyReadInfo: {
+      key: 'pac28',
+      // expected for both isInclusiveLimit true and false
+    },
+    changedKey: 'pab2',
+    expected: false,
+  });
+
 });

--- a/src/subscriptions.test.ts
+++ b/src/subscriptions.test.ts
@@ -234,7 +234,7 @@ test('scanInfoMatchesKey limit optimizations', () => {
   // No limit
   testScanLimitOptimizations({
     options: {
-      startKey: 'pac2'
+      startKey: 'pac2',
     },
     lastKeyReadInfo: {
       key: 'pac8',
@@ -302,10 +302,10 @@ test('scanInfoMatchesKey limit optimizations', () => {
   // No limit
   testScanLimitOptimizations({
     options: {
-      prefix: 'pac'
+      prefix: 'pac',
     },
     lastKeyReadInfo: {
-      key: 'pac8'
+      key: 'pac8',
     },
     changedKey: 'pac9',
     expected: true,
@@ -405,7 +405,7 @@ test('scanInfoMatchesKey limit optimizations', () => {
   testScanLimitOptimizations({
     options: {
       prefix: 'pac2',
-      startKey: 'pac22'
+      startKey: 'pac22',
     },
     lastKeyReadInfo: {
       key: 'pac28',
@@ -428,5 +428,4 @@ test('scanInfoMatchesKey limit optimizations', () => {
     changedKey: 'pab2',
     expected: false,
   });
-
 });

--- a/src/subscriptions.test.ts
+++ b/src/subscriptions.test.ts
@@ -1,101 +1,103 @@
 import {expect} from '@esm-bundle/chai';
-import {scanOptionsMatchesKey} from './subscriptions';
+import {scanInfoMatchesKey} from './subscriptions';
 
-test('scanOptionsMatchesKey', () => {
-  expect(scanOptionsMatchesKey({}, '', 'a')).to.be.true;
-  expect(scanOptionsMatchesKey({indexName: 'idx'}, 'idx', 'a')).to.be.true;
-  expect(scanOptionsMatchesKey({indexName: 'idx'}, '', 'a')).to.be.false;
-  expect(scanOptionsMatchesKey({}, 'idx', 'a')).to.be.false;
+test('scanInfoMatchesKey', () => {
+  expect(true).to.be.true;
+  scanInfoMatchesKey;
+  // expect(scanInfoMatchesKey({}, '', 'a')).to.be.true;
+  // expect(scanInfoMatchesKey({indexName: 'idx'}, 'idx', 'a')).to.be.true;
+  // expect(scanInfoMatchesKey({indexName: 'idx'}, '', 'a')).to.be.false;
+  // expect(scanInfoMatchesKey({}, 'idx', 'a')).to.be.false;
 
-  expect(scanOptionsMatchesKey({prefix: 'p'}, '', 'a')).to.be.false;
+  // expect(scanInfoMatchesKey({prefix: 'p'}, '', 'a')).to.be.false;
 
-  expect(scanOptionsMatchesKey({startKey: 'sk'}, '', 'a')).to.be.false;
-  expect(scanOptionsMatchesKey({startKey: 'sk'}, '', 'skate')).to.be.true;
-  expect(scanOptionsMatchesKey({startKey: 'a'}, '', 'b')).to.be.true;
+  // expect(scanInfoMatchesKey({startKey: 'sk'}, '', 'a')).to.be.false;
+  // expect(scanInfoMatchesKey({startKey: 'sk'}, '', 'skate')).to.be.true;
+  // expect(scanInfoMatchesKey({startKey: 'a'}, '', 'b')).to.be.true;
 
-  expect(
-    scanOptionsMatchesKey(
-      {prefix: 'a', indexName: 'idx'},
-      'idx',
-      '\u0000a\u0000b',
-    ),
-  ).to.be.true;
-  expect(
-    scanOptionsMatchesKey(
-      {prefix: 'sb', indexName: 'idx'},
-      'idx',
-      '\u0000sa\u0000p',
-    ),
-  ).to.be.false;
+  // expect(
+  //   scanInfoMatchesKey(
+  //     {prefix: 'a', indexName: 'idx'},
+  //     'idx',
+  //     '\u0000a\u0000b',
+  //   ),
+  // ).to.be.true;
+  // expect(
+  //   scanInfoMatchesKey(
+  //     {prefix: 'sb', indexName: 'idx'},
+  //     'idx',
+  //     '\u0000sa\u0000p',
+  //   ),
+  // ).to.be.false;
 
-  expect(
-    scanOptionsMatchesKey(
-      {prefix: 'sa', indexName: 'idx', startSecondaryKey: 'sab'},
-      'idx',
-      '\u0000sab\u0000p',
-    ),
-  ).to.be.true;
-  expect(
-    scanOptionsMatchesKey(
-      {prefix: 'sa', indexName: 'idx', startSecondaryKey: 'sab'},
-      'idx',
-      '\u0000sac\u0000p',
-    ),
-  ).to.be.true;
-  expect(
-    scanOptionsMatchesKey(
-      {prefix: 'sa', indexName: 'idx', startSecondaryKey: 'sac'},
-      'idx',
-      '\u0000sab\u0000p',
-    ),
-  ).to.be.false;
+  // expect(
+  //   scanInfoMatchesKey(
+  //     {prefix: 'sa', indexName: 'idx', startSecondaryKey: 'sab'},
+  //     'idx',
+  //     '\u0000sab\u0000p',
+  //   ),
+  // ).to.be.true;
+  // expect(
+  //   scanInfoMatchesKey(
+  //     {prefix: 'sa', indexName: 'idx', startSecondaryKey: 'sab'},
+  //     'idx',
+  //     '\u0000sac\u0000p',
+  //   ),
+  // ).to.be.true;
+  // expect(
+  //   scanInfoMatchesKey(
+  //     {prefix: 'sa', indexName: 'idx', startSecondaryKey: 'sac'},
+  //     'idx',
+  //     '\u0000sab\u0000p',
+  //   ),
+  // ).to.be.false;
 
-  expect(
-    scanOptionsMatchesKey(
-      {
-        prefix: 'sa',
-        indexName: 'idx',
-        startSecondaryKey: 'sab',
-        startKey: 'pa',
-      },
-      'idx',
-      '\u0000sac\u0000pa',
-    ),
-  ).to.be.true;
-  expect(
-    scanOptionsMatchesKey(
-      {
-        prefix: 'sa',
-        indexName: 'idx',
-        startSecondaryKey: 'sab',
-        startKey: 'pab',
-      },
-      'idx',
-      '\u0000sac\u0000pab',
-    ),
-  ).to.be.true;
-  expect(
-    scanOptionsMatchesKey(
-      {
-        prefix: 'sa',
-        indexName: 'idx',
-        startSecondaryKey: 'sab',
-        startKey: 'pab',
-      },
-      'idx',
-      '\u0000sac\u0000pac',
-    ),
-  ).to.be.true;
-  expect(
-    scanOptionsMatchesKey(
-      {
-        prefix: 'sa',
-        indexName: 'idx',
-        startSecondaryKey: 'sab',
-        startKey: 'pac',
-      },
-      'idx',
-      '\u0000sac\u0000pab',
-    ),
-  ).to.be.false;
+  // expect(
+  //   scanInfoMatchesKey(
+  //     {
+  //       prefix: 'sa',
+  //       indexName: 'idx',
+  //       startSecondaryKey: 'sab',
+  //       startKey: 'pa',
+  //     },
+  //     'idx',
+  //     '\u0000sac\u0000pa',
+  //   ),
+  // ).to.be.true;
+  // expect(
+  //   scanInfoMatchesKey(
+  //     {
+  //       prefix: 'sa',
+  //       indexName: 'idx',
+  //       startSecondaryKey: 'sab',
+  //       startKey: 'pab',
+  //     },
+  //     'idx',
+  //     '\u0000sac\u0000pab',
+  //   ),
+  // ).to.be.true;
+  // expect(
+  //   scanInfoMatchesKey(
+  //     {
+  //       prefix: 'sa',
+  //       indexName: 'idx',
+  //       startSecondaryKey: 'sab',
+  //       startKey: 'pab',
+  //     },
+  //     'idx',
+  //     '\u0000sac\u0000pac',
+  //   ),
+  // ).to.be.true;
+  // expect(
+  //   scanInfoMatchesKey(
+  //     {
+  //       prefix: 'sa',
+  //       indexName: 'idx',
+  //       startSecondaryKey: 'sab',
+  //       startKey: 'pac',
+  //     },
+  //     'idx',
+  //     '\u0000sac\u0000pab',
+  //   ),
+  // ).to.be.false;
 });

--- a/src/subscriptions.test.ts
+++ b/src/subscriptions.test.ts
@@ -331,7 +331,7 @@ test('scanInfoMatchesKey limit optimizations', () => {
       '',
       'pab',
     ),
-  ).to.be.true;
+  ).to.be.false;
 
   // No limit
   expect(

--- a/src/subscriptions.ts
+++ b/src/subscriptions.ts
@@ -5,10 +5,7 @@ import type * as sync from './sync/mod';
 
 export type ScanSubrscriptionInfo = {
   options: db.ScanOptions;
-  lastKeyReadInfo?: {
-    key: string;
-    isInclusiveLimit: boolean;
-  };
+  inclusiveLimitKey?: string;
 };
 
 export type Subscription<R extends JSONValue | undefined, E> = {
@@ -130,12 +127,11 @@ function isKeyPastInclusiveLimit(
   scanInfo: ScanSubrscriptionInfo,
   changedKey: string,
 ): boolean {
-  const {lastKeyReadInfo} = scanInfo;
+  const {inclusiveLimitKey} = scanInfo;
   return (
     scanInfo.options.limit !== undefined &&
-    lastKeyReadInfo !== undefined &&
-    lastKeyReadInfo.isInclusiveLimit &&
-    changedKey > lastKeyReadInfo.key
+    inclusiveLimitKey !== undefined &&
+    changedKey > inclusiveLimitKey
   );
 }
 

--- a/src/subscriptions.ts
+++ b/src/subscriptions.ts
@@ -3,7 +3,7 @@ import type {ReadTransaction} from './transactions';
 import * as db from './db/mod';
 import type * as sync from './sync/mod';
 
-export type ScanSubrscriptionInfo = {
+export type ScanSubscriptionInfo = {
   options: db.ScanOptions;
   inclusiveLimitKey?: string;
 };
@@ -15,7 +15,7 @@ export type Subscription<R extends JSONValue | undefined, E> = {
   onDone?: () => void;
   lastValue?: R;
   keys: ReadonlySet<string>;
-  scans: ReadonlyArray<Readonly<ScanSubrscriptionInfo>>;
+  scans: ReadonlyArray<Readonly<ScanSubscriptionInfo>>;
 };
 
 function keyMatchesSubscription<V, E>(
@@ -42,7 +42,7 @@ function keyMatchesSubscription<V, E>(
 }
 
 export function scanInfoMatchesKey(
-  scanInfo: ScanSubrscriptionInfo,
+  scanInfo: ScanSubscriptionInfo,
   changeIndexName: string,
   changedKey: string,
 ): boolean {
@@ -124,7 +124,7 @@ export function scanInfoMatchesKey(
 }
 
 function isKeyPastInclusiveLimit(
-  scanInfo: ScanSubrscriptionInfo,
+  scanInfo: ScanSubscriptionInfo,
   changedKey: string,
 ): boolean {
   const {inclusiveLimitKey} = scanInfo;

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -107,11 +107,7 @@ export class ReadTransactionImpl<
 
   scan<Options extends ScanOptions, Key extends KeyTypeForScanOptions<Options>>(
     options?: Options,
-    onKey?: (
-      key: string,
-      isLastBeforeLimit: boolean,
-      isLastEntry: boolean,
-    ) => void,
+    onKey?: (key: string, isInclusiveLimit: boolean) => void,
   ): ScanResult<Key, Value> {
     const dbRead = this._dbtx;
     return new ScanResult(
@@ -162,9 +158,11 @@ export class SubscriptionTransactionWrapper implements ReadTransaction {
       options: toDbScanOptions(options),
     };
     this._scans.push(scanInfo);
-    return this._tx.scan(options, (key, isLastBeforeLimit, isLastEntry) => {
-      scanInfo.endInclusiveKey =
-        isLastEntry && !isLastBeforeLimit ? undefined : key;
+    return this._tx.scan(options, (key, isInclusiveLimit) => {
+      scanInfo.lastKeyReadInfo = {
+        key,
+        isInclusiveLimit,
+      };
     });
   }
 

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -107,7 +107,7 @@ export class ReadTransactionImpl<
 
   scan<Options extends ScanOptions, Key extends KeyTypeForScanOptions<Options>>(
     options?: Options,
-    onKey?: (key: string, isInclusiveLimit: boolean) => void,
+    onLimitKey?: (key: string) => void,
   ): ScanResult<Key, Value> {
     const dbRead = this._dbtx;
     return new ScanResult(

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -107,7 +107,7 @@ export class ReadTransactionImpl<
 
   scan<Options extends ScanOptions, Key extends KeyTypeForScanOptions<Options>>(
     options?: Options,
-    onLimitKey?: (key: string) => void,
+    onLimitKey?: (inclusiveLimitKey: string) => void,
   ): ScanResult<Key, Value> {
     const dbRead = this._dbtx;
     return new ScanResult(
@@ -115,7 +115,7 @@ export class ReadTransactionImpl<
       () => dbRead,
       false, // shouldCloseTransaction
       dbRead instanceof db.Write, // shouldClone,
-      onKey,
+      onLimitKey,
     );
   }
 }
@@ -158,11 +158,8 @@ export class SubscriptionTransactionWrapper implements ReadTransaction {
       options: toDbScanOptions(options),
     };
     this._scans.push(scanInfo);
-    return this._tx.scan(options, (key, isInclusiveLimit) => {
-      scanInfo.lastKeyReadInfo = {
-        key,
-        isInclusiveLimit,
-      };
+    return this._tx.scan(options, inclusiveLimitKey => {
+      scanInfo.inclusiveLimitKey = inclusiveLimitKey;
     });
   }
 

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -10,7 +10,7 @@ import * as db from './db/mod';
 import * as sync from './sync/mod';
 import type {LogContext} from './logger';
 import type {Hash} from './hash';
-import type {ScanSubrscriptionInfo} from './subscriptions';
+import type {ScanSubscriptionInfo} from './subscriptions';
 
 /**
  * ReadTransactions are used with [[Replicache.query]] and
@@ -124,7 +124,7 @@ export class ReadTransactionImpl<
 // for use with Subscriptions.
 export class SubscriptionTransactionWrapper implements ReadTransaction {
   private readonly _keys: Set<string> = new Set();
-  private readonly _scans: ScanSubrscriptionInfo[] = [];
+  private readonly _scans: ScanSubscriptionInfo[] = [];
   private readonly _tx: ReadTransactionImpl;
 
   constructor(tx: ReadTransactionImpl) {
@@ -154,7 +154,7 @@ export class SubscriptionTransactionWrapper implements ReadTransaction {
   scan<Options extends ScanOptions, Key extends KeyTypeForScanOptions<Options>>(
     options?: Options,
   ): ScanResult<Key, ReadonlyJSONValue> {
-    const scanInfo: ScanSubrscriptionInfo = {
+    const scanInfo: ScanSubscriptionInfo = {
       options: toDbScanOptions(options),
     };
     this._scans.push(scanInfo);
@@ -167,7 +167,7 @@ export class SubscriptionTransactionWrapper implements ReadTransaction {
     return this._keys;
   }
 
-  get scans(): ScanSubrscriptionInfo[] {
+  get scans(): ScanSubscriptionInfo[] {
     return this._scans;
   }
 }


### PR DESCRIPTION
### Problem 

Right now we do not use `limit` when determining if a `scan` is affected by a key.(https://github.com/rocicorp/replicache/blob/2d2340227184c058bcb49ed1070bf129eb7a0385/src/subscriptions.ts#L39). 

We only use the `startKey` and `prefix`. This means that if we have something like:

```js
rep.subscripe(tx => {
  for await (const entry of tx.scan({startKey: 'a', limit: 5}) {
     console.log(e);
  }
}, {onData() {});
```

we cannot tell whether a change to key `'x'` should affect the subscription function.

### Solution

Inside `SubscriptionTransactionWrapper`'s `scan` method.
- We currently only store a `ScanOptions` for each scan, update to store a `ScanSubrscriptionInfo`, consisting of `ScanOptions` and the new field `inclusiveLimitKey`. `inclusiveLimitKey` will be populated based on a callback driven by the scan implementation in `btree/node.ts` (this callback has to be threaded through a few layers)
- Then in `scanOptionsMatchesKey` we know that a key does not match if there is a limit and the changed key is greater than the inclusiveLimitKey.  This works for both `prefix`, `startKey`, and a combination of `prefix` and `startKey`.  

Note this optimization is only applied when a subscription reads its scan to its limit (it choses to stop early, or it runs out of entries).   We can optimize some cases where a subscription does not read its scan to its limit, however these optimization are only correct if the subscription body is a pure function on the replicache store state.  Subscription bodies should be pure in this way, but so far replicache behavior is correct even if they are not pure. We chose to not implement these further optimizations, erroring on the side of correctness over performance.  We can of course revisit this if it turns out not reading a scan to its limit is a common use case.  


### Perf measurements

This greatly improves writeSubRead benchmark performance when random invalidates are used, **reducing the median time by ~70%**.  This benchmark uses 128 scans each using startKey and limit.   

Made on my M1 Max w 64 GB of memory

Before this optimization:
```
[MemStore] writeSubRead randomInvalidates false 100MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=2.50/4.00/11.40/11.40 ms avg=4.56 ms (7 runs sampled)
[MemStore] writeSubRead randomInvalidates true 100MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=9.50/12.70/19.70/19.70 ms avg=12.69 ms (7 runs sampled)
```

With this optimization:
```
Running 2 benchmarks on Chromium...
[MemStore] writeSubRead randomInvalidates false 100MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=2.50/4.20/10.70/10.70 ms avg=4.49 ms (7 runs sampled)
[MemStore] writeSubRead randomInvalidates true 100MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=3.00/4.40/11.10/11.10 ms avg=4.99 ms (7 runs sampled)
Done!
```

Closes #666
