### PR TITLE
feat: Take 2 - Update WriteSubRead benchmark to invalidate random keys (instead of a fixed set)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@esm-bundle/chai": "^4.3.4",
+        "@types/lodash-es": "^4.17.5",
         "@types/mocha": "^8.2.2",
         "@types/sinon": "^10.0.3",
         "@types/web-locks-api": "^0.0.1",
@@ -31,6 +32,7 @@
         "fetch-mock": "^9.11.0",
         "get-port": "^5.1.1",
         "idb": "^6.1.4",
+        "lodash-es": "^4.17.21",
         "navigator.locks": "^0.8.1",
         "playwright": "^1.15.0",
         "prettier": "^2.4.1",
@@ -839,6 +841,21 @@
       "dev": true,
       "dependencies": {
         "@types/koa": "*"
+      }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.176",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.176.tgz",
+      "integrity": "sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ==",
+      "dev": true
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.5.tgz",
+      "integrity": "sha512-SHBoI8/0aoMQWAgUHMQ599VM6ZiSKg8sh/0cFqqlQQMyY9uEplc0ULU5yQNzcvdR4ZKa0ey8+vFmahuRbOCT1A==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
       }
     },
     "node_modules/@types/mime": {
@@ -3913,6 +3930,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -6527,6 +6550,21 @@
         "@types/koa": "*"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.176",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.176.tgz",
+      "integrity": "sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ==",
+      "dev": true
+    },
+    "@types/lodash-es": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.5.tgz",
+      "integrity": "sha512-SHBoI8/0aoMQWAgUHMQ599VM6ZiSKg8sh/0cFqqlQQMyY9uEplc0ULU5yQNzcvdR4ZKa0ey8+vFmahuRbOCT1A==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -8817,6 +8855,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "dev": true
     },
     "lodash.camelcase": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
+    "@types/lodash-es": "^4.17.5",
     "@types/mocha": "^8.2.2",
     "@types/sinon": "^10.0.3",
     "@types/web-locks-api": "^0.0.1",
@@ -37,6 +38,7 @@
     "fetch-mock": "^9.11.0",
     "get-port": "^5.1.1",
     "idb": "^6.1.4",
+    "lodash-es": "^4.17.21",
     "navigator.locks": "^0.8.1",
     "playwright": "^1.15.0",
     "prettier": "^2.4.1",

--- a/perf/replicache.ts
+++ b/perf/replicache.ts
@@ -11,6 +11,7 @@ import {
 } from '../src/mod';
 import {jsonArrayTestData, TestDataObject, jsonObjectTestData} from './data';
 import type {Bencher, Benchmark} from './perf';
+import { range, sampleSize } from 'lodash-es';
 
 export function benchmarkPopulate(opts: {
   numKeys: number;
@@ -236,8 +237,8 @@ export function benchmarkWriteSubRead(opts: {
       // Build our random changes ahead of time, outside the timed window.
       // invalidate numSubsDirty different subscriptions by writing to the first key each is scanning.
       const changes = new Map(
-        Array.from({length: numSubsDirty}).map((_, i) => [
-          sortedKeys[i * keysPerSub],
+        sampleSize(range(numSubsTotal), numSubsDirty).map(v => [
+          sortedKeys[v * keysPerSub],
           jsonObjectTestData(valueSize),
         ]),
       );

--- a/perf/replicache.ts
+++ b/perf/replicache.ts
@@ -11,7 +11,7 @@ import {
 } from '../src/mod';
 import {jsonArrayTestData, TestDataObject, jsonObjectTestData} from './data';
 import type {Bencher, Benchmark} from './perf';
-import { range, sampleSize } from 'lodash-es';
+import {range, sampleSize} from 'lodash-es';
 
 export function benchmarkPopulate(opts: {
   numKeys: number;


### PR DESCRIPTION
Now using 'lodash-es' (the 'lodash.range' and 'lodash.samplesize' were cjs modules).  