### PR TITLE
feat: Setup dashboard and alerts for bundle sizes

### DIFF
--- a/.github/workflows/bundle-sizes.js.yml
+++ b/.github/workflows/bundle-sizes.js.yml
@@ -15,9 +15,10 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 16.x
-
+      - run: npm install
+      
       # Builds bundles then measures bundles sizes and stores them to a file
-      - name: Run benchmark
+      - name: Build and measure bundles
         run: npm run build && node perf/bundle-sizes | tee bundle-sizes.json
 
       # Run `github-action-benchmark` action

--- a/.github/workflows/bundle-sizes.js.yml
+++ b/.github/workflows/bundle-sizes.js.yml
@@ -16,8 +16,6 @@ jobs:
         with:
           node-version: 16.x
 
-      - run: npm ci
-
       # Run benchmark and stores the output to a file
       - name: Run benchmark
         run: npm run build && node perf/bundle-sizes | tee bundle-sizes.json

--- a/.github/workflows/bundle-sizes.js.yml
+++ b/.github/workflows/bundle-sizes.js.yml
@@ -1,0 +1,35 @@
+name: Bundle Sizes
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  benchmark:
+    name: Bundle sizes check
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+
+      # Run benchmark and stores the output to a file
+      - name: Run benchmark
+        run: npm run build && node perf/bundle-sizes | tee bundle-sizes.json
+
+      # Run `github-action-benchmark` action
+      - name: Store benchmark result
+        uses: rhysd/github-action-benchmark@v1
+        with:
+          # What benchmark tool the output.json came from
+        tool: 'customSmallerIsBetter'
+          # Where the output from the benchmark tool is stored
+          output-file-path: bundle-sizes.json
+          # Workflow will fail when an alert happens
+          fail-on-alert: true
+          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          benchmark-data-dir-path: bundle-sizes
+          auto-push: true
+          alert-threshold: '105%'
+          comment-on-alert: true

--- a/.github/workflows/bundle-sizes.js.yml
+++ b/.github/workflows/bundle-sizes.js.yml
@@ -3,7 +3,8 @@ name: Bundle Sizes
 on:
   push:
     branches: [main]
-
+  pull_request:
+    branches: [main]
 jobs:
   benchmark:
     name: Bundle sizes check
@@ -30,6 +31,6 @@ jobs:
           fail-on-alert: true
           github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           benchmark-data-dir-path: bundle-sizes
-          auto-push: true
+          #auto-push: true
           alert-threshold: '105%'
           comment-on-alert: true

--- a/.github/workflows/bundle-sizes.js.yml
+++ b/.github/workflows/bundle-sizes.js.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           node-version: 16.x
 
+      - run: npm ci
+
       # Run benchmark and stores the output to a file
       - name: Run benchmark
         run: npm run build && node perf/bundle-sizes | tee bundle-sizes.json

--- a/.github/workflows/bundle-sizes.js.yml
+++ b/.github/workflows/bundle-sizes.js.yml
@@ -3,8 +3,6 @@ name: Bundle Sizes
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 jobs:
   benchmark:
@@ -21,20 +19,20 @@ jobs:
       - name: Build and measure bundles
         run: npm run build && node perf/bundle-sizes | tee bundle-sizes.json
 
+      # install above may have modified package-lock, in which case
+      # rhysd/github-action-benchmark@v1 will error when trying to switch
+      # branches to commit the new data to the gh-pages branch
       - run: git restore package-lock.json
 
       # Run `github-action-benchmark` action
-      - name: Store benchmark result
+      - name: Store bundle size
         uses: rhysd/github-action-benchmark@v1
         with:
-          # What benchmark tool the output.json came from
           tool: 'customSmallerIsBetter'
-          # Where the output from the benchmark tool is stored
           output-file-path: bundle-sizes.json
-          # Workflow will fail when an alert happens
           fail-on-alert: true
           github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           benchmark-data-dir-path: bundle-sizes
-          auto-push: false
+          auto-push: true
           alert-threshold: '105%'
           comment-on-alert: true

--- a/.github/workflows/bundle-sizes.js.yml
+++ b/.github/workflows/bundle-sizes.js.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Build and measure bundles
         run: npm run build && node perf/bundle-sizes | tee bundle-sizes.json
 
+      - run: git restore package-lock.json
+
       # Run `github-action-benchmark` action
       - name: Store benchmark result
         uses: rhysd/github-action-benchmark@v1

--- a/.github/workflows/bundle-sizes.js.yml
+++ b/.github/workflows/bundle-sizes.js.yml
@@ -5,9 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+
 jobs:
   benchmark:
-    name: Bundle sizes check
+    name: Bundle Sizes Check
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/bundle-sizes.js.yml
+++ b/.github/workflows/bundle-sizes.js.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 16.x
 
-      # Run benchmark and stores the output to a file
+      # Builds bundles then measures bundles sizes and stores them to a file
       - name: Run benchmark
         run: npm run build && node perf/bundle-sizes | tee bundle-sizes.json
 
@@ -25,13 +25,13 @@ jobs:
         uses: rhysd/github-action-benchmark@v1
         with:
           # What benchmark tool the output.json came from
-        tool: 'customSmallerIsBetter'
+          tool: 'customSmallerIsBetter'
           # Where the output from the benchmark tool is stored
           output-file-path: bundle-sizes.json
           # Workflow will fail when an alert happens
           fail-on-alert: true
           github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           benchmark-data-dir-path: bundle-sizes
-          #auto-push: true
+          auto-push: false
           alert-threshold: '105%'
           comment-on-alert: true

--- a/perf/bundle-sizes.js
+++ b/perf/bundle-sizes.js
@@ -1,0 +1,57 @@
+/* eslint-env node, es2020 */
+
+import commandLineArgs from 'command-line-args';
+import commandLineUsage from 'command-line-usage';
+import * as path from 'path';
+import {promises as fs} from 'fs';
+
+async function main() {
+  const optionDefinitions = [
+    {
+      name: 'bundles',
+      multiple: true,
+      defaultValue: ['replicache.js', 'replicache.mjs'],
+      description: 'bundle files whose sizes should be included in output',
+    },
+    {
+      name: 'dir',
+      defaultValue: './out',
+      description: 'directory where bundles are located',
+    },
+    {
+      name: 'help',
+      alias: 'h',
+      type: Boolean,
+      description: 'Show this help message',
+    },
+  ];
+  const options = commandLineArgs(optionDefinitions);
+  if (options.help) {
+    console.log(
+      commandLineUsage([
+        {content: 'Usage: module-sizes [options...]'},
+        {optionList: optionDefinitions},
+      ]),
+    );
+    process.exit();
+  }
+
+  const jsonEntries = [];
+  for (const bundle of options.bundles) {
+    const stats = await fs.stat(
+      path.join(options.dir, bundle),
+    );
+    jsonEntries.push({
+      name: `${bundle} size`,
+      unit: 'bytes',
+      value: stats.size
+    })
+  }
+
+  process.stdout.write(JSON.stringify(jsonEntries, undefined, 2) + '\n');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/perf/bundle-sizes.js
+++ b/perf/bundle-sizes.js
@@ -38,14 +38,12 @@ async function main() {
 
   const jsonEntries = [];
   for (const bundle of options.bundles) {
-    const stats = await fs.stat(
-      path.join(options.dir, bundle),
-    );
+    const stats = await fs.stat(path.join(options.dir, bundle));
     jsonEntries.push({
       name: `${bundle} size`,
       unit: 'bytes',
-      value: stats.size
-    })
+      value: stats.size,
+    });
   }
 
   process.stdout.write(JSON.stringify(jsonEntries, undefined, 2) + '\n');


### PR DESCRIPTION
### Problem
We are missing a way to see bundle size changes over time (i.e. across commits).  It would also be nice to get alerts when bundle sizes increase by more than a small percent.

### Solution

- Create a small node script that outputs the bundle sizes in the format needed for the github-action-benchmark customSmallerIsBetter tool.  
- Set up yml for github action that will run this script and use github-action-benchmark to graph the sizes on a new dashboard at https://rocicorp.github.io/replicache/bundle-sizes/
- Also configure an alert for when bundle sizes increase by more than **5%.** 

Closes #125 