### PR TITLE
feat: Add Brotli compressed bundle sizes to Bundle Sizes dashboard

### DIFF
--- a/.github/workflows/bundle-sizes.js.yml
+++ b/.github/workflows/bundle-sizes.js.yml
@@ -16,10 +16,12 @@ jobs:
         with:
           node-version: 16.x
       - run: npm install
+      - run: npm run build
+      - run: brotli ./out/*
       
       # Builds bundles then measures bundles sizes and stores them to a file
       - name: Build and measure bundles
-        run: npm run build && brotli ./out/* && node perf/bundle-sizes | tee bundle-sizes.json
+        run: node perf/bundle-sizes --bundles replicache.js replicache.js.br replicache.mjs replicache.mjs.br | tee bundle-sizes.json
 
       # install above may have modified package-lock, in which case
       # rhysd/github-action-benchmark@v1 will error when trying to switch

--- a/.github/workflows/bundle-sizes.js.yml
+++ b/.github/workflows/bundle-sizes.js.yml
@@ -3,8 +3,6 @@ name: Bundle Sizes
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 jobs:
   benchmark:
@@ -20,7 +18,7 @@ jobs:
       - run: brotli ./out/*
       
       # Builds bundles then measures bundles sizes and stores them to a file
-      - name: Build and measure bundles
+      - name: Measure bundles
         run: node perf/bundle-sizes --bundles replicache.js replicache.js.br replicache.mjs replicache.mjs.br | tee bundle-sizes.json
 
       # install above may have modified package-lock, in which case

--- a/.github/workflows/bundle-sizes.js.yml
+++ b/.github/workflows/bundle-sizes.js.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Store bundle size
         uses: rhysd/github-action-benchmark@v1
         with:
+          name: 'Bundle Sizes'
           tool: 'customSmallerIsBetter'
           output-file-path: bundle-sizes.json
           fail-on-alert: true

--- a/.github/workflows/bundle-sizes.js.yml
+++ b/.github/workflows/bundle-sizes.js.yml
@@ -9,18 +9,17 @@ on:
 jobs:
   benchmark:
     name: Bundle Sizes Check
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 16.x
-      - run: apt-get install -y --no-install-recommends brotli
       - run: npm install
       
       # Builds bundles then measures bundles sizes and stores them to a file
       - name: Build and measure bundles
-        run: npm run build && brotli ./out/ && node perf/bundle-sizes | tee bundle-sizes.json
+        run: npm run build && brotli ./out/* && node perf/bundle-sizes | tee bundle-sizes.json
 
       # install above may have modified package-lock, in which case
       # rhysd/github-action-benchmark@v1 will error when trying to switch

--- a/.github/workflows/bundle-sizes.js.yml
+++ b/.github/workflows/bundle-sizes.js.yml
@@ -3,6 +3,8 @@ name: Bundle Sizes
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   benchmark:
@@ -17,7 +19,7 @@ jobs:
       
       # Builds bundles then measures bundles sizes and stores them to a file
       - name: Build and measure bundles
-        run: npm run build && node perf/bundle-sizes | tee bundle-sizes.json
+        run: npm run build && brotli ./out/ && node perf/bundle-sizes | tee bundle-sizes.json
 
       # install above may have modified package-lock, in which case
       # rhysd/github-action-benchmark@v1 will error when trying to switch

--- a/.github/workflows/bundle-sizes.js.yml
+++ b/.github/workflows/bundle-sizes.js.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 16.x
+      - run: apt-get install -y --no-install-recommends brotli
       - run: npm install
       
       # Builds bundles then measures bundles sizes and stores them to a file

--- a/perf/bundle-sizes.js
+++ b/perf/bundle-sizes.js
@@ -40,7 +40,9 @@ async function main() {
   for (const bundle of options.bundles) {
     const stats = await fs.stat(path.join(options.dir, bundle));
     jsonEntries.push({
-      name: `Size of ${bundle}${bundle.endsWith('.br') ? ' (Brotli compressed)' :''}`,
+      name: `Size of ${bundle}${
+        bundle.endsWith('.br') ? ' (Brotli compressed)' : ''
+      }`,
       unit: 'bytes',
       value: stats.size,
     });

--- a/perf/bundle-sizes.js
+++ b/perf/bundle-sizes.js
@@ -40,7 +40,7 @@ async function main() {
   for (const bundle of options.bundles) {
     const stats = await fs.stat(path.join(options.dir, bundle));
     jsonEntries.push({
-      name: `Size of ${bundle}`,
+      name: `Size of ${bundle}${bundle.endsWith('.br') ? ' (Brotli compressed)' :''}`,
       unit: 'bytes',
       value: stats.size,
     });

--- a/perf/bundle-sizes.js
+++ b/perf/bundle-sizes.js
@@ -40,7 +40,7 @@ async function main() {
   for (const bundle of options.bundles) {
     const stats = await fs.stat(path.join(options.dir, bundle));
     jsonEntries.push({
-      name: `${bundle} size`,
+      name: `Size of ${bundle}`,
       unit: 'bytes',
       value: stats.size,
     });


### PR DESCRIPTION
### Problem
Bundle Size dashboard https://rocicorp.github.io/replicache/bundle-sizes/ and associated alerts currently only track non-compressed sizes of bundles.  What we really care about is Brotli compressed size.

### Solution
Add Brotli compressed sizes of bundles to dashboard and alert.
To do this needed to move from `self-hosted` runner to `ubuntu-latest` as `brotli` command was not available in the `self-hosted` environment (but is in `ubuntu-latest`).  This is fine as we don't care about cpu/memory isolation for this benchmark as we do for the performance benchmarks, because we are just measuring byte size.