### PR TITLE
feat: Functionality for managing the ClientMap needed for Simplified Dueling Dags

### DIFF
--- a/src/json.ts
+++ b/src/json.ts
@@ -1,4 +1,4 @@
-import {throwInvalidType} from './asserts';
+import {assertObject, throwInvalidType} from './asserts';
 import {hasOwn} from './has-own';
 
 /** The values that can be represented in JSON */
@@ -178,12 +178,13 @@ export function assertJSONValue(v: unknown): asserts v is JSONValue {
       if (Array.isArray(v)) {
         return assertJSONArray(v);
       }
-      return assertJSONObject(v as Record<string, unknown>);
+      return assertJSONObject(v);
   }
   throwInvalidType(v, 'JSON value');
 }
 
-function assertJSONObject(v: Record<string, unknown>): asserts v is JSONObject {
+export function assertJSONObject(v: unknown): asserts v is JSONObject {
+  assertObject(v);
   for (const k in v) {
     if (hasOwn(v, k)) {
       const val = v[k];
@@ -196,6 +197,7 @@ function assertJSONObject(v: Record<string, unknown>): asserts v is JSONObject {
     }
   }
 }
+
 function assertJSONArray(v: unknown[]): asserts v is JSONValue[] {
   for (let i = 0; i < v.length; i++) {
     const val = v[i];

--- a/src/sync/clients.test.ts
+++ b/src/sync/clients.test.ts
@@ -1,0 +1,528 @@
+import {expect} from '@esm-bundle/chai';
+import {MemStore} from '../kv/mod';
+import * as dag from '../dag/mod';
+import {assertHash, hashOf, initHasher, newTempHash} from '../hash';
+import {getClient, getClients, setClient, setClients} from './clients';
+
+setup(async () => {
+  await initHasher();
+});
+
+test('getClients with no existing ClientMap in dag store', async () => {
+  const dagStore = new dag.Store(new MemStore());
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap.size).to.equal(0);
+  });
+});
+
+test('setClients and getClients', async () => {
+  const dagStore = new dag.Store(new MemStore());
+  const clientMap = new Map(
+    Object.entries({
+      client1: {
+        heartbeatTimestampMs: 1000,
+        headHash: hashOf('head of commit client1 is currently at'),
+      },
+      client2: {
+        heartbeatTimestampMs: 3000,
+        headHash: hashOf('head of commit client2 is currently at'),
+      },
+    }),
+  );
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClients(clientMap, write);
+    return write.commit();
+  });
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(clientMap);
+  });
+});
+
+test('setClients and getClients sequence', async () => {
+  const dagStore = new dag.Store(new MemStore());
+  const clientMap1 = new Map(
+    Object.entries({
+      client1: {
+        heartbeatTimestampMs: 1000,
+        headHash: hashOf('head of commit client1 is currently at'),
+      },
+      client2: {
+        heartbeatTimestampMs: 3000,
+        headHash: hashOf('head of commit client2 is currently at'),
+      },
+    }),
+  );
+
+  const clientMap2 = new Map(
+    Object.entries({
+      client3: {
+        heartbeatTimestampMs: 4000,
+        headHash: hashOf('head of commit client3 is currently at'),
+      },
+    }),
+  );
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClients(clientMap1, write);
+    return write.commit();
+  });
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap1 = await getClients(read);
+    expect(readClientMap1).to.deep.equal(clientMap1);
+  });
+
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClients(clientMap2, write);
+    return write.commit();
+  });
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap2 = await getClients(read);
+    expect(readClientMap2).to.deep.equal(clientMap2);
+  });
+});
+
+test('setClients properly manages refs to client heads when clients are removed and added', async () => {
+  const dagStore = new dag.Store(new MemStore());
+  const client1HeadHash = hashOf('head of commit client1 is currently at');
+  const client2HeadHash = hashOf('head of commit client2 is currently at');
+
+  const clientMap1 = new Map(
+    Object.entries({
+      client1: {
+        heartbeatTimestampMs: 1000,
+        headHash: client1HeadHash,
+      },
+      client2: {
+        heartbeatTimestampMs: 3000,
+        headHash: client2HeadHash,
+      },
+    }),
+  );
+
+  const client3HeadHash = hashOf('head of commit client3 is currently at');
+  const clientMap2 = new Map(
+    Object.entries({
+      client3: {
+        heartbeatTimestampMs: 4000,
+        headHash: client3HeadHash,
+      },
+    }),
+  );
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClients(clientMap1, write);
+    return write.commit();
+  });
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const clientsHash = await read.getHead('clients');
+    assertHash(clientsHash);
+    const clientsChunk = await read.getChunk(clientsHash);
+    expect(clientsChunk?.meta).to.deep.equal([
+      client1HeadHash,
+      client2HeadHash,
+    ]);
+  });
+
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClients(clientMap2, write);
+    return write.commit();
+  });
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const clientsHash = await read.getHead('clients');
+    assertHash(clientsHash);
+    const clientsChunk = await read.getChunk(clientsHash);
+    expect(clientsChunk?.meta).to.deep.equal([client3HeadHash]);
+  });
+});
+
+test('setClients properly manages refs to client heads when client head changes', async () => {
+  const dagStore = new dag.Store(new MemStore());
+  const client1V1HeadHash = hashOf('head of commit client1 is currently at');
+  const client1V2HeadHash = hashOf(
+    'head of new commit client1 is currently at',
+  );
+  const client2HeadHash = hashOf('head of commit client2 is currently at');
+
+  const client1V1 = {
+    heartbeatTimestampMs: 1000,
+    headHash: client1V1HeadHash,
+  };
+  const client1V2 = {
+    heartbeatTimestampMs: 2000,
+    headHash: client1V2HeadHash,
+  };
+  const client2 = {
+    heartbeatTimestampMs: 3000,
+    headHash: client2HeadHash,
+  };
+
+  const clientMap1 = new Map(
+    Object.entries({
+      client1: client1V1,
+      client2,
+    }),
+  );
+
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClients(clientMap1, write);
+    return write.commit();
+  });
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const clientsHash = await read.getHead('clients');
+    assertHash(clientsHash);
+    const clientsChunk = await read.getChunk(clientsHash);
+    expect(clientsChunk?.meta).to.deep.equal([
+      client1V1HeadHash,
+      client2HeadHash,
+    ]);
+  });
+
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClients(
+      new Map(
+        Object.entries({
+          client1: client1V2,
+          client2,
+        }),
+      ),
+      write,
+    );
+    return write.commit();
+  });
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const clientsHash = await read.getHead('clients');
+    assertHash(clientsHash);
+    const clientsChunk = await read.getChunk(clientsHash);
+    expect(clientsChunk?.meta).to.deep.equal([
+      client1V2HeadHash,
+      client2HeadHash,
+    ]);
+  });
+});
+
+test('setClient properly manages refs to client heads', async () => {
+  const dagStore = new dag.Store(new MemStore());
+  const client1V1HeadHash = hashOf('head of commit client1 is currently at');
+  const client1V2HeadHash = hashOf(
+    'head of new commit client1 is currently at',
+  );
+  const client2HeadHash = hashOf('head of commit client2 is currently at');
+
+  const client1V1 = {
+    heartbeatTimestampMs: 1000,
+    headHash: client1V1HeadHash,
+  };
+  const client1V2 = {
+    heartbeatTimestampMs: 2000,
+    headHash: client1V2HeadHash,
+  };
+  const client2 = {
+    heartbeatTimestampMs: 3000,
+    headHash: client2HeadHash,
+  };
+
+  const clientMap1 = new Map(
+    Object.entries({
+      client1: client1V1,
+      client2,
+    }),
+  );
+
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClients(clientMap1, write);
+    return write.commit();
+  });
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const clientsHash = await read.getHead('clients');
+    assertHash(clientsHash);
+    const clientsChunk = await read.getChunk(clientsHash);
+    expect(clientsChunk?.meta).to.deep.equal([
+      client1V1HeadHash,
+      client2HeadHash,
+    ]);
+  });
+
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClient('client1', client1V2, write);
+    return write.commit();
+  });
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const clientsHash = await read.getHead('clients');
+    assertHash(clientsHash);
+    const clientsChunk = await read.getChunk(clientsHash);
+    expect(clientsChunk?.meta).to.deep.equal([
+      client1V2HeadHash,
+      client2HeadHash,
+    ]);
+  });
+});
+
+test('getClient', async () => {
+  const dagStore = new dag.Store(new MemStore());
+  const client1 = {
+    heartbeatTimestampMs: 1000,
+    headHash: hashOf('head of commit client1 is currently at'),
+  };
+  const clientMap = new Map(
+    Object.entries({
+      client1,
+      client2: {
+        heartbeatTimestampMs: 3000,
+        headHash: hashOf('head of commit client2 is currently at'),
+      },
+    }),
+  );
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClients(clientMap, write);
+    return write.commit();
+  });
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClient1 = await getClient('client1', read);
+    expect(readClient1).to.deep.equal(client1);
+  });
+});
+
+test('setClient with existing client id', async () => {
+  const dagStore = new dag.Store(new MemStore());
+  const client1V1 = {
+    heartbeatTimestampMs: 1000,
+    headHash: hashOf('head of commit client1 is currently at'),
+  };
+  const client1V2 = {
+    heartbeatTimestampMs: 2000,
+    headHash: hashOf('head of new commit client1 is currently at'),
+  };
+  const client2 = {
+    heartbeatTimestampMs: 3000,
+    headHash: hashOf('head of commit client2 is currently at'),
+  };
+  const clientMap = new Map(
+    Object.entries({
+      client1: client1V1,
+      client2,
+    }),
+  );
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClients(clientMap, write);
+    return write.commit();
+  });
+
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClient('client1', client1V2, write);
+    return write.commit();
+  });
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(
+      new Map(
+        Object.entries({
+          client1: client1V2,
+          client2,
+        }),
+      ),
+    );
+  });
+});
+
+test('setClient with new client id', async () => {
+  const dagStore = new dag.Store(new MemStore());
+  const client1 = {
+    heartbeatTimestampMs: 1000,
+    headHash: hashOf('head of commit client1 is currently at'),
+  };
+  const client2 = {
+    heartbeatTimestampMs: 3000,
+    headHash: hashOf('head of commit client2 is currently at'),
+  };
+  const client3 = {
+    heartbeatTimestampMs: 5000,
+    headHash: hashOf('head of commit client3 is currently at'),
+  };
+  const clientMap = new Map(
+    Object.entries({
+      client1,
+      client2,
+    }),
+  );
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClients(clientMap, write);
+    return write.commit();
+  });
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClient('client3', client3, write);
+    return write.commit();
+  });
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(
+      new Map(
+        Object.entries({
+          client1,
+          client2,
+          client3,
+        }),
+      ),
+    );
+  });
+});
+
+test('setClients throws error if any client headHash is a temp hash', async () => {
+  const dagStore = new dag.Store(new MemStore());
+  const client1 = {
+    heartbeatTimestampMs: 1000,
+    headHash: hashOf('head of commit client1 is currently at'),
+  };
+  const client2 = {
+    heartbeatTimestampMs: 3000,
+    headHash: hashOf('head of commit client2 is currently at'),
+  };
+  const clientMap = new Map(
+    Object.entries({
+      client1,
+      client2,
+    }),
+  );
+
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClients(clientMap, write);
+    return write.commit();
+  });
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(clientMap);
+  });
+
+  await dagStore.withWrite(async (write: dag.Write) => {
+    const clientMapWTempHash = new Map(
+      Object.entries({
+        client1,
+        client2: {
+          heartbeatTimestampMs: 3000,
+          headHash: newTempHash(),
+        },
+      }),
+    );
+    let e;
+    try {
+      await setClients(clientMapWTempHash, write);
+    } catch (ex) {
+      e = ex;
+    }
+    expect(e).to.be.instanceOf(Error);
+    return write.commit();
+  });
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(clientMap);
+  });
+});
+
+test('setClient throws error if client headHash is a temp hash', async () => {
+  const dagStore = new dag.Store(new MemStore());
+  const client1 = {
+    heartbeatTimestampMs: 1000,
+    headHash: hashOf('head of commit client1 is currently at'),
+  };
+  const client2 = {
+    heartbeatTimestampMs: 3000,
+    headHash: hashOf('head of commit client2 is currently at'),
+  };
+  const clientMap = new Map(
+    Object.entries({
+      client1,
+      client2,
+    }),
+  );
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClients(clientMap, write);
+    return write.commit();
+  });
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(clientMap);
+  });
+
+  await dagStore.withWrite(async (write: dag.Write) => {
+    let e;
+    try {
+      await setClient(
+        'client2',
+        {
+          heartbeatTimestampMs: 3000,
+          headHash: newTempHash(),
+        },
+        write,
+      );
+    } catch (ex) {
+      e = ex;
+    }
+    expect(e).to.be.instanceOf(Error);
+    return write.commit();
+  });
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(clientMap);
+  });
+});
+
+test('getClients throws errors if clients head exist but the chunk it refrences does not', async () => {
+  const dagStore = new dag.Store(new MemStore());
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await write.setHead('clients', hashOf('random stuff'));
+    return write.commit();
+  });
+  await dagStore.withRead(async (read: dag.Read) => {
+    let e;
+    try {
+      await getClients(read);
+    } catch (ex) {
+      e = ex;
+    }
+    expect(e).to.be.instanceOf(Error);
+  });
+});
+
+test('getClients throws errors if chunk pointed to by clients head does not contain a valid ClientMap', async () => {
+  const dagStore = new dag.Store(new MemStore());
+  await dagStore.withWrite(async (write: dag.Write) => {
+    const headHash = hashOf('head of commit client1 is currently at');
+    const chunk = dag.Chunk.new(
+      {
+        heartbeatTimestampMs: 'this should be a number',
+        headHash,
+      },
+      [headHash],
+    );
+
+    await Promise.all([
+      write.putChunk(chunk),
+      write.setHead('clients', chunk.hash),
+    ]);
+    return write.commit();
+  });
+  await dagStore.withRead(async (read: dag.Read) => {
+    let e;
+    try {
+      await getClients(read);
+    } catch (ex) {
+      e = ex;
+    }
+    expect(e).to.be.instanceOf(Error);
+  });
+});

--- a/src/sync/clients.ts
+++ b/src/sync/clients.ts
@@ -1,0 +1,90 @@
+import {assertHash, assertNotTempHash, Hash} from './../hash';
+import * as dag from '../dag/mod';
+import type {ReadonlyJSONValue} from '../json';
+import {assertNumber, assertObject} from '../asserts';
+import {hasOwn} from '../has-own';
+
+// TODO: Make ClientID an opaque type
+type ClientID = string;
+type ClientMap = Map<ClientID, Client>;
+
+type Client = {
+  // A UNIX timestamp in milliseconds updated by the client once a minute
+  // while it is active and everytime the client persists its state to
+  // the perdag.
+  heartbeatTimestampMs: number;
+  // The hash of the commit this session is currently at.
+  headHash: Hash;
+};
+const CLIENTS_HEAD = 'clients';
+
+function assertClient(value: unknown): asserts value is Client {
+  assertObject(value);
+  const {heartbeatTimestampMs, headHash} = value;
+  assertNumber(heartbeatTimestampMs);
+  assertHash(headHash);
+}
+
+function chunkDataToClientMap(chunkData?: ReadonlyJSONValue): ClientMap {
+  assertObject(chunkData);
+  const clients: ClientMap = new Map();
+  for (const key in chunkData) {
+    if (hasOwn(chunkData, key)) {
+      const value = chunkData[key];
+      if (value !== undefined) {
+        assertClient(value);
+        clients.set(key, value);
+      }
+    }
+  }
+  return clients;
+}
+
+function clientMapToChunkData(clients: ClientMap): ReadonlyJSONValue {
+  clients.forEach(client => {
+    assertNotTempHash(client.headHash);
+  });
+  return Object.fromEntries(clients);
+}
+
+export async function getClients(dagRead: dag.Read): Promise<ClientMap> {
+  const hash = await dagRead.getHead(CLIENTS_HEAD);
+  if (!hash) {
+    return new Map();
+  }
+  const chunk = await dagRead.getChunk(hash);
+  return chunkDataToClientMap(chunk?.data);
+}
+
+export async function getClient(
+  id: ClientID,
+  dagRead: dag.Read,
+): Promise<Client | undefined> {
+  const clients = await getClients(dagRead);
+  return clients.get(id);
+}
+
+export function setClients(
+  clients: ClientMap,
+  dagWrite: dag.Write,
+): Promise<void> {
+  const chunkData = clientMapToChunkData(clients);
+  const chunk = dag.Chunk.new(
+    chunkData,
+    Array.from(clients.values()).map(client => client.headHash),
+  );
+  return Promise.all([
+    dagWrite.putChunk(chunk),
+    dagWrite.setHead(CLIENTS_HEAD, chunk.hash),
+  ]).then(() => undefined);
+}
+
+export async function setClient(
+  id: ClientID,
+  client: Client,
+  dagWrite: dag.Write,
+): Promise<void> {
+  const clients = await getClients(dagWrite);
+  clients.set(id, client);
+  return setClients(clients, dagWrite);
+}


### PR DESCRIPTION
In the Simplified Dueling Dags design for Realtime Persistence, each tab is a `client` and has its own `perdag` - an instance of `dag.Store` backed by IDB.  All tabs' `perdag` instances are backed by the same IDB object store, thus they share physical storage. 

To keep track of each client's current `headHash` (and additional metadata such as heartbeatTimestampMS used for garbage collection of client perdags), a new `ClientMap` data structure is introduced.  The `ClientMap` is stored in a chunk in the `perdag` at the head `'clients'`.  This `ClientMap` chunk contains refs to each client's `headHash`.

This change implements helpers for reading and writing the `ClientMap`.     

See larger design at https://www.notion.so/Simplified-DD1-1ed242a8c1094d9ca3734c46d65ffce4

Part of #671 