### PR TITLE
feat: Implement heartbeats mechanism needed for Client state garbage collection for Simplified Dueling Dags

### DIFF
--- a/src/sync/client-id.ts
+++ b/src/sync/client-id.ts
@@ -2,9 +2,11 @@ import type * as kv from '../kv/mod';
 import {uuid as makeUuid} from './uuid';
 import {assertString} from '../asserts';
 
+// TODO: Make ClientID an opaque type
+export type ClientID = string;
 export const CID_KEY = 'sys/cid';
 
-export async function init(store: kv.Store): Promise<string> {
+export async function init(store: kv.Store): Promise<ClientID> {
   const cid = await store.withRead(r => r.get(CID_KEY));
   if (cid !== undefined) {
     assertString(cid);
@@ -15,7 +17,7 @@ export async function init(store: kv.Store): Promise<string> {
   return uuid;
 }
 
-function writeClientID(s: kv.Store, uuid: string): Promise<void> {
+function writeClientID(s: kv.Store, uuid: ClientID): Promise<void> {
   return s.withWrite(async wt => {
     await wt.put(CID_KEY, uuid);
     await wt.commit();

--- a/src/sync/clients.test.ts
+++ b/src/sync/clients.test.ts
@@ -140,7 +140,7 @@ test('setClients properly manages refs to client heads when clients are removed 
   });
 });
 
-test('setClients properly manages refs to client heads when a client\'s head changes', async () => {
+test("setClients properly manages refs to client heads when a client's head changes", async () => {
   const dagStore = new dag.Store(new MemStore());
   const client1V1HeadHash = hashOf('head of commit client1 is currently at');
   const client1V2HeadHash = hashOf(

--- a/src/sync/clients.test.ts
+++ b/src/sync/clients.test.ts
@@ -140,7 +140,7 @@ test('setClients properly manages refs to client heads when clients are removed 
   });
 });
 
-test("setClients properly manages refs to client heads when a client's head changes", async () => {
+test('setClients properly manages refs to client heads when a client\'s head changes', async () => {
   const dagStore = new dag.Store(new MemStore());
   const client1V1HeadHash = hashOf('head of commit client1 is currently at');
   const client1V2HeadHash = hashOf(

--- a/src/sync/clients.ts
+++ b/src/sync/clients.ts
@@ -13,7 +13,7 @@ type Client = {
    * while it is active and everytime the client persists its state to
    * the perdag.
    */
-   readonly heartbeatTimestampMs: number;
+  readonly heartbeatTimestampMs: number;
   /** The hash of the commit this session is currently at. */
   readonly headHash: Hash;
 };

--- a/src/sync/clients.ts
+++ b/src/sync/clients.ts
@@ -13,9 +13,9 @@ type Client = {
    * while it is active and everytime the client persists its state to
    * the perdag.
    */
-  heartbeatTimestampMs: number;
+   readonly heartbeatTimestampMs: number;
   /** The hash of the commit this session is currently at. */
-  headHash: Hash;
+  readonly headHash: Hash;
 };
 const CLIENTS_HEAD = 'clients';
 

--- a/src/sync/clients.ts
+++ b/src/sync/clients.ts
@@ -3,9 +3,8 @@ import * as dag from '../dag/mod';
 import type {ReadonlyJSONValue} from '../json';
 import {assertNumber, assertObject} from '../asserts';
 import {hasOwn} from '../has-own';
+import type {ClientID} from './client-id';
 
-// TODO: Make ClientID an opaque type
-type ClientID = string;
 type ClientMap = Map<ClientID, Client>;
 
 type Client = {

--- a/src/sync/heartbeat.test.ts
+++ b/src/sync/heartbeat.test.ts
@@ -1,0 +1,205 @@
+import {expect} from '@esm-bundle/chai';
+import {SinonFakeTimers, useFakeTimers} from 'sinon';
+import {MemStore} from '../kv/mod';
+import * as dag from '../dag/mod';
+import {startHeartbeats, writeHeartbeat} from './heartbeat';
+import {getClients, setClients} from './clients';
+import {hashOf, initHasher} from '../hash';
+
+let clock: SinonFakeTimers;
+const START_TIME = 100000;
+const ONE_MIN_IN_MS = 60 * 1000;
+setup(async () => {
+  await initHasher();
+  clock = useFakeTimers(START_TIME);
+});
+
+teardown(() => {
+  clock.restore();
+});
+
+test('startHeartbeats starts interval that writes heartbeat each minute', async () => {
+  const dagStore = new dag.Store(new MemStore());
+  const client1 = {
+    heartbeatTimestampMs: 1000,
+    headHash: hashOf('head of commit client1 is currently at'),
+  };
+  const client2 = {
+    heartbeatTimestampMs: 3000,
+    headHash: hashOf('head of commit client2 is currently at'),
+  };
+  const clientMap = new Map(
+    Object.entries({
+      client1,
+      client2,
+    }),
+  );
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClients(clientMap, write);
+    return write.commit();
+  });
+
+  startHeartbeats('client1', dagStore);
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(clientMap);
+  });
+
+  clock.tick(ONE_MIN_IN_MS);
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(
+      new Map(
+        Object.entries({
+          client1: {
+            ...client1,
+            heartbeatTimestampMs: START_TIME + ONE_MIN_IN_MS,
+          },
+          client2,
+        }),
+      ),
+    );
+  });
+
+  clock.tick(ONE_MIN_IN_MS);
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(
+      new Map(
+        Object.entries({
+          client1: {
+            ...client1,
+            heartbeatTimestampMs: START_TIME + ONE_MIN_IN_MS + ONE_MIN_IN_MS,
+          },
+          client2,
+        }),
+      ),
+    );
+  });
+});
+
+test('calling function returned by startHeartbeats, stops heartbeats', async () => {
+  const dagStore = new dag.Store(new MemStore());
+  const client1 = {
+    heartbeatTimestampMs: 1000,
+    headHash: hashOf('head of commit client1 is currently at'),
+  };
+  const client2 = {
+    heartbeatTimestampMs: 3000,
+    headHash: hashOf('head of commit client2 is currently at'),
+  };
+  const clientMap = new Map(
+    Object.entries({
+      client1,
+      client2,
+    }),
+  );
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClients(clientMap, write);
+    return write.commit();
+  });
+
+  const stopHeartbeats = startHeartbeats('client1', dagStore);
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(clientMap);
+  });
+
+  clock.tick(ONE_MIN_IN_MS);
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(
+      new Map(
+        Object.entries({
+          client1: {
+            ...client1,
+            heartbeatTimestampMs: START_TIME + ONE_MIN_IN_MS,
+          },
+          client2,
+        }),
+      ),
+    );
+  });
+
+  stopHeartbeats();
+  clock.tick(ONE_MIN_IN_MS);
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(
+      new Map(
+        Object.entries({
+          client1: {
+            ...client1,
+            // Heartbeat *NOT* updated to START_TIME + ONE_MIN_IN_MS + ONE_MIN_IN_MS
+            heartbeatTimestampMs: START_TIME + ONE_MIN_IN_MS,
+          },
+          client2,
+        }),
+      ),
+    );
+  });
+});
+
+test('writeHeartbeat writes heartbeat', async () => {
+  const dagStore = new dag.Store(new MemStore());
+  const client1 = {
+    heartbeatTimestampMs: 1000,
+    headHash: hashOf('head of commit client1 is currently at'),
+  };
+  const client2 = {
+    heartbeatTimestampMs: 3000,
+    headHash: hashOf('head of commit client2 is currently at'),
+  };
+  const clientMap = new Map(
+    Object.entries({
+      client1,
+      client2,
+    }),
+  );
+
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClients(clientMap, write);
+    return write.commit();
+  });
+
+  const TICK_IN_MS = 20000;
+  clock.tick(TICK_IN_MS);
+
+  await dagStore.withWrite(async write => {
+    await writeHeartbeat('client1', write);
+    await write.commit();
+    await dagStore.withRead(async (read: dag.Read) => {
+      const readClientMap = await getClients(read);
+      expect(readClientMap).to.deep.equal(
+        new Map(
+          Object.entries({
+            client1: {
+              ...client1,
+              heartbeatTimestampMs: START_TIME + TICK_IN_MS,
+            },
+            client2,
+          }),
+        ),
+      );
+    });
+  });
+});
+
+test('writeHeartbeat throws Error if no Client is found for clientID', async () => {
+  const dagStore = new dag.Store(new MemStore());
+  await dagStore.withWrite(async write => {
+    let e;
+    try {
+      await writeHeartbeat('client1', write);
+    } catch (ex) {
+      e = ex;
+    }
+    expect(e).to.be.instanceOf(Error);
+  });
+});

--- a/src/sync/heartbeat.ts
+++ b/src/sync/heartbeat.ts
@@ -1,0 +1,40 @@
+import type {ClientID} from './client-id';
+import type * as dag from '../dag/mod';
+import {getClient, setClient} from './clients';
+
+const HEARTBEAT_INTERVAL_MS = 60 * 1000;
+
+export function startHeartbeats(
+  clientID: ClientID,
+  dagStore: dag.Store,
+): () => void {
+  const intervalID = window.setInterval(async () => {
+    await dagStore.withWrite(async (write: dag.Write) => {
+      await writeHeartbeat(clientID, write);
+      await write.commit();
+    });
+  }, HEARTBEAT_INTERVAL_MS);
+  return () => {
+    window.clearInterval(intervalID);
+  };
+}
+
+export async function writeHeartbeat(
+  clientID: ClientID,
+  write: dag.Write,
+): Promise<void> {
+  const client = await getClient(clientID, write);
+  if (!client) {
+    // Should this be a more specific error so caller can detect and handle?
+    throw new Error('Cannot write heartbeat. Client with clientID not found');
+  }
+
+  await setClient(
+    clientID,
+    {
+      ...client,
+      heartbeatTimestampMs: Date.now(),
+    },
+    write,
+  );
+}

--- a/src/sync/heartbeat.ts
+++ b/src/sync/heartbeat.ts
@@ -32,8 +32,8 @@ export async function writeHeartbeat(
   await setClient(
     clientID,
     {
-      ...client,
       heartbeatTimestampMs: Date.now(),
+      headHash: client.headHash,
     },
     write,
   );


### PR DESCRIPTION
Simplified Dueling Dags requires a mechanism for collecting the perdag state for Clients (i.e. tabs) which have been closed.

A Client (i.e. tab) that has been closed cannot reliably clean up its own state (due to crashes and force closes).  It is difficult for other Client (i.e. tabs) to determine if a tab has been closed and is gone for ever, or just has been frozen for a long time.  The approach taken here is to have each Client update a heartbeatTimestampMS once per minute while it is active.  Other Client's then collect a Client only if it hasn't been active for a very long time (current plan is 1 week).

A client's heartbeat time is also updated when its memdag is persisted to the perdag.  This way the "newest" client state is roughly the state of the client with the most recent heartbeat time, which is useful for determining which client state a new client should choose for bootstrapping. 

A timestamp is used (as opposed to a heartbeat counter) in order to support expiration periods much longer than a typical session (e.g. 7 days).

See larger design at https://www.notion.so/Simplified-DD1-1ed242a8c1094d9ca3734c46d65ffce4

Part of #671