### PR TITLE
feat: Implements Client state Garbage Collection for Simplified Dueling Dags

### DIFF
--- a/src/sync/client-gc.test.ts
+++ b/src/sync/client-gc.test.ts
@@ -1,0 +1,189 @@
+import {expect} from '@esm-bundle/chai';
+import {SinonFakeTimers, useFakeTimers} from 'sinon';
+import {MemStore} from '../kv/mod';
+import * as dag from '../dag/mod';
+import {getClients, setClient, setClients} from './clients';
+import {hashOf, initHasher} from '../hash';
+import {initClientGC} from './client-gc';
+
+let clock: SinonFakeTimers;
+const START_TIME = 0;
+const SEVEN_DAYS_IN_MS = 7 * 24 * 60 * 60 * 1000;
+const FIVE_MINS_IN_MS = 5 * 60 * 1000;
+setup(async () => {
+  await initHasher();
+  clock = useFakeTimers(0);
+});
+
+teardown(() => {
+  clock.restore();
+});
+
+test('initClientGC starts 5 min interval that collects clients that have been inactive for > 7 days', async () => {
+  const dagStore = new dag.Store(new MemStore());
+  const client1 = {
+    heartbeatTimestampMs: START_TIME,
+    headHash: hashOf('head of commit client1 is currently at'),
+  };
+  const client2 = {
+    heartbeatTimestampMs: START_TIME,
+    headHash: hashOf('head of commit client2 is currently at'),
+  };
+  const client3 = {
+    heartbeatTimestampMs: START_TIME + 60 * 1000,
+    headHash: hashOf('head of commit client3 is currently at'),
+  };
+  const client4 = {
+    heartbeatTimestampMs: START_TIME + 60 * 1000,
+    headHash: hashOf('head of commit client4 is currently at'),
+  };
+  const clientMap = new Map(
+    Object.entries({
+      client1,
+      client2,
+      client3,
+      client4,
+    }),
+  );
+
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClients(clientMap, write);
+    return write.commit();
+  });
+
+  initClientGC('client1', dagStore);
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(clientMap);
+  });
+
+  clock.tick(SEVEN_DAYS_IN_MS + 1);
+
+  // client1 is not collected because it is the current client (despite being old enough to collect)
+  // client2 is collected because it is > 7 days inactive
+  // client3 is not collected because its < 7 days inactive (by 1 minute)
+  // client4 is not collected because its < 7 days inactive (by 1 minute)
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(
+      new Map(
+        Object.entries({
+          client1,
+          client3,
+          client4,
+        }),
+      ),
+    );
+  });
+
+  // Update client4's heartbeat to now
+  const client4WUpdatedHeartbeat = {
+    ...client4,
+    heartbeatTimestampMs: clock.now,
+  };
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClient('client4', client4WUpdatedHeartbeat, write);
+    return write.commit();
+  });
+
+  clock.tick(FIVE_MINS_IN_MS);
+
+  // client1 is not collected because it is the current client (despite being old enough to collect)
+  // client3 is collected because it is > 7 days inactive (by 4 mins)
+  // client4 is not collected because its update heartbeat is < 7 days inactive (7 days - 5 mins)
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(
+      new Map(
+        Object.entries({
+          client1,
+          client4: client4WUpdatedHeartbeat,
+        }),
+      ),
+    );
+  });
+
+  clock.tick(SEVEN_DAYS_IN_MS);
+
+  // client1 is not collected because it is the current client (despite being old enough to collect)
+  // client4 is collected because it is > 7 days inactive
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(
+      new Map(
+        Object.entries({
+          client1,
+        }),
+      ),
+    );
+  });
+});
+
+test('calling function returned by initClientGC, stops Client GCs', async () => {
+  const dagStore = new dag.Store(new MemStore());
+  const client1 = {
+    heartbeatTimestampMs: START_TIME,
+    headHash: hashOf('head of commit client1 is currently at'),
+  };
+  const client2 = {
+    heartbeatTimestampMs: START_TIME,
+    headHash: hashOf('head of commit client2 is currently at'),
+  };
+  const client3 = {
+    heartbeatTimestampMs: START_TIME + 60 * 1000,
+    headHash: hashOf('head of commit client3 is currently at'),
+  };
+  const clientMap = new Map(
+    Object.entries({
+      client1,
+      client2,
+      client3,
+    }),
+  );
+
+  await dagStore.withWrite(async (write: dag.Write) => {
+    await setClients(clientMap, write);
+    return write.commit();
+  });
+
+  const stopClientGC = initClientGC('client1', dagStore);
+
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(clientMap);
+  });
+
+  clock.tick(SEVEN_DAYS_IN_MS + 1);
+
+  // client1 is not collected because it is the current client (despite being old enough to collect)
+  // client2 is collected because it is > 7 days inactive
+  // client3 is not collected because its < 7 days inactive (by 1 minute)
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(
+      new Map(
+        Object.entries({
+          client1,
+          client3,
+        }),
+      ),
+    );
+  });
+
+  stopClientGC();
+  clock.tick(FIVE_MINS_IN_MS);
+
+  // client3 is not collected because GC has been stopped
+  await dagStore.withRead(async (read: dag.Read) => {
+    const readClientMap = await getClients(read);
+    expect(readClientMap).to.deep.equal(
+      new Map(
+        Object.entries({
+          client1,
+          client3,
+        }),
+      ),
+    );
+  });
+});

--- a/src/sync/client-gc.test.ts
+++ b/src/sync/client-gc.test.ts
@@ -62,8 +62,8 @@ test('initClientGC starts 5 min interval that collects clients that have been in
 
   // client1 is not collected because it is the current client (despite being old enough to collect)
   // client2 is collected because it is > 7 days inactive
-  // client3 is not collected because its < 7 days inactive (by 1 minute)
-  // client4 is not collected because its < 7 days inactive (by 1 minute)
+  // client3 is not collected because it is < 7 days inactive (by 1 minute)
+  // client4 is not collected because it is < 7 days inactive (by 1 minute)
   await dagStore.withRead(async (read: dag.Read) => {
     const readClientMap = await getClients(read);
     expect(readClientMap).to.deep.equal(
@@ -158,7 +158,7 @@ test('calling function returned by initClientGC, stops Client GCs', async () => 
 
   // client1 is not collected because it is the current client (despite being old enough to collect)
   // client2 is collected because it is > 7 days inactive
-  // client3 is not collected because its < 7 days inactive (by 1 minute)
+  // client3 is not collected because it is < 7 days inactive (by 1 minute)
   await dagStore.withRead(async (read: dag.Read) => {
     const readClientMap = await getClients(read);
     expect(readClientMap).to.deep.equal(

--- a/src/sync/client-gc.ts
+++ b/src/sync/client-gc.ts
@@ -1,0 +1,32 @@
+import type {ClientID} from './clients';
+import type * as dag from '../dag/mod';
+import {getClients, setClients} from './clients';
+
+const CLIENT_MAX_INACTIVE_IN_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const GC_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+export function initClientGC(
+  clientID: ClientID,
+  dagStore: dag.Store,
+): () => void {
+  const intervalID = window.setInterval(async () => {
+    await dagStore.withWrite(async (write: dag.Write) => {
+      const clients = await getClients(write);
+      const now = Date.now();
+      for (const [id, client] of clients) {
+        if (
+          id !== clientID /* never collect ourself */ &&
+          now - client.heartbeatTimestampMs > CLIENT_MAX_INACTIVE_IN_MS
+        ) {
+          clients.delete(id);
+        }
+      }
+      await setClients(clients, write);
+      await write.commit();
+    });
+  }, GC_INTERVAL_MS);
+
+  return () => {
+    window.clearInterval(intervalID);
+  };
+}


### PR DESCRIPTION
Simplified Dueling Dags requires a mechanism for collecting the perdag state for Clients (i.e. tabs) which have been closed.

Every **five minutes**, each Client collects any Clients that haven't updated their heartbeat timestamp **for at least seven days**. 

See larger design at https://www.notion.so/Simplified-DD1-1ed242a8c1094d9ca3734c46d65ffce4

Part of #671