### PR TITLE
feat: Add db visitor/transformer

### DIFF
--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -1,8 +1,11 @@
 type Truthy<T> = T extends null | undefined | false | '' | 0 ? never : T;
 
-export function assert<T>(b: T): asserts b is Truthy<T> {
+export function assert<T>(
+  b: T,
+  msg = 'Assertion failed',
+): asserts b is Truthy<T> {
   if (!b) {
-    throw new Error('Assertion failed');
+    throw new Error(msg);
   }
 }
 

--- a/src/btree/mod.ts
+++ b/src/btree/mod.ts
@@ -1,4 +1,5 @@
 export {BTreeRead} from './read';
 export {BTreeWrite} from './write';
 export {changedKeys} from './changed-keys';
+export {assertBTreeNode} from './node';
 export type {Entry} from './node';

--- a/src/btree/node.ts
+++ b/src/btree/node.ts
@@ -19,6 +19,13 @@ export type InternalNode = BaseNode<Hash>;
 
 export type DataNode = BaseNode<ReadonlyJSONValue>;
 
+export function getRefs(node: DataNode | InternalNode): ReadonlyArray<Hash> {
+  if (node[NODE_LEVEL] === 0) {
+    return [];
+  }
+  return node[NODE_ENTRIES].map(e => e[1]) as ReadonlyArray<Hash>;
+}
+
 export const enum DiffResultOp {
   Add,
   Delete,
@@ -136,6 +143,12 @@ export function assertBTreeNode(
   } else {
     entries.forEach(e => assertEntry(e, assertJSONValue));
   }
+}
+
+export function isInternalNode(
+  node: DataNode | InternalNode,
+): node is InternalNode {
+  return node[NODE_LEVEL] > 0;
 }
 
 abstract class NodeImpl<Value extends Hash | ReadonlyJSONValue> {

--- a/src/db/commit.ts
+++ b/src/db/commit.ts
@@ -75,7 +75,7 @@ export class Commit<M extends Meta = Meta> {
     return this.mutationID + 1;
   }
 
-  get indexes(): IndexRecord[] {
+  get indexes(): readonly IndexRecord[] {
     // Already validated!
     return this.chunk.data.indexes;
   }
@@ -316,7 +316,7 @@ export function fromChunk(chunk: Chunk): Commit {
   return new Commit(chunk);
 }
 
-function chunkFromCommitData(data: CommitData): Chunk<CommitData> {
+export function chunkFromCommitData(data: CommitData): Chunk<CommitData> {
   const refs = getRefs(data);
   return Chunk.new(data, refs);
 }
@@ -325,7 +325,7 @@ function commitFromCommitData(data: CommitData): Commit {
   return new Commit(chunkFromCommitData(data));
 }
 
-function getRefs(data: CommitData): Hash[] {
+export function getRefs(data: CommitData): Hash[] {
   const refs: Hash[] = [data.valueHash];
   const {meta} = data;
   switch (meta.type) {
@@ -351,10 +351,10 @@ function getRefs(data: CommitData): Hash[] {
 export type CommitData = {
   readonly meta: Meta;
   readonly valueHash: Hash;
-  readonly indexes: IndexRecord[];
+  readonly indexes: readonly IndexRecord[];
 };
 
-function assertCommitData(v: unknown): asserts v is CommitData {
+export function assertCommitData(v: unknown): asserts v is CommitData {
   assertObject(v);
   assertMeta(v.meta);
   assertString(v.valueHash);

--- a/src/db/mod.ts
+++ b/src/db/mod.ts
@@ -17,9 +17,12 @@ export {
   newIndexChange,
   newLocal,
   newSnapshot,
+  chunkFromCommitData,
+  getRefs,
+  assertCommitData,
 } from './commit';
 export {getRoot} from './root';
 export {decodeIndexKey} from './index';
-export type {LocalMeta, IndexRecord} from './commit';
+export type {LocalMeta, IndexRecord, CommitData} from './commit';
 export type {ScanOptions} from './scan';
 export type {Whence} from './read';

--- a/src/db/transformer.test.ts
+++ b/src/db/transformer.test.ts
@@ -1,0 +1,139 @@
+import {expect} from '@esm-bundle/chai';
+import * as dag from '../dag/mod';
+import {MemStore} from '../kv/mod';
+import {
+  addGenesis,
+  addIndexChange,
+  addLocal,
+  addSnapshot,
+  Chain,
+} from './test-helpers';
+import {Commit, IndexRecord} from './commit';
+import {Transformer} from './transformer';
+import {Hash, initHasher} from '../hash';
+import {BTreeRead, BTreeWrite, Entry} from '../btree/mod';
+import type {DataNode} from '../btree/node';
+import type {ReadonlyJSONValue} from '../json';
+import {assert} from '../asserts';
+
+setup(async () => {
+  await initHasher();
+});
+
+test('noops transformBTreeInternalEntry', async () => {
+  const dagStore = new dag.Store(new MemStore());
+
+  await dagStore.withWrite(async write => {
+    const transformer = new Transformer(write);
+
+    const dataNode: DataNode = [0, [['k', 42]]];
+    const chunk = dag.Chunk.new(dataNode, []);
+    await write.putChunk(chunk);
+    const entry: Entry<Hash> = ['key', chunk.hash];
+
+    expect(await transformer.transformBTreeInternalEntry(entry)).to.equal(
+      entry,
+    );
+  });
+});
+
+test('transformBTreeNode - noop', async () => {
+  const dagStore = new dag.Store(new MemStore());
+
+  await dagStore.withWrite(async write => {
+    const transformer = new Transformer(write);
+
+    const map = new BTreeWrite(write);
+    await map.put('key', 'value');
+    const valueHash = await map.flush();
+
+    expect(await transformer.transformBTreeNode(valueHash)).to.equal(valueHash);
+  });
+});
+
+test('transformCommit - noop', async () => {
+  const dagStore = new dag.Store(new MemStore());
+
+  const testChain = async (chain: Commit[]) => {
+    await dagStore.withWrite(async write => {
+      const transformer = new Transformer(write);
+
+      for (const commit of chain) {
+        const h = commit.chunk.hash;
+        expect(await transformer.transformCommit(h)).to.equal(h);
+      }
+    });
+  };
+
+  const chain: Chain = [];
+  await addGenesis(chain, dagStore);
+  await addLocal(chain, dagStore);
+  await addIndexChange(chain, dagStore);
+  await addLocal(chain, dagStore);
+  await testChain(chain);
+
+  await addSnapshot(chain, dagStore, [['k', 42]]);
+  await addLocal(chain, dagStore);
+  await testChain(chain.slice(-2));
+});
+
+test('transformIndexRecord - noop', async () => {
+  const dagStore = new dag.Store(new MemStore());
+
+  await dagStore.withWrite(async write => {
+    const transformer = new Transformer(write);
+
+    const map = new BTreeWrite(write);
+    await map.put('key', 'value');
+    const valueHash = await map.flush();
+
+    const index: IndexRecord = {
+      definition: {
+        jsonPointer: '',
+        keyPrefix: '',
+        name: 'index',
+      },
+      valueHash,
+    };
+
+    expect(await transformer.transformIndexRecord(index)).to.equal(index);
+  });
+});
+
+test('transforms data entry', async () => {
+  const dagStore = new dag.Store(new MemStore());
+
+  class TestTransformer extends Transformer {
+    override async transformBTreeDataEntry(
+      entry: Entry<ReadonlyJSONValue>,
+    ): Promise<Entry<ReadonlyJSONValue>> {
+      if (entry[0] === 'k') {
+        return ['k', entry[0] + ' - Changed!'];
+      }
+      return entry;
+    }
+  }
+
+  const chain: Chain = [];
+  await addGenesis(chain, dagStore);
+  await addSnapshot(chain, dagStore, [['k', 42]]);
+  await addLocal(chain, dagStore);
+
+  await dagStore.withWrite(async write => {
+    const transformer = new TestTransformer(write);
+
+    const h = chain[2].chunk.hash;
+    const h2 = await transformer.transformCommit(h);
+
+    await write.setHead('test', h2);
+    await write.commit();
+  });
+
+  await dagStore.withRead(async read => {
+    const headHash = await read.getHead('test');
+    assert(headHash);
+    const commit = await Commit.fromHash(headHash, read);
+    const map = new BTreeRead(read, commit.valueHash);
+    expect(await map.get('k')).to.equal('k - Changed!');
+  });
+});

--- a/src/db/transformer.ts
+++ b/src/db/transformer.ts
@@ -1,0 +1,264 @@
+import {assert} from '../asserts';
+import {
+  assertBTreeNode,
+  DataNode,
+  Entry,
+  getRefs as getRefsFromBTreeNode,
+  InternalNode,
+} from '../btree/node';
+import {IndexChangeMeta, Meta, MetaTyped, SnapshotMeta} from './commit';
+import * as db from './mod';
+import {assertCommitData} from './mod';
+import {emptyHash, Hash} from '../hash';
+import {Chunk} from '../dag/chunk';
+import type {Write} from '../dag/write';
+import type {ReadonlyJSONValue} from '../json';
+
+export class Transformer {
+  readonly write: Write;
+  private readonly _transforming: Map<Hash, Promise<Hash>> = new Map();
+
+  constructor(write: Write) {
+    this.write = write;
+  }
+
+  transformCommit(h: Hash, allowWeak = false): Promise<Hash> {
+    const newHash = this._transforming.get(h);
+    if (newHash !== undefined) {
+      return newHash;
+    }
+
+    const inner = async () => {
+      const chunk = await this.write.getChunk(h);
+      if (!chunk) {
+        if (allowWeak) {
+          return h;
+        }
+        throw new Error(`Chunk ${h} not found`);
+      }
+      const {data} = chunk;
+      assertCommitData(data);
+
+      const newCommit = await this.transformCommitData(data);
+      if (newCommit === data) {
+        return h;
+      }
+
+      // Changed. Need to create a new chunk.
+      const newChunk = db.chunkFromCommitData(newCommit);
+      await this.write.putChunk(newChunk);
+      return newChunk.hash;
+    };
+
+    const promise = inner();
+    this._transforming.set(h, promise);
+    return promise;
+  }
+
+  async transformCommitData(data: db.CommitData): Promise<db.CommitData> {
+    const meta = await this.transformCommitMeta(data.meta);
+    const valueHash = await this._transformCommitValue(data.valueHash);
+    const indexes = await this._transformIndexRecords(data.indexes);
+
+    if (
+      meta === data.meta &&
+      valueHash === data.valueHash &&
+      indexes === data.indexes
+    ) {
+      return data;
+    }
+    return {
+      meta,
+      valueHash,
+      indexes,
+    };
+  }
+
+  transformCommitMeta(meta: Meta): Promise<Meta> {
+    switch (meta.type) {
+      case MetaTyped.IndexChange:
+        return this.transformIndexChangeMeta(meta);
+
+      case MetaTyped.Local:
+        return this.transformLocalMeta(meta);
+
+      case MetaTyped.Snapshot:
+        return this.transformSnapshot(meta);
+    }
+  }
+
+  private _transformBasisHash(
+    basisHash: Hash | null,
+    allowWeak: boolean,
+  ): Promise<Hash> | null {
+    if (basisHash !== null) {
+      return this.transformCommit(basisHash, allowWeak);
+    }
+    return null;
+  }
+
+  async transformSnapshot(meta: SnapshotMeta): Promise<SnapshotMeta> {
+    // basisHash is weak for Snapshot Commits
+    const basisHash = await this._transformBasisHash(meta.basisHash, true);
+    if (basisHash === meta.basisHash) {
+      return meta;
+    }
+    return {
+      basisHash,
+      type: meta.type,
+      lastMutationID: meta.lastMutationID,
+      cookieJSON: meta.cookieJSON,
+    };
+  }
+
+  async transformLocalMeta(meta: db.LocalMeta): Promise<db.LocalMeta> {
+    const basisHash = await this._transformBasisHash(meta.basisHash, false);
+    // originalHash is weak for Local Commits
+    const originalHash =
+      meta.originalHash &&
+      (await this.transformCommit(meta.originalHash, true));
+    if (basisHash === meta.basisHash && originalHash === meta.originalHash) {
+      return meta;
+    }
+    return {
+      basisHash,
+      type: meta.type,
+      mutationID: meta.mutationID,
+      mutatorName: meta.mutatorName,
+      mutatorArgsJSON: meta.mutatorArgsJSON,
+      originalHash,
+    };
+  }
+
+  async transformIndexChangeMeta(
+    meta: IndexChangeMeta,
+  ): Promise<IndexChangeMeta> {
+    const basisHash = await this._transformBasisHash(meta.basisHash, false);
+    if (basisHash === meta.basisHash) {
+      return meta;
+    }
+    return {
+      basisHash,
+      type: meta.type,
+      lastMutationID: meta.lastMutationID,
+    };
+  }
+
+  private _transformCommitValue(valueHash: Hash): Promise<Hash> {
+    return this.transformBTreeNode(valueHash);
+  }
+
+  async transformBTreeNode(h: Hash): Promise<Hash> {
+    if (h === emptyHash) {
+      return h;
+    }
+
+    const newHash = this._transforming.get(h);
+    if (newHash !== undefined) {
+      return newHash;
+    }
+
+    const inner = async () => {
+      const chunk = await this.write.getChunk(h);
+      assert(chunk, `Missing chunk: ${h}`);
+      const {data} = chunk;
+      assertBTreeNode(data);
+
+      const newData = await this.transformBTreeNodeData(data);
+      if (data === newData) {
+        return h;
+      }
+
+      // Changed. Need to create a new chunk.
+      const refs = getRefsFromBTreeNode(newData);
+      const newChunk = Chunk.new(newData, refs);
+      await this.write.putChunk(newChunk);
+      return newChunk.hash;
+    };
+
+    const promise = inner();
+    this._transforming.set(h, promise);
+    return promise;
+  }
+
+  transformBTreeNodeData(data: DataNode): Promise<DataNode>;
+  transformBTreeNodeData(data: InternalNode): Promise<InternalNode>;
+  async transformBTreeNodeData(
+    data: DataNode | InternalNode,
+  ): Promise<DataNode | InternalNode> {
+    const level = data[0];
+    const entries = data[1];
+    let newEntries: (DataNode | InternalNode)[1];
+    if (level === 0) {
+      newEntries = await this._transformBTreeDataEntries(entries);
+    } else {
+      newEntries = await this._transformBTreeInternalEntries(
+        entries as InternalNode[1],
+      );
+    }
+    if (newEntries === entries) {
+      return data;
+    }
+
+    // Changed. Need to create a new chunk.
+    return [level, newEntries];
+  }
+
+  async transformBTreeDataEntry(
+    entry: Entry<ReadonlyJSONValue>,
+  ): Promise<Entry<ReadonlyJSONValue>> {
+    return entry;
+  }
+
+  private async _transformBTreeDataEntries(
+    entries: readonly Entry<ReadonlyJSONValue>[],
+  ): Promise<readonly Entry<ReadonlyJSONValue>[]> {
+    return this._transformArray(entries, this.transformBTreeDataEntry);
+  }
+
+  async transformBTreeInternalEntry(entry: Entry<Hash>): Promise<Entry<Hash>> {
+    const hash = await this.transformBTreeNode(entry[1]);
+    if (hash === entry[1]) {
+      return entry;
+    }
+    return [entry[0], hash];
+  }
+
+  private async _transformBTreeInternalEntries(
+    entries: readonly Entry<Hash>[],
+  ): Promise<readonly Entry<Hash>[]> {
+    return this._transformArray(entries, this.transformBTreeInternalEntry);
+  }
+
+  private async _transformArray<T>(
+    values: readonly T[],
+    itemTransform: (item: T) => Promise<T>,
+  ): Promise<readonly T[]> {
+    const newValues = await Promise.all(values.map(itemTransform));
+    for (let i = 0; i < newValues.length; i++) {
+      if (values[i] !== newValues[i]) {
+        return newValues;
+      }
+    }
+    return values;
+  }
+
+  private _transformIndexRecords(
+    indexes: readonly db.IndexRecord[],
+  ): Promise<readonly db.IndexRecord[]> {
+    return this._transformArray(indexes, index =>
+      this.transformIndexRecord(index),
+    );
+  }
+
+  async transformIndexRecord(index: db.IndexRecord): Promise<db.IndexRecord> {
+    const valueHash = await this.transformBTreeNode(index.valueHash);
+    if (valueHash === index.valueHash) {
+      return index;
+    }
+    return {
+      definition: index.definition,
+      valueHash,
+    };
+  }
+}

--- a/src/db/visitor.test.ts
+++ b/src/db/visitor.test.ts
@@ -1,0 +1,67 @@
+import {expect} from '@esm-bundle/chai';
+import * as dag from '../dag/mod';
+import {MemStore} from '../kv/mod';
+import {
+  addGenesis,
+  addIndexChange,
+  addLocal,
+  addSnapshot,
+  Chain,
+} from './test-helpers';
+import {initHasher} from '../hash';
+import type {DataNode} from '../btree/node';
+import type {ReadonlyJSONValue} from '../json';
+import {Visitor} from './visitor';
+import type {Commit} from './commit';
+
+setup(async () => {
+  await initHasher();
+});
+
+test('test that we get to the data nodes', async () => {
+  const dagStore = new dag.Store(new MemStore());
+
+  const log: ReadonlyJSONValue[] = [];
+  const chain: Chain = [];
+
+  class TestVisitor extends Visitor {
+    override async visitBTreeDataNode(node: DataNode) {
+      log.push(node[1]);
+    }
+  }
+
+  const t = async (commit: Commit, expected: ReadonlyJSONValue[]) => {
+    log.length = 0;
+    await dagStore.withRead(async dagRead => {
+      const visitor = new TestVisitor(dagRead);
+      await visitor.visitCommit(commit.chunk.hash);
+      expect(log).to.deep.equal(expected);
+    });
+  };
+
+  await addGenesis(chain, dagStore);
+  await t(chain[0], []);
+
+  await addLocal(chain, dagStore);
+  await t(chain[1], [[['local', '1']]]);
+
+  await addIndexChange(chain, dagStore);
+  await t(chain[2], [[['local', '1']], [['\u00001\u0000local', '1']]]);
+
+  await addLocal(chain, dagStore);
+  await t(chain[3], [
+    [['local', '1']],
+    [['\u00001\u0000local', '1']],
+    [['local', '3']],
+    [['\u00003\u0000local', '3']],
+  ]);
+
+  await addSnapshot(chain, dagStore, [['k', 42]]);
+  await t(chain[4], [
+    [
+      ['k', 42],
+      ['local', '3'],
+    ],
+    [['\u00003\u0000local', '3']],
+  ]);
+});

--- a/src/db/visitor.ts
+++ b/src/db/visitor.ts
@@ -1,0 +1,127 @@
+import {assert} from '../asserts';
+import {assertBTreeNode} from '../btree/mod';
+import {
+  assertCommitData,
+  IndexChangeMeta,
+  IndexRecord,
+  LocalMeta,
+  Meta,
+  MetaTyped,
+  SnapshotMeta,
+} from './commit';
+import type * as dag from '../dag/mod';
+import {emptyHash, Hash} from '../hash';
+import {DataNode, InternalNode, isInternalNode} from '../btree/node';
+
+export class Visitor {
+  readonly dagRead: dag.Read;
+  private _visitedHashes: Set<Hash> = new Set();
+
+  constructor(dagRead: dag.Read) {
+    this.dagRead = dagRead;
+  }
+
+  async visitCommit(h: Hash, allowWeak = false): Promise<void> {
+    if (this._visitedHashes.has(h)) {
+      return;
+    }
+    this._visitedHashes.add(h);
+
+    const chunk = await this.dagRead.getChunk(h);
+    if (!chunk) {
+      if (allowWeak) {
+        return;
+      }
+      throw new Error(`Chunk ${h} not found`);
+    }
+    const {data} = chunk;
+    assertCommitData(data);
+
+    await this.visitCommitMeta(data.meta);
+    await this.visitCommitValue(data.valueHash);
+    await this.visitCommitIndexes(data.indexes);
+  }
+
+  async visitCommitMeta(meta: Meta): Promise<void> {
+    switch (meta.type) {
+      case MetaTyped.IndexChange:
+        await this.visitIndexChangeMeta(meta);
+        break;
+
+      case MetaTyped.Local:
+        await this.visitLocalMeta(meta);
+        break;
+
+      case MetaTyped.Snapshot:
+        await this.visitSnapshot(meta);
+        break;
+    }
+  }
+
+  private async _visitBasisHash(
+    basisHash: Hash | null,
+    allowWeak: boolean,
+  ): Promise<void> {
+    if (basisHash !== null) {
+      await this.visitCommit(basisHash, allowWeak);
+    }
+  }
+
+  async visitSnapshot(meta: SnapshotMeta): Promise<void> {
+    // basisHash is weak for Snapshot Commits
+    await this._visitBasisHash(meta.basisHash, true);
+  }
+
+  async visitLocalMeta(meta: LocalMeta): Promise<void> {
+    await this._visitBasisHash(meta.basisHash, false);
+    if (meta.originalHash !== null) {
+      await this.visitCommit(meta.originalHash, false);
+    }
+  }
+
+  async visitIndexChangeMeta(meta: IndexChangeMeta): Promise<void> {
+    await this._visitBasisHash(meta.basisHash, false);
+  }
+
+  visitCommitValue(valueHash: Hash): Promise<void> {
+    return this.visitBTreeNode(valueHash);
+  }
+
+  async visitBTreeNode(h: Hash): Promise<void> {
+    // we use the emptyHash for an empty btree
+    if (h === emptyHash) {
+      return;
+    }
+
+    if (this._visitedHashes.has(h)) {
+      return;
+    }
+    this._visitedHashes.add(h);
+
+    const chunk = await this.dagRead.getChunk(h);
+    assert(chunk);
+    const {data} = chunk;
+    assertBTreeNode(data);
+    if (isInternalNode(data)) {
+      await this.visitBTreeInternalNode(data);
+    } else {
+      await this.visitBTreeDataNode(data);
+    }
+  }
+
+  async visitBTreeInternalNode(node: InternalNode): Promise<void> {
+    await Promise.all(
+      node[1].map(entry => this.visitBTreeNode(entry[1] as Hash)),
+    );
+  }
+
+  async visitBTreeDataNode(_node: DataNode): Promise<void> {
+    // empty
+  }
+
+  async visitCommitIndexes(indexes: readonly IndexRecord[]): Promise<void> {
+    await Promise.all(
+      indexes.map(async index => this.visitBTreeNode(index.valueHash)),
+    );
+  }
+}


### PR DESCRIPTION
This adds 2 base classes for visitors and transformers over the DB/Dag.
It will be used by persist in an upcoming PR.