### PR TITLE
refactor: Make the hash function a property of the dag store

### DIFF
--- a/src/dag/chunk.test.ts
+++ b/src/dag/chunk.test.ts
@@ -1,7 +1,7 @@
 import {expect} from '@esm-bundle/chai';
 import {Hash, hashOf, initHasher, parse} from '../hash';
 import type {Value} from '../kv/store';
-import {defaultChunkHasher, makeChunk, readChunk} from './chunk';
+import {defaultChunkHasher, createChunk, readChunk} from './chunk';
 import type {Chunk} from './chunk';
 
 setup(async () => {
@@ -10,7 +10,7 @@ setup(async () => {
 
 test('round trip', async () => {
   const t = (hash: Hash, data: Value, refs: Hash[]) => {
-    const c = makeChunk(data, refs, defaultChunkHasher);
+    const c = createChunk(data, refs, defaultChunkHasher);
     expect(c.hash).to.equal(hash);
     expect(c.data).to.deep.equal(data);
     expect(c.meta).to.deep.equal(refs);
@@ -39,7 +39,7 @@ test('equals', async () => {
   };
 
   const newChunk = (data: Value, refs: Hash[]) => {
-    return makeChunk(data, refs, defaultChunkHasher);
+    return createChunk(data, refs, defaultChunkHasher);
   };
 
   eq(newChunk([], []), newChunk([], []));

--- a/src/dag/chunk.test.ts
+++ b/src/dag/chunk.test.ts
@@ -1,7 +1,8 @@
 import {expect} from '@esm-bundle/chai';
 import {Hash, hashOf, initHasher, parse} from '../hash';
 import type {Value} from '../kv/store';
-import {Chunk} from './chunk';
+import {defaultChunkHasher, makeChunk, readChunk} from './chunk';
+import type {Chunk} from './chunk';
 
 setup(async () => {
   await initHasher();
@@ -9,13 +10,13 @@ setup(async () => {
 
 test('round trip', async () => {
   const t = (hash: Hash, data: Value, refs: Hash[]) => {
-    const c = Chunk.new(data, refs);
+    const c = makeChunk(data, refs, defaultChunkHasher);
     expect(c.hash).to.equal(hash);
     expect(c.data).to.deep.equal(data);
     expect(c.meta).to.deep.equal(refs);
 
     const buf = c.meta;
-    const c2 = Chunk.read(hash, data, buf);
+    const c2 = readChunk(hash, data, buf);
     expect(c).to.deep.equal(c2);
   };
 
@@ -37,13 +38,17 @@ test('equals', async () => {
     expect(a).to.not.deep.equal(b);
   };
 
-  eq(Chunk.new([], []), Chunk.new([], []));
-  neq(Chunk.new([1], []), Chunk.new([], []));
-  neq(Chunk.new([0], []), Chunk.new([1], []));
+  const newChunk = (data: Value, refs: Hash[]) => {
+    return makeChunk(data, refs, defaultChunkHasher);
+  };
 
-  eq(Chunk.new([1], []), Chunk.new([1], []));
-  eq(Chunk.new([], [hashOf('a')]), Chunk.new([], [hashOf('a')]));
+  eq(newChunk([], []), newChunk([], []));
+  neq(newChunk([1], []), newChunk([], []));
+  neq(newChunk([0], []), newChunk([1], []));
 
-  neq(Chunk.new([], [hashOf('a')]), Chunk.new([], [hashOf('b')]));
-  neq(Chunk.new([], [hashOf('a')]), Chunk.new([], [hashOf('a'), hashOf('b')]));
+  eq(newChunk([1], []), newChunk([1], []));
+  eq(newChunk([], [hashOf('a')]), newChunk([], [hashOf('a')]));
+
+  neq(newChunk([], [hashOf('a')]), newChunk([], [hashOf('b')]));
+  neq(newChunk([], [hashOf('a')]), newChunk([], [hashOf('a'), hashOf('b')]));
 });

--- a/src/dag/chunk.ts
+++ b/src/dag/chunk.ts
@@ -35,7 +35,7 @@ export function assertMeta(v: unknown): asserts v is Refs {
   }
 }
 
-export function makeChunk<V extends Value>(
+export function createChunk<V extends Value>(
   data: V,
   refs: Refs,
   chunkHasher: ChunkHasher,

--- a/src/dag/chunk.ts
+++ b/src/dag/chunk.ts
@@ -4,7 +4,7 @@ import type {Value} from '../kv/store';
 
 type Refs = readonly Hash[];
 
-export class Chunk<V extends Value = Value> {
+export interface Chunk<V extends Value = Value> {
   readonly hash: Hash;
   readonly data: V;
   /**
@@ -12,24 +12,17 @@ export class Chunk<V extends Value = Value> {
    * chunk.
    */
   readonly meta: Refs;
+}
 
-  private constructor(hash: Hash, data: V, meta: Refs) {
+class ChunkImpl<V extends Value = Value> implements Chunk<V> {
+  readonly hash: Hash;
+  readonly data: V;
+  readonly meta: Refs;
+
+  constructor(hash: Hash, data: V, meta: Refs) {
     this.hash = hash;
     this.data = data;
     this.meta = meta;
-  }
-
-  static new<V extends Value = Value>(data: V, refs: Refs): Chunk<V> {
-    const hash = hashOf(JSON.stringify(data));
-    return new Chunk(hash, data, refs);
-  }
-
-  static read<V extends Value = Value>(
-    hash: Hash,
-    data: V,
-    refs: Refs,
-  ): Chunk<V> {
-    return new Chunk(hash, data, refs);
   }
 }
 
@@ -41,3 +34,28 @@ export function assertMeta(v: unknown): asserts v is Refs {
     assertString(e);
   }
 }
+
+export function makeChunk<V extends Value>(
+  data: V,
+  refs: Refs,
+  chunkHasher: ChunkHasher,
+): Chunk<V> {
+  const hash = chunkHasher(data);
+  return new ChunkImpl(hash, data, refs);
+}
+
+export function readChunk<V extends Value>(
+  hash: Hash,
+  data: V,
+  refs: Refs,
+): Chunk<V> {
+  return new ChunkImpl(hash, data, refs);
+}
+
+export type CreateChunk = <V extends Value>(data: V, refs: Refs) => Chunk<V>;
+
+export function defaultChunkHasher<V extends Value>(data: V): Hash {
+  return hashOf(JSON.stringify(data));
+}
+
+export type ChunkHasher = typeof defaultChunkHasher;

--- a/src/dag/mod.ts
+++ b/src/dag/mod.ts
@@ -1,5 +1,7 @@
 export {Read, metaFromFlatbuffer, metaToFlatbuffer} from './read';
 export {Write, fromLittleEndian, toLittleEndian} from './write';
-export {Chunk} from './chunk';
+export type {Chunk, CreateChunk} from './chunk';
+export {defaultChunkHasher} from './chunk';
 export {Store} from './store';
+export {TestStore} from './test-store';
 export * from './key';

--- a/src/dag/mod.ts
+++ b/src/dag/mod.ts
@@ -1,7 +1,7 @@
 export {Read, metaFromFlatbuffer, metaToFlatbuffer} from './read';
 export {Write, fromLittleEndian, toLittleEndian} from './write';
 export type {Chunk, CreateChunk} from './chunk';
-export {defaultChunkHasher} from './chunk';
+export {createChunk, defaultChunkHasher} from './chunk';
 export {Store} from './store';
 export {TestStore} from './test-store';
 export * from './key';

--- a/src/dag/read.test.ts
+++ b/src/dag/read.test.ts
@@ -1,7 +1,7 @@
 import {expect} from '@esm-bundle/chai';
 import {Hash, hashOf, initHasher} from '../hash';
 import {MemStore} from '../kv/mod';
-import {defaultChunkHasher, readChunk} from './chunk';
+import {defaultChunkHasher, createChunk} from './chunk';
 import {chunkDataKey, chunkMetaKey} from './key';
 import {Read} from './read';
 import type {Value} from '../kv/store';
@@ -32,8 +32,7 @@ test('has chunk', async () => {
 test('get chunk', async () => {
   const t = async (data: Value, refs: Hash[], getSameChunk: boolean) => {
     const kv = new MemStore();
-    const hash = defaultChunkHasher(data);
-    const chunk = readChunk(hash, data, refs);
+    const chunk = createChunk(data, refs, defaultChunkHasher);
     await kv.withWrite(async kvw => {
       await kvw.put(chunkDataKey(chunk.hash), chunk.data);
       if (chunk.meta.length > 0) {

--- a/src/dag/read.ts
+++ b/src/dag/read.ts
@@ -1,5 +1,5 @@
 import type * as kv from '../kv/mod';
-import {assertMeta, Chunk, ChunkHasher, readChunk} from './chunk';
+import {assertMeta, Chunk, ChunkHasher, createChunk, readChunk} from './chunk';
 import {chunkDataKey, chunkMetaKey, headKey} from './key';
 import * as flatbuffers from 'flatbuffers';
 import {Meta as MetaFB} from './generated/meta/meta.js';
@@ -8,11 +8,11 @@ import type {ReadonlyJSONValue} from '../json';
 
 export class Read {
   private readonly _kvr: kv.Read;
-  readonly chunkHasher: ChunkHasher;
+  private readonly _chunkHasher: ChunkHasher;
 
   constructor(kv: kv.Read, chunkHasher: ChunkHasher) {
     this._kvr = kv;
-    this.chunkHasher = chunkHasher;
+    this._chunkHasher = chunkHasher;
   }
 
   async hasChunk(hash: Hash): Promise<boolean> {
@@ -39,10 +39,7 @@ export class Read {
   createChunk = <V extends ReadonlyJSONValue>(
     data: V,
     refs: readonly Hash[],
-  ): Chunk<V> => {
-    const hash = this.chunkHasher(data);
-    return readChunk(hash, data, refs);
-  };
+  ): Chunk<V> => createChunk(data, refs, this._chunkHasher);
 
   async getHead(name: string): Promise<Hash | undefined> {
     const data = await this._kvr.get(headKey(name));

--- a/src/dag/read.ts
+++ b/src/dag/read.ts
@@ -1,15 +1,18 @@
 import type * as kv from '../kv/mod';
-import {assertMeta, Chunk} from './chunk';
+import {assertMeta, Chunk, ChunkHasher, readChunk} from './chunk';
 import {chunkDataKey, chunkMetaKey, headKey} from './key';
 import * as flatbuffers from 'flatbuffers';
 import {Meta as MetaFB} from './generated/meta/meta.js';
 import {assertHash, Hash} from '../hash';
+import type {ReadonlyJSONValue} from '../json';
 
 export class Read {
   private readonly _kvr: kv.Read;
+  readonly chunkHasher: ChunkHasher;
 
-  constructor(kv: kv.Read) {
+  constructor(kv: kv.Read, chunkHasher: ChunkHasher) {
     this._kvr = kv;
+    this.chunkHasher = chunkHasher;
   }
 
   async hasChunk(hash: Hash): Promise<boolean> {
@@ -30,8 +33,16 @@ export class Read {
     } else {
       refs = [];
     }
-    return Chunk.read(hash, data, refs);
+    return readChunk(hash, data, refs);
   }
+
+  createChunk = <V extends ReadonlyJSONValue>(
+    data: V,
+    refs: readonly Hash[],
+  ): Chunk<V> => {
+    const hash = this.chunkHasher(data);
+    return readChunk(hash, data, refs);
+  };
 
   async getHead(name: string): Promise<Hash | undefined> {
     const data = await this._kvr.get(headKey(name));

--- a/src/dag/store.ts
+++ b/src/dag/store.ts
@@ -1,28 +1,32 @@
 import type * as kv from '../kv/mod';
+import type {ChunkHasher} from './chunk';
 import {Read} from './read';
 import {Write} from './write';
 
 export class Store {
   private readonly _kv: kv.Store;
 
-  constructor(kv: kv.Store) {
+  readonly chunkHasher: ChunkHasher;
+
+  constructor(kv: kv.Store, chunkHasher: ChunkHasher) {
     this._kv = kv;
+    this.chunkHasher = chunkHasher;
   }
 
   async read(): Promise<Read> {
-    return new Read(await this._kv.read());
+    return new Read(await this._kv.read(), this.chunkHasher);
   }
 
   async withRead<R>(fn: (read: Read) => R | Promise<R>): Promise<R> {
-    return this._kv.withRead(kvr => fn(new Read(kvr)));
+    return this._kv.withRead(kvr => fn(new Read(kvr, this.chunkHasher)));
   }
 
   async write(): Promise<Write> {
-    return new Write(await this._kv.write());
+    return new Write(await this._kv.write(), this.chunkHasher);
   }
 
   async withWrite<R>(fn: (Write: Write) => R | Promise<R>): Promise<R> {
-    return this._kv.withWrite(kvw => fn(new Write(kvw)));
+    return this._kv.withWrite(kvw => fn(new Write(kvw, this.chunkHasher)));
   }
 
   async close(): Promise<void> {

--- a/src/dag/store.ts
+++ b/src/dag/store.ts
@@ -5,28 +5,27 @@ import {Write} from './write';
 
 export class Store {
   private readonly _kv: kv.Store;
-
-  readonly chunkHasher: ChunkHasher;
+  private readonly _chunkHasher: ChunkHasher;
 
   constructor(kv: kv.Store, chunkHasher: ChunkHasher) {
     this._kv = kv;
-    this.chunkHasher = chunkHasher;
+    this._chunkHasher = chunkHasher;
   }
 
   async read(): Promise<Read> {
-    return new Read(await this._kv.read(), this.chunkHasher);
+    return new Read(await this._kv.read(), this._chunkHasher);
   }
 
   async withRead<R>(fn: (read: Read) => R | Promise<R>): Promise<R> {
-    return this._kv.withRead(kvr => fn(new Read(kvr, this.chunkHasher)));
+    return this._kv.withRead(kvr => fn(new Read(kvr, this._chunkHasher)));
   }
 
   async write(): Promise<Write> {
-    return new Write(await this._kv.write(), this.chunkHasher);
+    return new Write(await this._kv.write(), this._chunkHasher);
   }
 
   async withWrite<R>(fn: (Write: Write) => R | Promise<R>): Promise<R> {
-    return this._kv.withWrite(kvw => fn(new Write(kvw, this.chunkHasher)));
+    return this._kv.withWrite(kvw => fn(new Write(kvw, this._chunkHasher)));
   }
 
   async close(): Promise<void> {

--- a/src/dag/test-store.ts
+++ b/src/dag/test-store.ts
@@ -1,0 +1,12 @@
+import {Store} from './store';
+import * as kv from '../kv/mod';
+import {ChunkHasher, defaultChunkHasher} from './chunk';
+
+export class TestStore extends Store {
+  constructor(
+    kvStore: kv.Store = new kv.MemStore(),
+    chunkkHasher: ChunkHasher = defaultChunkHasher,
+  ) {
+    super(kvStore, chunkkHasher);
+  }
+}

--- a/src/dag/test-store.ts
+++ b/src/dag/test-store.ts
@@ -5,8 +5,8 @@ import {ChunkHasher, defaultChunkHasher} from './chunk';
 export class TestStore extends Store {
   constructor(
     kvStore: kv.Store = new kv.MemStore(),
-    chunkkHasher: ChunkHasher = defaultChunkHasher,
+    chunkHasher: ChunkHasher = defaultChunkHasher,
   ) {
-    super(kvStore, chunkkHasher);
+    super(kvStore, chunkHasher);
   }
 }

--- a/src/dag/write.ts
+++ b/src/dag/write.ts
@@ -1,7 +1,7 @@
 import type * as kv from '../kv/mod';
 import {chunkDataKey, chunkMetaKey, headKey, chunkRefCountKey} from './key';
 import {Read} from './read';
-import {assertMeta, Chunk} from './chunk';
+import {assertMeta, Chunk, ChunkHasher} from './chunk';
 import {assertNumber} from '../asserts';
 import {assertNotTempHash, Hash} from '../hash';
 
@@ -15,8 +15,8 @@ export class Write extends Read {
   private readonly _newChunks = new Set<Hash>();
   private readonly _changedHeads = new Map<string, HeadChange>();
 
-  constructor(kvw: kv.Write) {
-    super(kvw);
+  constructor(kvw: kv.Write, chunkHasher: ChunkHasher) {
+    super(kvw, chunkHasher);
     this._kvw = kvw;
   }
 

--- a/src/db/commit.test.ts
+++ b/src/db/commit.test.ts
@@ -1,7 +1,5 @@
 import {expect} from '@esm-bundle/chai';
-import {Chunk} from '../dag/mod';
 import * as dag from '../dag/mod';
-import {MemStore} from '../kv/mod';
 import {
   Commit,
   CommitData,
@@ -23,13 +21,15 @@ import {
 } from './test-helpers';
 import {Hash, hashOf, initHasher} from '../hash';
 import type {JSONValue} from '../json';
+import {defaultChunkHasher, makeChunk} from '../dag/chunk';
+import type {Value} from '../kv/store';
 
 setup(async () => {
   await initHasher();
 });
 
 test('base snapshot', async () => {
-  const store = new dag.Store(new MemStore());
+  const store = new dag.TestStore();
   const chain: Chain = [];
   await addGenesis(chain, store);
   let genesisHash = chain[0].chunk.hash;
@@ -71,7 +71,7 @@ test('base snapshot', async () => {
 });
 
 test('local mutations', async () => {
-  const store = new dag.Store(new MemStore());
+  const store = new dag.TestStore();
   const chain: Chain = [];
   await addGenesis(chain, store);
   const genesisHash = chain[0].chunk.hash;
@@ -95,7 +95,7 @@ test('local mutations', async () => {
 });
 
 test('chain', async () => {
-  const store = new dag.Store(new MemStore());
+  const store = new dag.TestStore();
   const chain: Chain = [];
   await addGenesis(chain, store);
 
@@ -118,7 +118,7 @@ test('chain', async () => {
 });
 
 test('load roundtrip', async () => {
-  const t = (chunk: Chunk, expected: Commit | Error) => {
+  const t = (chunk: dag.Chunk, expected: Commit | Error) => {
     {
       if (expected instanceof Error) {
         expect(() => fromChunk(chunk)).to.throw(
@@ -135,6 +135,7 @@ test('load roundtrip', async () => {
   const valueHash = hashOf('value');
   const emptyStringHash = hashOf('');
   const hashHash = hashOf('hash');
+
   for (const basisHash of [null, emptyStringHash, hashHash]) {
     t(
       await makeCommit(
@@ -149,7 +150,16 @@ test('load roundtrip', async () => {
         valueHash,
         basisHash === null ? [valueHash] : [valueHash, basisHash],
       ),
-      commitNewLocal(basisHash, 0, 'mutname', 42, original, valueHash, []),
+      commitNewLocal(
+        createChunk,
+        basisHash,
+        0,
+        'mutname',
+        42,
+        original,
+        valueHash,
+        [],
+      ),
     );
   }
 
@@ -199,7 +209,16 @@ test('load roundtrip', async () => {
         hashOf('vh'),
         basisHash === null ? [hashOf('vh')] : [hashOf('vh'), basisHash],
       ),
-      await commitNewLocal(basisHash, 0, 'mutname', 44, null, hashOf('vh'), []),
+      await commitNewLocal(
+        createChunk,
+        basisHash,
+        0,
+        'mutname',
+        44,
+        null,
+        hashOf('vh'),
+        [],
+      ),
     );
   }
 
@@ -229,7 +248,7 @@ test('load roundtrip', async () => {
         hashOf('vh'),
         [hashOf('vh')],
       ),
-      commitNewSnapshot(basisHash, 0, cookie, hashOf('vh'), []),
+      commitNewSnapshot(createChunk, basisHash, 0, cookie, hashOf('vh'), []),
     );
   }
   t(
@@ -253,7 +272,13 @@ test('load roundtrip', async () => {
         hashOf('value'),
         basisHash === null ? [hashOf('value')] : [hashOf('value'), basisHash],
       ),
-      await commitNewIndexChange(basisHash, 0, hashOf('value'), []),
+      await commitNewIndexChange(
+        createChunk,
+        basisHash,
+        0,
+        hashOf('value'),
+        [],
+      ),
     );
   }
 });
@@ -326,18 +351,24 @@ test('accessors', async () => {
   expect(indexChange.mutationID).to.equal(3);
 });
 
+function createChunk<V extends Value>(
+  data: V,
+  refs: readonly Hash[],
+): dag.Chunk<V> {
+  return makeChunk(data, refs, defaultChunkHasher);
+}
+
 async function makeCommit(
   meta: Meta,
   valueHash: Hash,
   refs: Hash[],
-): Promise<Chunk> {
+): Promise<dag.Chunk> {
   const data: CommitData = {
     meta,
     valueHash,
     indexes: [],
   };
-
-  return Chunk.new(data, refs);
+  return createChunk(data, refs);
 }
 
 function makeSnapshotMeta(

--- a/src/db/commit.test.ts
+++ b/src/db/commit.test.ts
@@ -21,7 +21,6 @@ import {
 } from './test-helpers';
 import {Hash, hashOf, initHasher} from '../hash';
 import type {JSONValue} from '../json';
-import {defaultChunkHasher, makeChunk} from '../dag/chunk';
 import type {Value} from '../kv/store';
 
 setup(async () => {
@@ -355,7 +354,7 @@ function createChunk<V extends Value>(
   data: V,
   refs: readonly Hash[],
 ): dag.Chunk<V> {
-  return makeChunk(data, refs, defaultChunkHasher);
+  return dag.createChunk(data, refs, dag.defaultChunkHasher);
 }
 
 async function makeCommit(

--- a/src/db/index.test.ts
+++ b/src/db/index.test.ts
@@ -195,7 +195,7 @@ test('index value', async () => {
     expected: number[] | string,
   ) => {
     const memStore = new kv.MemStore();
-    const dagStore = new dag.Store(memStore);
+    const dagStore = new dag.TestStore(memStore);
     await dagStore.withWrite(async dagWrite => {
       const index = new BTreeWrite(dagWrite);
       await index.put(encodeIndexKey(['s1', '1']), 'v1');

--- a/src/db/read.test.ts
+++ b/src/db/read.test.ts
@@ -1,7 +1,6 @@
 import {expect} from '@esm-bundle/chai';
 import * as dag from '../dag/mod';
 import {initHasher} from '../hash';
-import {MemStore} from '../kv/mod';
 import {LogContext} from '../logger';
 import {DEFAULT_HEAD_NAME} from './commit';
 import {fromWhence, whenceHead} from './read';
@@ -12,7 +11,7 @@ setup(async () => {
 });
 
 test('basics', async () => {
-  const ds = new dag.Store(new MemStore());
+  const ds = new dag.TestStore();
   const lc = new LogContext();
   await initDB(await ds.write(), DEFAULT_HEAD_NAME);
   const w = await Write.newLocal(

--- a/src/db/root.test.ts
+++ b/src/db/root.test.ts
@@ -12,7 +12,7 @@ setup(async () => {
 test('getRoot', async () => {
   const t = async (headHash: Hash | undefined, expected: Hash | Error) => {
     const kvs = new MemStore();
-    const ds = new dag.Store(kvs);
+    const ds = new dag.TestStore(kvs);
     if (headHash !== undefined) {
       await ds.withWrite(async dw => {
         await dw.setHead(DEFAULT_HEAD_NAME, headHash);

--- a/src/db/scan.test.ts
+++ b/src/db/scan.test.ts
@@ -16,7 +16,7 @@ test('scan', async () => {
     )}, expected: ${expected}`;
 
     const memStore = new kv.MemStore();
-    const dagStore = new dag.Store(memStore);
+    const dagStore = new dag.TestStore(memStore);
 
     await dagStore.withWrite(async dagWrite => {
       const map = new BTreeWrite(dagWrite);
@@ -325,7 +325,7 @@ test('exclusive regular map', async () => {
     const testDesc = `keys: ${keys}, startKey: ${startKey}, expected: ${expected}`;
 
     const memStore = new kv.MemStore();
-    const dagStore = new dag.Store(memStore);
+    const dagStore = new dag.TestStore(memStore);
 
     await dagStore.withWrite(async dagWrite => {
       const map = new BTreeWrite(dagWrite);
@@ -366,7 +366,7 @@ test('exclusive index map', async () => {
     const testDesc = `entries: ${entries}, startSecondaryKey ${startSecondaryKey}, startKey: ${startKey}, expected: ${expected}`;
 
     const memStore = new kv.MemStore();
-    const dagStore = new dag.Store(memStore);
+    const dagStore = new dag.TestStore(memStore);
 
     await dagStore.withWrite(async dagWrite => {
       const map = new BTreeWrite(dagWrite);
@@ -620,7 +620,7 @@ test('scan index startKey', async () => {
     expected: ScanItem[],
   ) => {
     const memStore = new kv.MemStore();
-    const dagStore = new dag.Store(memStore);
+    const dagStore = new dag.TestStore(memStore);
 
     await dagStore.withWrite(async dagWrite => {
       const map = await makeBTreeWrite(dagWrite, entries);

--- a/src/db/write.test.ts
+++ b/src/db/write.test.ts
@@ -1,7 +1,6 @@
 import {expect} from '@esm-bundle/chai';
 import {assertNotUndefined} from '../asserts';
 import * as dag from '../dag/mod';
-import {MemStore} from '../kv/mod';
 import {DEFAULT_HEAD_NAME} from './commit';
 import {readCommit, readIndexesForRead, whenceHead} from './read';
 import {initDB, Write} from './write';
@@ -16,7 +15,7 @@ setup(async () => {
 });
 
 test('basics', async () => {
-  const ds = new dag.Store(new MemStore());
+  const ds = new dag.TestStore();
   const lc = new LogContext();
   await initDB(await ds.write(), DEFAULT_HEAD_NAME);
 
@@ -80,7 +79,7 @@ test('basics', async () => {
 });
 
 test('index commit type constraints', async () => {
-  const ds = new dag.Store(new MemStore());
+  const ds = new dag.TestStore();
   const lc = new LogContext();
   await initDB(await ds.write(), DEFAULT_HEAD_NAME);
 
@@ -113,7 +112,7 @@ test('index commit type constraints', async () => {
 });
 
 test('clear', async () => {
-  const ds = new dag.Store(new MemStore());
+  const ds = new dag.TestStore();
   const lc = new LogContext();
   await ds.withWrite(dagWrite => initDB(dagWrite, DEFAULT_HEAD_NAME));
   await ds.withWrite(async dagWrite => {
@@ -185,7 +184,7 @@ test('clear', async () => {
 
 test('create and drop index', async () => {
   const t = async (writeBeforeIndexing: boolean) => {
-    const ds = new dag.Store(new MemStore());
+    const ds = new dag.TestStore();
     const lc = new LogContext();
     await ds.withWrite(dagWrite => initDB(dagWrite, DEFAULT_HEAD_NAME));
 

--- a/src/db/write.ts
+++ b/src/db/write.ts
@@ -306,6 +306,7 @@ export class Write extends Read {
       case MetaType.Local: {
         const {mutationID, mutatorName, mutatorArgs, originalHash} = meta;
         commit = commitNewLocal(
+          this._dagWrite.createChunk,
           basisHash,
           mutationID,
           mutatorName,
@@ -319,6 +320,7 @@ export class Write extends Read {
       case MetaType.Snapshot: {
         const {lastMutationID, cookie} = meta;
         commit = commitNewSnapshot(
+          this._dagWrite.createChunk,
           basisHash,
           lastMutationID,
           cookie,
@@ -339,6 +341,7 @@ export class Write extends Read {
         }
 
         commit = commitNewIndexChange(
+          this._dagWrite.createChunk,
           basisHash,
           lastMutationID,
           valueHash,

--- a/src/migrate/generate.test.ts
+++ b/src/migrate/generate.test.ts
@@ -13,7 +13,7 @@ setup(async () => {
 
 test.skip('generate', async () => {
   const kv = new TestMemStore();
-  const store = new dag.Store(kv);
+  const store = new dag.TestStore(kv);
 
   const mainChain: Chain = [];
 
@@ -28,7 +28,7 @@ test.skip('generate', async () => {
 
 test.skip('gen with index', async () => {
   const kv = new TestMemStore();
-  const store = new dag.Store(kv);
+  const store = new dag.TestStore(kv);
 
   const mainChain: Chain = [];
 

--- a/src/migrate/migrate-1-to-2.ts
+++ b/src/migrate/migrate-1-to-2.ts
@@ -99,6 +99,7 @@ export async function migrateMaybeWeakCommit(
   switch (commit.meta.type) {
     case MetaTyped.IndexChange:
       newCommit = db.newIndexChange(
+        dagWrite.createChunk,
         basisHash,
         commit.meta.lastMutationID,
         valueHash,
@@ -107,6 +108,7 @@ export async function migrateMaybeWeakCommit(
       break;
     case MetaTyped.Snapshot:
       newCommit = db.newSnapshot(
+        dagWrite.createChunk,
         basisHash,
         commit.meta.lastMutationID,
         commit.meta.cookieJSON,
@@ -116,6 +118,7 @@ export async function migrateMaybeWeakCommit(
       break;
     case MetaTyped.Local:
       newCommit = db.newLocal(
+        dagWrite.createChunk,
         basisHash,
         commit.meta.mutationID,
         commit.meta.mutatorName,

--- a/src/migrate/migrate-sample-data.ts
+++ b/src/migrate/migrate-sample-data.ts
@@ -241,7 +241,7 @@ export const chatSampleV2 = {
 // This was used to generate test data below.
 export async function getTestData(): Promise<void> {
   const kv = new TestMemStore();
-  const store = new dag.Store(kv);
+  const store = new dag.TestStore(kv);
 
   const mainChain: Chain = [];
 

--- a/src/migrate/migrate.test.ts
+++ b/src/migrate/migrate.test.ts
@@ -59,7 +59,7 @@ async function testMigrate1to2(
   const kvStore = new TestMemStore();
   await writeSampleData(kvStore, inputdata);
 
-  const dagStore = new dag.Store(kvStore);
+  const dagStore = new dag.TestStore(kvStore);
   await dagStore.withWrite(async dagWrite => {
     await migrate1to2(dagWrite, new LogContext());
     await dagWrite.commit();

--- a/src/migrate/migrate.ts
+++ b/src/migrate/migrate.ts
@@ -19,7 +19,7 @@ export async function migrate(
   }
 
   if (v === 1) {
-    const dagStore = new dag.Store(kvStore);
+    const dagStore = new dag.Store(kvStore, dag.defaultChunkHasher);
     await dagStore.withWrite(async dagWrite => {
       await migrate1to2(dagWrite, lc);
       await dagWrite.commit();

--- a/src/prolly/map.test.ts
+++ b/src/prolly/map.test.ts
@@ -1,10 +1,11 @@
 import {expect} from '@esm-bundle/chai';
-import {Chunk, Store} from '../dag/mod';
+import {Store} from '../dag/mod';
 import {MemStore} from '../kv/mod';
 import {stringCompare} from './string-compare';
 import * as prolly from './mod';
 import {initHasher} from '../hash';
 import {binarySearch, Entry} from './map';
+import {defaultChunkHasher, makeChunk} from '../dag/chunk';
 
 setup(async () => {
   await initHasher();
@@ -93,7 +94,7 @@ test('iter flush', async () => {
     t(map, expected);
 
     const kv = new MemStore();
-    const store = new Store(kv);
+    const store = new Store(kv, defaultChunkHasher);
     const write = await store.write();
     const hash = await map.flush(write);
 
@@ -179,8 +180,8 @@ test('load errors', async () => {
   const t = async (data: any, expectedError: string) => {
     let err;
     try {
-      // @ts-expect-error Constructor is private
-      const chunk = new Chunk('hash', data, undefined);
+      // @ts-expect-error refs is wrong type and chunkHasher is wrong type.
+      const chunk = makeChunk(data, undefined, () => 'hash');
       prolly.fromChunk(chunk);
     } catch (e) {
       err = e;

--- a/src/prolly/map.test.ts
+++ b/src/prolly/map.test.ts
@@ -5,7 +5,7 @@ import {stringCompare} from './string-compare';
 import * as prolly from './mod';
 import {initHasher} from '../hash';
 import {binarySearch, Entry} from './map';
-import {defaultChunkHasher, makeChunk} from '../dag/chunk';
+import {defaultChunkHasher, createChunk} from '../dag/chunk';
 
 setup(async () => {
   await initHasher();
@@ -181,7 +181,7 @@ test('load errors', async () => {
     let err;
     try {
       // @ts-expect-error refs is wrong type and chunkHasher is wrong type.
-      const chunk = makeChunk(data, undefined, () => 'hash');
+      const chunk = createChunk(data, undefined, () => 'hash');
       prolly.fromChunk(chunk);
     } catch (e) {
       err = e;

--- a/src/prolly/map.ts
+++ b/src/prolly/map.ts
@@ -1,5 +1,5 @@
 import {assertArray, assertNotNull, assertString} from '../asserts';
-import * as dag from '../dag/mod';
+import type * as dag from '../dag/mod';
 import {assertJSONValue, deepEqual, ReadonlyJSONValue} from '../json';
 import {stringCompare} from './string-compare';
 import * as flatbuffers from 'flatbuffers';
@@ -98,7 +98,7 @@ class ProllyMap {
     const entries = this._entries;
     // Now it is no longer safe to mutate the entries.
     this._isReadonly = true;
-    const chunk = dag.Chunk.new(entries, []);
+    const chunk = write.createChunk(entries, []);
     this._pendingChangedKeys.clear();
     await write.putChunk(chunk);
     return chunk.hash;

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -290,7 +290,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
     this._kvStore =
       experimentalKVStore ||
       (this._useMemstore ? new MemStore() : new IDBStore(this.name));
-    this._dagStore = new dag.Store(this._kvStore);
+    this._dagStore = new dag.Store(this._kvStore, dag.defaultChunkHasher);
 
     // Use a promise-resolve pair so that we have a promise to use even before
     // we call the Open RPC.

--- a/src/sync/client-gc.test.ts
+++ b/src/sync/client-gc.test.ts
@@ -1,6 +1,5 @@
 import {expect} from '@esm-bundle/chai';
 import {SinonFakeTimers, useFakeTimers} from 'sinon';
-import {MemStore} from '../kv/mod';
 import * as dag from '../dag/mod';
 import {getClients, setClient, setClients} from './clients';
 import {hashOf, initHasher} from '../hash';
@@ -20,7 +19,7 @@ teardown(() => {
 });
 
 test('initClientGC starts 5 min interval that collects clients that have been inactive for > 7 days', async () => {
-  const dagStore = new dag.Store(new MemStore());
+  const dagStore = new dag.TestStore();
   const client1 = {
     heartbeatTimestampMs: START_TIME,
     headHash: hashOf('head of commit client1 is currently at'),
@@ -121,7 +120,7 @@ test('initClientGC starts 5 min interval that collects clients that have been in
 });
 
 test('calling function returned by initClientGC, stops Client GCs', async () => {
-  const dagStore = new dag.Store(new MemStore());
+  const dagStore = new dag.TestStore();
   const client1 = {
     heartbeatTimestampMs: START_TIME,
     headHash: hashOf('head of commit client1 is currently at'),

--- a/src/sync/clients.test.ts
+++ b/src/sync/clients.test.ts
@@ -1,5 +1,4 @@
 import {expect} from '@esm-bundle/chai';
-import {MemStore} from '../kv/mod';
 import * as dag from '../dag/mod';
 import {assertHash, hashOf, initHasher, newTempHash} from '../hash';
 import {getClient, getClients, setClient, setClients} from './clients';
@@ -9,7 +8,7 @@ setup(async () => {
 });
 
 test('getClients with no existing ClientMap in dag store', async () => {
-  const dagStore = new dag.Store(new MemStore());
+  const dagStore = new dag.TestStore();
   await dagStore.withRead(async (read: dag.Read) => {
     const readClientMap = await getClients(read);
     expect(readClientMap.size).to.equal(0);
@@ -17,7 +16,7 @@ test('getClients with no existing ClientMap in dag store', async () => {
 });
 
 test('setClients and getClients', async () => {
-  const dagStore = new dag.Store(new MemStore());
+  const dagStore = new dag.TestStore();
   const clientMap = new Map(
     Object.entries({
       client1: {
@@ -42,7 +41,7 @@ test('setClients and getClients', async () => {
 });
 
 test('setClients and getClients sequence', async () => {
-  const dagStore = new dag.Store(new MemStore());
+  const dagStore = new dag.TestStore();
   const clientMap1 = new Map(
     Object.entries({
       client1: {
@@ -86,7 +85,7 @@ test('setClients and getClients sequence', async () => {
 });
 
 test('setClients properly manages refs to client heads when clients are removed and added', async () => {
-  const dagStore = new dag.Store(new MemStore());
+  const dagStore = new dag.TestStore();
   const client1HeadHash = hashOf('head of commit client1 is currently at');
   const client2HeadHash = hashOf('head of commit client2 is currently at');
 
@@ -141,7 +140,7 @@ test('setClients properly manages refs to client heads when clients are removed 
 });
 
 test("setClients properly manages refs to client heads when a client's head changes", async () => {
-  const dagStore = new dag.Store(new MemStore());
+  const dagStore = new dag.TestStore();
   const client1V1HeadHash = hashOf('head of commit client1 is currently at');
   const client1V2HeadHash = hashOf(
     'head of new commit client1 is currently at',
@@ -208,7 +207,7 @@ test("setClients properly manages refs to client heads when a client's head chan
 });
 
 test('setClient properly manages refs to client heads', async () => {
-  const dagStore = new dag.Store(new MemStore());
+  const dagStore = new dag.TestStore();
   const client1V1HeadHash = hashOf('head of commit client1 is currently at');
   const client1V2HeadHash = hashOf(
     'head of new commit client1 is currently at',
@@ -267,7 +266,7 @@ test('setClient properly manages refs to client heads', async () => {
 });
 
 test('getClient', async () => {
-  const dagStore = new dag.Store(new MemStore());
+  const dagStore = new dag.TestStore();
   const client1 = {
     heartbeatTimestampMs: 1000,
     headHash: hashOf('head of commit client1 is currently at'),
@@ -293,7 +292,7 @@ test('getClient', async () => {
 });
 
 test('setClient with existing client id', async () => {
-  const dagStore = new dag.Store(new MemStore());
+  const dagStore = new dag.TestStore();
   const client1V1 = {
     heartbeatTimestampMs: 1000,
     headHash: hashOf('head of commit client1 is currently at'),
@@ -336,7 +335,7 @@ test('setClient with existing client id', async () => {
 });
 
 test('setClient with new client id', async () => {
-  const dagStore = new dag.Store(new MemStore());
+  const dagStore = new dag.TestStore();
   const client1 = {
     heartbeatTimestampMs: 1000,
     headHash: hashOf('head of commit client1 is currently at'),
@@ -379,7 +378,7 @@ test('setClient with new client id', async () => {
 });
 
 test('setClients throws error if any client headHash is a temp hash', async () => {
-  const dagStore = new dag.Store(new MemStore());
+  const dagStore = new dag.TestStore();
   const client1 = {
     heartbeatTimestampMs: 1000,
     headHash: hashOf('head of commit client1 is currently at'),
@@ -432,7 +431,7 @@ test('setClients throws error if any client headHash is a temp hash', async () =
 });
 
 test('setClient throws error if client headHash is a temp hash', async () => {
-  const dagStore = new dag.Store(new MemStore());
+  const dagStore = new dag.TestStore();
   const client1 = {
     heartbeatTimestampMs: 1000,
     headHash: hashOf('head of commit client1 is currently at'),
@@ -482,7 +481,7 @@ test('setClient throws error if client headHash is a temp hash', async () => {
 });
 
 test('getClients throws errors if clients head exist but the chunk it refrences does not', async () => {
-  const dagStore = new dag.Store(new MemStore());
+  const dagStore = new dag.TestStore();
   await dagStore.withWrite(async (write: dag.Write) => {
     await write.setHead('clients', hashOf('random stuff'));
     await write.commit();
@@ -499,10 +498,10 @@ test('getClients throws errors if clients head exist but the chunk it refrences 
 });
 
 test('getClients throws errors if chunk pointed to by clients head does not contain a valid ClientMap', async () => {
-  const dagStore = new dag.Store(new MemStore());
+  const dagStore = new dag.TestStore();
   await dagStore.withWrite(async (write: dag.Write) => {
     const headHash = hashOf('head of commit client1 is currently at');
-    const chunk = dag.Chunk.new(
+    const chunk = write.createChunk(
       {
         heartbeatTimestampMs: 'this should be a number',
         headHash,

--- a/src/sync/clients.ts
+++ b/src/sync/clients.ts
@@ -1,5 +1,5 @@
 import {assertHash, assertNotTempHash, Hash} from './../hash';
-import * as dag from '../dag/mod';
+import type * as dag from '../dag/mod';
 import type {ReadonlyJSONValue} from '../json';
 import {assertNumber, assertObject} from '../asserts';
 import {hasOwn} from '../has-own';
@@ -70,7 +70,7 @@ export async function setClients(
   dagWrite: dag.Write,
 ): Promise<void> {
   const chunkData = clientMapToChunkData(clients);
-  const chunk = dag.Chunk.new(
+  const chunk = dagWrite.createChunk(
     chunkData,
     Array.from(clients.values(), client => client.headHash),
   );

--- a/src/sync/heartbeat.test.ts
+++ b/src/sync/heartbeat.test.ts
@@ -1,6 +1,5 @@
 import {expect} from '@esm-bundle/chai';
 import {SinonFakeTimers, useFakeTimers} from 'sinon';
-import {MemStore} from '../kv/mod';
 import * as dag from '../dag/mod';
 import {startHeartbeats, writeHeartbeat} from './heartbeat';
 import {getClients, setClients} from './clients';
@@ -19,7 +18,7 @@ teardown(() => {
 });
 
 test('startHeartbeats starts interval that writes heartbeat each minute', async () => {
-  const dagStore = new dag.Store(new MemStore());
+  const dagStore = new dag.TestStore();
   const client1 = {
     heartbeatTimestampMs: 1000,
     headHash: hashOf('head of commit client1 is currently at'),
@@ -82,7 +81,7 @@ test('startHeartbeats starts interval that writes heartbeat each minute', async 
 });
 
 test('calling function returned by startHeartbeats, stops heartbeats', async () => {
-  const dagStore = new dag.Store(new MemStore());
+  const dagStore = new dag.TestStore();
   const client1 = {
     heartbeatTimestampMs: 1000,
     headHash: hashOf('head of commit client1 is currently at'),
@@ -147,7 +146,7 @@ test('calling function returned by startHeartbeats, stops heartbeats', async () 
 });
 
 test('writeHeartbeat writes heartbeat', async () => {
-  const dagStore = new dag.Store(new MemStore());
+  const dagStore = new dag.TestStore();
   const client1 = {
     heartbeatTimestampMs: 1000,
     headHash: hashOf('head of commit client1 is currently at'),
@@ -192,7 +191,7 @@ test('writeHeartbeat writes heartbeat', async () => {
 });
 
 test('writeHeartbeat throws Error if no Client is found for clientID', async () => {
-  const dagStore = new dag.Store(new MemStore());
+  const dagStore = new dag.TestStore();
   await dagStore.withWrite(async write => {
     let e;
     try {

--- a/src/sync/patch.test.ts
+++ b/src/sync/patch.test.ts
@@ -1,5 +1,4 @@
 import {expect} from '@esm-bundle/chai';
-import {MemStore} from '../kv/mem-store';
 import * as dag from '../dag/mod';
 import * as db from '../db/mod';
 import type {JSONValue} from '../json';
@@ -14,7 +13,7 @@ setup(async () => {
 });
 
 test('patch', async () => {
-  const store = new dag.Store(new MemStore());
+  const store = new dag.TestStore();
   const lc = new LogContext();
 
   type Case = {

--- a/src/sync/pull.test.ts
+++ b/src/sync/pull.test.ts
@@ -14,7 +14,6 @@ import {
   createIndex,
 } from '../db/test-helpers';
 import type {ReadonlyJSONValue} from '../json';
-import {MemStore} from '../kv/mod';
 import type {
   PatchOperation,
   Puller,
@@ -42,7 +41,7 @@ setup(async () => {
 });
 
 test('begin try pull', async () => {
-  const store = new dag.Store(new MemStore());
+  const store = new dag.TestStore();
   const chain: Chain = [];
   await addGenesis(chain, store);
   await addSnapshot(chain, store, [['foo', '"bar"']]);
@@ -587,7 +586,7 @@ test('maybe end try pull', async () => {
   ];
 
   for (const [i, c] of cases.entries()) {
-    const store = new dag.Store(new MemStore());
+    const store = new dag.TestStore();
     const lc = new LogContext();
     const chain: Chain = [];
     await addGenesis(chain, store);
@@ -748,7 +747,7 @@ test('changed keys', async () => {
     patch: PatchOperation[],
     expectedChangedKeysMap: sync.ChangedKeysMap,
   ) => {
-    const store = new dag.Store(new MemStore());
+    const store = new dag.TestStore();
     const lc = new LogContext();
     const chain: Chain = [];
     await addGenesis(chain, store);

--- a/src/sync/push.test.ts
+++ b/src/sync/push.test.ts
@@ -9,7 +9,6 @@ import {
   addSnapshot,
   Chain,
 } from '../db/test-helpers';
-import {MemStore} from '../kv/mod';
 import type {HTTPRequestInfo} from '../http-request-info';
 import {SYNC_HEAD_NAME} from './sync-head-name';
 import {push, PushRequest, PUSH_VERSION} from './push';
@@ -66,7 +65,7 @@ function makeFakePusher(options: FakePusherArgs): Pusher {
 }
 
 test('try push', async () => {
-  const store = new dag.Store(new MemStore());
+  const store = new dag.TestStore();
   const lc = new LogContext();
   const chain: Chain = [];
   await addGenesis(chain, store);


### PR DESCRIPTION
The dag store now takes the function to use when computing the hash of a
chunk. This is needed because we want to use differn hash functions for
memdag and perdag.

Towards #671