### PR TITLE
refactor: Make assertValidChunk part of dag Store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "replicache",
       "version": "8.0.0",
       "license": "BSL-1.1",
       "dependencies": {

--- a/src/dag/read.test.ts
+++ b/src/dag/read.test.ts
@@ -1,5 +1,5 @@
 import {expect} from '@esm-bundle/chai';
-import {Hash, hashOf, initHasher} from '../hash';
+import {assertNotTempHash, Hash, hashOf, initHasher} from '../hash';
 import {MemStore} from '../kv/mod';
 import {defaultChunkHasher, createChunk} from './chunk';
 import {chunkDataKey, chunkMetaKey} from './key';
@@ -20,7 +20,7 @@ test('has chunk', async () => {
     });
 
     await kv.withRead(async kvr => {
-      const r = new Read(kvr, defaultChunkHasher);
+      const r = new Read(kvr, defaultChunkHasher, assertNotTempHash);
       expect(await r.hasChunk(hash)).to.equal(expectHas);
     });
   };
@@ -42,7 +42,7 @@ test('get chunk', async () => {
     });
 
     await kv.withRead(async kvr => {
-      const r = new Read(kvr, defaultChunkHasher);
+      const r = new Read(kvr, defaultChunkHasher, assertNotTempHash);
       let expected = undefined;
       let chunkHash: Hash;
       if (getSameChunk) {

--- a/src/dag/read.ts
+++ b/src/dag/read.ts
@@ -7,12 +7,18 @@ import {assertHash, Hash} from '../hash';
 import type {ReadonlyJSONValue} from '../json';
 
 export class Read {
-  private readonly _kvr: kv.Read;
+  protected readonly _kvr: kv.Read;
   private readonly _chunkHasher: ChunkHasher;
+  readonly assertValidHash: (hash: Hash) => void;
 
-  constructor(kv: kv.Read, chunkHasher: ChunkHasher) {
+  constructor(
+    kv: kv.Read,
+    chunkHasher: ChunkHasher,
+    assertValidHash: (hash: Hash) => void,
+  ) {
     this._kvr = kv;
     this._chunkHasher = chunkHasher;
+    this.assertValidHash = assertValidHash;
   }
 
   async hasChunk(hash: Hash): Promise<boolean> {

--- a/src/dag/store.ts
+++ b/src/dag/store.ts
@@ -1,3 +1,4 @@
+import type {Hash} from '../hash';
 import type * as kv from '../kv/mod';
 import type {ChunkHasher} from './chunk';
 import {Read} from './read';
@@ -6,26 +7,44 @@ import {Write} from './write';
 export class Store {
   private readonly _kv: kv.Store;
   private readonly _chunkHasher: ChunkHasher;
+  private readonly _assertValidHash: (hash: Hash) => void;
 
-  constructor(kv: kv.Store, chunkHasher: ChunkHasher) {
+  constructor(
+    kv: kv.Store,
+    chunkHasher: ChunkHasher,
+    assertValidHash: (hash: Hash) => void,
+  ) {
     this._kv = kv;
     this._chunkHasher = chunkHasher;
+    this._assertValidHash = assertValidHash;
   }
 
   async read(): Promise<Read> {
-    return new Read(await this._kv.read(), this._chunkHasher);
+    return new Read(
+      await this._kv.read(),
+      this._chunkHasher,
+      this._assertValidHash,
+    );
   }
 
   async withRead<R>(fn: (read: Read) => R | Promise<R>): Promise<R> {
-    return this._kv.withRead(kvr => fn(new Read(kvr, this._chunkHasher)));
+    return this._kv.withRead(kvr =>
+      fn(new Read(kvr, this._chunkHasher, this._assertValidHash)),
+    );
   }
 
   async write(): Promise<Write> {
-    return new Write(await this._kv.write(), this._chunkHasher);
+    return new Write(
+      await this._kv.write(),
+      this._chunkHasher,
+      this._assertValidHash,
+    );
   }
 
   async withWrite<R>(fn: (Write: Write) => R | Promise<R>): Promise<R> {
-    return this._kv.withWrite(kvw => fn(new Write(kvw, this._chunkHasher)));
+    return this._kv.withWrite(kvw =>
+      fn(new Write(kvw, this._chunkHasher, this._assertValidHash)),
+    );
   }
 
   async close(): Promise<void> {

--- a/src/dag/test-store.ts
+++ b/src/dag/test-store.ts
@@ -1,12 +1,14 @@
 import {Store} from './store';
 import * as kv from '../kv/mod';
 import {ChunkHasher, defaultChunkHasher} from './chunk';
+import {assertNotTempHash} from '../hash';
 
 export class TestStore extends Store {
   constructor(
     kvStore: kv.Store = new kv.MemStore(),
     chunkHasher: ChunkHasher = defaultChunkHasher,
+    assertValidHash = assertNotTempHash,
   ) {
-    super(kvStore, chunkHasher);
+    super(kvStore, chunkHasher, assertValidHash);
   }
 }

--- a/src/dag/write.test.ts
+++ b/src/dag/write.test.ts
@@ -5,8 +5,17 @@ import {chunkDataKey, chunkMetaKey, chunkRefCountKey, headKey} from './key';
 import {Write} from './write';
 import type * as kv from '../kv/mod';
 import {Read} from './read';
-import {Hash, hashOf, initHasher} from '../hash';
+import {
+  assertNotTempHash,
+  Hash,
+  hashOf,
+  initHasher,
+  isTempHash,
+  newTempHash,
+} from '../hash';
 import type {Value} from '../kv/store';
+import {Store} from './store';
+import {assert} from '../asserts';
 
 setup(async () => {
   await initHasher();
@@ -16,7 +25,7 @@ test('put chunk', async () => {
   const t = async (data: Value, refs: Hash[]) => {
     const kv = new MemStore();
     await kv.withWrite(async kvw => {
-      const w = new Write(kvw, defaultChunkHasher);
+      const w = new Write(kvw, defaultChunkHasher, assertNotTempHash);
       const c = w.createChunk(data, refs);
       await w.putChunk(c);
 
@@ -62,7 +71,7 @@ async function assertRefCount(kvr: kv.Read, hash: Hash, count: number) {
 test('set head', async () => {
   const t = async (kv: kv.Store, name: string, hash: Hash | undefined) => {
     await kv.withWrite(async kvw => {
-      const w = new Write(kvw, defaultChunkHasher);
+      const w = new Write(kvw, defaultChunkHasher, assertNotTempHash);
       await (hash === undefined ? w.removeHead(name) : w.setHead(name, hash));
       if (hash !== undefined) {
         const h = await kvw.get(headKey(name));
@@ -129,7 +138,7 @@ test('ref count invalid', async () => {
       await kvw.commit();
     });
     await kv.withWrite(async kvw => {
-      const w = new Write(kvw, defaultChunkHasher);
+      const w = new Write(kvw, defaultChunkHasher, assertNotTempHash);
       let err;
       try {
         await w.getRefCount(h);
@@ -173,7 +182,7 @@ test('commit rollback', async () => {
     let key: string;
     const kv = new MemStore();
     await kv.withWrite(async kvw => {
-      const w = new Write(kvw, defaultChunkHasher);
+      const w = new Write(kvw, defaultChunkHasher, assertNotTempHash);
       const c = w.createChunk([0, 1], []);
       await w.putChunk(c);
 
@@ -208,7 +217,7 @@ test('roundtrip', async () => {
     const hash = defaultChunkHasher(data);
     const c = readChunk(hash, data, refs);
     await kv.withWrite(async kvw => {
-      const w = new Write(kvw, defaultChunkHasher);
+      const w = new Write(kvw, defaultChunkHasher, assertNotTempHash);
       await w.putChunk(c);
       await w.setHead(name, c.hash);
 
@@ -222,7 +231,7 @@ test('roundtrip', async () => {
 
     // Read the changes outside the tx.
     await kv.withRead(async kvr => {
-      const r = new Read(kvr, defaultChunkHasher);
+      const r = new Read(kvr, defaultChunkHasher, assertNotTempHash);
       const c2 = await r.getChunk(c.hash);
       const h = await r.getHead(name);
       expect(c2).to.deep.equal(c);
@@ -241,4 +250,54 @@ test('roundtrip', async () => {
   await t('', null, []);
   await t('', [0], []);
   await t('', {a: true}, []);
+});
+
+test('that we check if the hash is good when committing', async () => {
+  const t = async (
+    chunkHasher: (v: Value) => Hash,
+    assertValidHash: (h: Hash) => void,
+  ) => {
+    const store = new Store(new MemStore(), chunkHasher, assertValidHash);
+
+    const hash = await store.withWrite(async dagWrite => {
+      const c = dagWrite.createChunk([0, 1], []);
+      await dagWrite.putChunk(c);
+      await dagWrite.setHead('test', c.hash);
+      await dagWrite.commit();
+      return c.hash;
+    });
+
+    await store.withRead(async dagRead => {
+      const c = await dagRead.getChunk(hash);
+      const h = await dagRead.getHead('test');
+      expect(c).to.deep.equal(c);
+      expect(c?.hash).to.equal(h);
+    });
+  };
+
+  {
+    let counter = 0;
+    const prefix = 'testhash';
+    const hasher = () =>
+      (counter++).toString().padStart(32, 'testhash') as unknown as Hash;
+    const testHash = (hash: Hash) => {
+      assert(hash.toString().startsWith(prefix));
+    };
+
+    await t(hasher, testHash);
+    await t(defaultChunkHasher, assertNotTempHash);
+    await t(newTempHash, (h: Hash) => {
+      assert(isTempHash(h));
+    });
+
+    let err;
+    try {
+      await t(newTempHash, assertNotTempHash);
+    } catch (e) {
+      err = e;
+    }
+    expect(err)
+      .to.be.instanceof(Error)
+      .with.property('message', 'Unexpected temp hash');
+  }
 });

--- a/src/dag/write.test.ts
+++ b/src/dag/write.test.ts
@@ -259,19 +259,22 @@ test('that we check if the hash is good when committing', async () => {
   ) => {
     const store = new Store(new MemStore(), chunkHasher, assertValidHash);
 
-    const hash = await store.withWrite(async dagWrite => {
-      const c = dagWrite.createChunk([0, 1], []);
+    const data = [true, 42];
+
+    await store.withWrite(async dagWrite => {
+      const c = dagWrite.createChunk(data, []);
       await dagWrite.putChunk(c);
       await dagWrite.setHead('test', c.hash);
       await dagWrite.commit();
-      return c.hash;
     });
 
     await store.withRead(async dagRead => {
-      const c = await dagRead.getChunk(hash);
       const h = await dagRead.getHead('test');
-      expect(c).to.deep.equal(c);
-      expect(c?.hash).to.equal(h);
+      assert(h);
+      const c = await dagRead.getChunk(h);
+      assert(c);
+      expect(c.hash).to.equal(h);
+      expect(c.data).to.deep.equal(data);
     });
   };
 

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -139,7 +139,7 @@ export function isTempHash(v: unknown): v is Hash {
 
 export function assertNotTempHash(hash: Hash): void {
   if (tempHashRe.test(hash as unknown as string)) {
-    throw new Error('must not be a temp hash');
+    throw new Error('Unexpected temp hash');
   }
 }
 

--- a/src/migrate/migrate.ts
+++ b/src/migrate/migrate.ts
@@ -3,6 +3,7 @@ import {currentVersion, migrate0to1} from './migrate-0-to-1';
 import {migrate1to2} from './migrate-1-to-2';
 import type * as kv from '../kv/mod';
 import type {LogContext} from '../logger';
+import {assertNotTempHash} from '../hash';
 
 export async function migrate(
   kvStore: kv.Store,
@@ -19,7 +20,11 @@ export async function migrate(
   }
 
   if (v === 1) {
-    const dagStore = new dag.Store(kvStore, dag.defaultChunkHasher);
+    const dagStore = new dag.Store(
+      kvStore,
+      dag.defaultChunkHasher,
+      assertNotTempHash,
+    );
     await dagStore.withWrite(async dagWrite => {
       await migrate1to2(dagWrite, lc);
       await dagWrite.commit();

--- a/src/prolly/map.test.ts
+++ b/src/prolly/map.test.ts
@@ -1,11 +1,10 @@
 import {expect} from '@esm-bundle/chai';
-import {Store} from '../dag/mod';
-import {MemStore} from '../kv/mod';
+import * as dag from '../dag/mod';
 import {stringCompare} from './string-compare';
 import * as prolly from './mod';
 import {initHasher} from '../hash';
 import {binarySearch, Entry} from './map';
-import {defaultChunkHasher, createChunk} from '../dag/chunk';
+import {createChunk} from '../dag/chunk';
 
 setup(async () => {
   await initHasher();
@@ -93,8 +92,7 @@ test('iter flush', async () => {
 
     t(map, expected);
 
-    const kv = new MemStore();
-    const store = new Store(kv, defaultChunkHasher);
+    const store = new dag.TestStore();
     const write = await store.write();
     const hash = await map.flush(write);
 

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -33,7 +33,7 @@ import type * as kv from './kv/mod';
 import * as dag from './dag/mod';
 import * as db from './db/mod';
 import * as sync from './sync/mod';
-import {emptyHash, Hash, initHasher} from './hash';
+import {assertNotTempHash, emptyHash, Hash, initHasher} from './hash';
 import {migrate} from './migrate/migrate';
 
 export type BeginPullResult = {
@@ -284,7 +284,11 @@ export class Replicache<MD extends MutatorDefs = {}> {
     this._kvStore =
       experimentalKVStore ||
       (this._useMemstore ? new MemStore() : new IDBStore(this.name));
-    this._dagStore = new dag.Store(this._kvStore, dag.defaultChunkHasher);
+    this._dagStore = new dag.Store(
+      this._kvStore,
+      dag.defaultChunkHasher,
+      assertNotTempHash,
+    );
 
     // Use a promise-resolve pair so that we have a promise to use even before
     // we call the Open RPC.

--- a/src/sync/clients.ts
+++ b/src/sync/clients.ts
@@ -1,4 +1,4 @@
-import {assertHash, assertNotTempHash, Hash} from './../hash';
+import {assertHash, Hash} from './../hash';
 import type * as dag from '../dag/mod';
 import type {ReadonlyJSONValue} from '../json';
 import {assertNumber, assertObject} from '../asserts';
@@ -41,9 +41,12 @@ function chunkDataToClientMap(chunkData?: ReadonlyJSONValue): ClientMap {
   return clients;
 }
 
-function clientMapToChunkData(clients: ClientMap): ReadonlyJSONValue {
+function clientMapToChunkData(
+  clients: ClientMap,
+  dagWrite: dag.Write,
+): ReadonlyJSONValue {
   clients.forEach(client => {
-    assertNotTempHash(client.headHash);
+    dagWrite.assertValidHash(client.headHash);
   });
   return Object.fromEntries(clients);
 }
@@ -69,7 +72,7 @@ export async function setClients(
   clients: ClientMap,
   dagWrite: dag.Write,
 ): Promise<void> {
-  const chunkData = clientMapToChunkData(clients);
+  const chunkData = clientMapToChunkData(clients, dagWrite);
   const chunk = dagWrite.createChunk(
     chunkData,
     Array.from(clients.values(), client => client.headHash),


### PR DESCRIPTION
For memdag we will allow temp hashes but for perdag we will not.

Towards #671