### PR TITLE
refactor: Add PersistGatherVisitor

### DIFF
--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -1,8 +1,11 @@
 type Truthy<T> = T extends null | undefined | false | '' | 0 ? never : T;
 
-export function assert<T>(b: T): asserts b is Truthy<T> {
+export function assert<T>(
+  b: T,
+  msg = 'Assertion failed',
+): asserts b is Truthy<T> {
   if (!b) {
-    throw new Error('Assertion failed');
+    throw new Error(msg);
   }
 }
 

--- a/src/btree/mod.ts
+++ b/src/btree/mod.ts
@@ -1,4 +1,5 @@
 export {BTreeRead} from './read';
 export {BTreeWrite} from './write';
 export {changedKeys} from './changed-keys';
-export type {Entry} from './node';
+export {assertBTreeNode} from './node';
+export type {Entry, Node, InternalNode, DataNode} from './node';

--- a/src/btree/node.test.ts
+++ b/src/btree/node.test.ts
@@ -3,7 +3,6 @@ import * as dag from '../dag/mod';
 import type {ScanOptionsInternal} from '../db/scan';
 import {emptyHash, Hash, initHasher} from '../hash';
 import type {ReadonlyJSONValue} from '../json';
-import * as kv from '../kv/mod';
 import {
   DataNode,
   findLeaf,
@@ -27,8 +26,7 @@ setup(async () => {
 const emptyTreeHash = 'mdcncodijhl6jk2o8bb7m0hg15p3sf24';
 
 test('findLeaf', async () => {
-  const kvStore = new kv.MemStore();
-  const dagStore = new dag.TestStore(kvStore);
+  const dagStore = new dag.TestStore();
 
   const leaf0: DataNode = [
     0,
@@ -265,8 +263,7 @@ async function asyncIterToArray<T>(iter: AsyncIterable<T>): Promise<T[]> {
 }
 
 test('empty read tree', async () => {
-  const kvStore = new kv.MemStore();
-  const dagStore = new dag.TestStore(kvStore);
+  const dagStore = new dag.TestStore();
   await dagStore.withRead(async dagRead => {
     const r = new BTreeRead(dagRead);
     expect(await r.get('a')).to.be.undefined;
@@ -276,8 +273,7 @@ test('empty read tree', async () => {
 });
 
 test('empty write tree', async () => {
-  const kvStore = new kv.MemStore();
-  const dagStore = new dag.TestStore(kvStore);
+  const dagStore = new dag.TestStore();
 
   await dagStore.withWrite(async dagWrite => {
     const w = new BTreeWrite(
@@ -323,8 +319,7 @@ test('empty write tree', async () => {
 });
 
 test('get', async () => {
-  const kvStore = new kv.MemStore();
-  const dagStore = new dag.TestStore(kvStore);
+  const dagStore = new dag.TestStore();
 
   const tree: TreeData = {
     $level: 1,
@@ -382,8 +377,7 @@ test('get', async () => {
 });
 
 test('has', async () => {
-  const kvStore = new kv.MemStore();
-  const dagStore = new dag.TestStore(kvStore);
+  const dagStore = new dag.TestStore();
 
   const tree: TreeData = {
     $level: 1,
@@ -490,8 +484,7 @@ test('partition', () => {
 });
 
 test('put', async () => {
-  const kvStore = new kv.MemStore();
-  const dagStore = new dag.TestStore(kvStore);
+  const dagStore = new dag.TestStore();
 
   const tree: TreeData = {
     $level: 0,
@@ -833,8 +826,7 @@ test('put', async () => {
 });
 
 test('del - single data node', async () => {
-  const kvStore = new kv.MemStore();
-  const dagStore = new dag.TestStore(kvStore);
+  const dagStore = new dag.TestStore();
 
   const tree: TreeData = {
     $level: 0,
@@ -875,8 +867,7 @@ test('del - single data node', async () => {
 });
 
 test('del - flatten', async () => {
-  const kvStore = new kv.MemStore();
-  const dagStore = new dag.TestStore(kvStore);
+  const dagStore = new dag.TestStore();
 
   // This tests that we can flatten "an invalid tree"
 
@@ -938,8 +929,7 @@ test('del - flatten', async () => {
 });
 
 test('del - with internal nodes', async () => {
-  const kvStore = new kv.MemStore();
-  const dagStore = new dag.TestStore(kvStore);
+  const dagStore = new dag.TestStore();
 
   const tree: TreeData = {
     $level: 2,
@@ -1107,8 +1097,7 @@ test('del - with internal nodes', async () => {
 });
 
 test('put - invalid', async () => {
-  const kvStore = new kv.MemStore();
-  const dagStore = new dag.TestStore(kvStore);
+  const dagStore = new dag.TestStore();
 
   // This tests that we can do puts on "an invalid tree"
 
@@ -1147,8 +1136,7 @@ test('put/del - getSize', async () => {
   maxSize = minSize * 2;
   getEntrySize = getSizeOfValue;
 
-  const kvStore = new kv.MemStore();
-  const dagStore = new dag.TestStore(kvStore);
+  const dagStore = new dag.TestStore();
 
   // This tests that we can do puts on "an invalid tree"
 
@@ -1214,8 +1202,7 @@ test('scan', async () => {
     options: ScanOptionsInternal = {},
     expectedEntries = entries,
   ) => {
-    const kvStore = new kv.MemStore();
-    const dagStore = new dag.TestStore(kvStore);
+    const dagStore = new dag.TestStore();
 
     const tree: TreeData = {
       $level: 0,
@@ -1434,8 +1421,7 @@ test('diff', async () => {
     newEntries: Entry<ReadonlyJSONValue>[],
     expectedDiff: DiffResult<ReadonlyJSONValue>[],
   ) => {
-    const kvStore = new kv.MemStore();
-    const dagStore = new dag.TestStore(kvStore);
+    const dagStore = new dag.TestStore();
 
     const [oldHash, newHash] = await dagStore.withWrite(async dagWrite => {
       const oldTree = new BTreeWrite(

--- a/src/btree/node.ts
+++ b/src/btree/node.ts
@@ -19,6 +19,8 @@ export type InternalNode = BaseNode<Hash>;
 
 export type DataNode = BaseNode<ReadonlyJSONValue>;
 
+export type Node = DataNode | InternalNode;
+
 export const enum DiffResultOp {
   Add,
   Delete,
@@ -138,6 +140,10 @@ export function assertBTreeNode(
   }
 }
 
+export function isInternalNode(node: Node): node is InternalNode {
+  return node[NODE_LEVEL] > 0;
+}
+
 abstract class NodeImpl<Value extends Hash | ReadonlyJSONValue> {
   entries: Array<Entry<Value>>;
   hash: Hash;
@@ -165,7 +171,7 @@ abstract class NodeImpl<Value extends Hash | ReadonlyJSONValue> {
     return this.entries[this.entries.length - 1][0];
   }
 
-  toChunkData(): DataNode | InternalNode {
+  toChunkData(): Node {
     return [this.level, this.entries];
   }
 }

--- a/src/dag/test-store.ts
+++ b/src/dag/test-store.ts
@@ -24,19 +24,16 @@ export class TestStore extends Store {
       const pk = parseKey(key);
       if (pk.type === KeyType.ChunkData) {
         const refsValue = this.kvStore.map().get(chunkMetaKey(pk.hash));
-        let refs: Hash[];
-        if (refsValue === undefined) {
-          refs = [];
-        } else {
-          refs = toRefs(refsValue);
-        }
-        yield readChunk(pk.hash, value, refs);
+        yield readChunk(pk.hash, value, toRefs(refsValue));
       }
     }
   }
 }
 
 function toRefs(refs: unknown): Hash[] {
+  if (refs === undefined) {
+    return [];
+  }
   assertArray(refs);
   return refs.map(h => {
     assertString(h);

--- a/src/dag/test-store.ts
+++ b/src/dag/test-store.ts
@@ -1,14 +1,45 @@
+import {parse as parseHash} from '../hash';
 import {Store} from './store';
-import * as kv from '../kv/mod';
-import {ChunkHasher, defaultChunkHasher} from './chunk';
-import {assertNotTempHash} from '../hash';
+import {Chunk, ChunkHasher, defaultChunkHasher, readChunk} from './chunk';
+import {assertNotTempHash, Hash} from '../hash';
+import {chunkMetaKey, parse as parseKey} from './key';
+import {KeyType} from './key';
+import {TestMemStore} from '../kv/test-mem-store';
+import {assertArray, assertString} from '../asserts';
 
 export class TestStore extends Store {
+  readonly kvStore: TestMemStore;
+
   constructor(
-    kvStore: kv.Store = new kv.MemStore(),
+    kvStore = new TestMemStore(),
     chunkHasher: ChunkHasher = defaultChunkHasher,
     assertValidHash = assertNotTempHash,
   ) {
     super(kvStore, chunkHasher, assertValidHash);
+    this.kvStore = kvStore;
   }
+
+  *chunks(): Generator<Chunk, void, unknown> {
+    for (const [key, value] of this.kvStore.entries()) {
+      const pk = parseKey(key);
+      if (pk.type === KeyType.ChunkData) {
+        const refsValue = this.kvStore.map().get(chunkMetaKey(pk.hash));
+        let refs: Hash[];
+        if (refsValue === undefined) {
+          refs = [];
+        } else {
+          refs = toRefs(refsValue);
+        }
+        yield readChunk(pk.hash, value, refs);
+      }
+    }
+  }
+}
+
+function toRefs(refs: unknown): Hash[] {
+  assertArray(refs);
+  return refs.map(h => {
+    assertString(h);
+    return parseHash(h);
+  });
 }

--- a/src/db/commit.ts
+++ b/src/db/commit.ts
@@ -74,7 +74,7 @@ export class Commit<M extends Meta = Meta> {
     return this.mutationID + 1;
   }
 
-  get indexes(): IndexRecord[] {
+  get indexes(): readonly IndexRecord[] {
     // Already validated!
     return this.chunk.data.indexes;
   }
@@ -318,22 +318,14 @@ export function fromChunk(chunk: dag.Chunk): Commit {
   return new Commit(chunk);
 }
 
-function chunkFromCommitData(
-  createChunk: dag.CreateChunk,
-  data: CommitData,
-): dag.Chunk<CommitData> {
-  const refs = getRefs(data);
-  return createChunk(data, refs);
-}
-
 function commitFromCommitData(
   createChunk: dag.CreateChunk,
   data: CommitData,
 ): Commit {
-  return new Commit(chunkFromCommitData(createChunk, data));
+  return new Commit(createChunk(data, getRefs(data)));
 }
 
-function getRefs(data: CommitData): Hash[] {
+export function getRefs(data: CommitData): Hash[] {
   const refs: Hash[] = [data.valueHash];
   const {meta} = data;
   switch (meta.type) {
@@ -359,10 +351,10 @@ function getRefs(data: CommitData): Hash[] {
 export type CommitData = {
   readonly meta: Meta;
   readonly valueHash: Hash;
-  readonly indexes: IndexRecord[];
+  readonly indexes: readonly IndexRecord[];
 };
 
-function assertCommitData(v: unknown): asserts v is CommitData {
+export function assertCommitData(v: unknown): asserts v is CommitData {
   assertObject(v);
   assertMeta(v.meta);
   assertString(v.valueHash);

--- a/src/db/commit.ts
+++ b/src/db/commit.ts
@@ -268,7 +268,7 @@ export function newLocal(
   mutatorArgsJSON: ReadonlyJSONValue,
   originalHash: Hash | null,
   valueHash: Hash,
-  indexes: IndexRecord[],
+  indexes: readonly IndexRecord[],
 ): Commit {
   const meta: LocalMeta = {
     type: MetaTyped.Local,
@@ -287,7 +287,7 @@ export function newSnapshot(
   lastMutationID: number,
   cookieJSON: ReadonlyJSONValue,
   valueHash: Hash,
-  indexes: IndexRecord[],
+  indexes: readonly IndexRecord[],
 ): Commit {
   const meta: SnapshotMeta = {
     type: MetaTyped.Snapshot,
@@ -303,7 +303,7 @@ export function newIndexChange(
   basisHash: Hash | null,
   lastMutationID: number,
   valueHash: Hash,
-  indexes: IndexRecord[],
+  indexes: readonly IndexRecord[],
 ): Commit {
   const meta: IndexChangeMeta = {
     type: MetaTyped.IndexChange,

--- a/src/db/index.test.ts
+++ b/src/db/index.test.ts
@@ -1,7 +1,6 @@
 import {expect} from '@esm-bundle/chai';
 import type {JSONValue} from '../json';
 import {stringCompare} from '../prolly/string-compare';
-import * as kv from '../kv/mod';
 import * as dag from '../dag/mod';
 import {
   decodeIndexKey,
@@ -194,8 +193,7 @@ test('index value', async () => {
     op: IndexOperation,
     expected: number[] | string,
   ) => {
-    const memStore = new kv.MemStore();
-    const dagStore = new dag.TestStore(memStore);
+    const dagStore = new dag.TestStore();
     await dagStore.withWrite(async dagWrite => {
       const index = new BTreeWrite(dagWrite);
       await index.put(encodeIndexKey(['s1', '1']), 'v1');

--- a/src/db/mod.ts
+++ b/src/db/mod.ts
@@ -17,9 +17,12 @@ export {
   newIndexChange,
   newLocal,
   newSnapshot,
+  assertCommitData,
 } from './commit';
 export {getRoot} from './root';
 export {decodeIndexKey} from './index';
-export type {LocalMeta, IndexRecord} from './commit';
+export {Visitor} from './visitor';
+
+export type {LocalMeta, IndexRecord, CommitData} from './commit';
 export type {ScanOptions} from './scan';
 export type {Whence} from './read';

--- a/src/db/root.test.ts
+++ b/src/db/root.test.ts
@@ -1,7 +1,6 @@
 import {expect} from '@esm-bundle/chai';
 import * as dag from '../dag/mod';
 import {Hash, hashOf, initHasher} from '../hash';
-import {MemStore} from '../kv/mod';
 import {DEFAULT_HEAD_NAME} from './commit';
 import {getRoot} from './root';
 
@@ -11,8 +10,7 @@ setup(async () => {
 
 test('getRoot', async () => {
   const t = async (headHash: Hash | undefined, expected: Hash | Error) => {
-    const kvs = new MemStore();
-    const ds = new dag.TestStore(kvs);
+    const ds = new dag.TestStore();
     if (headHash !== undefined) {
       await ds.withWrite(async dw => {
         await dw.setHead(DEFAULT_HEAD_NAME, headHash);

--- a/src/db/scan.test.ts
+++ b/src/db/scan.test.ts
@@ -1,6 +1,5 @@
 import {expect} from '@esm-bundle/chai';
 import {convert, scan, ScanItem, ScanOptions} from './scan';
-import * as kv from '../kv/mod';
 import * as dag from '../dag/mod';
 import {decodeIndexKey, encodeIndexKey} from './index';
 import {BTreeWrite} from '../btree/mod';
@@ -15,8 +14,7 @@ test('scan', async () => {
       2,
     )}, expected: ${expected}`;
 
-    const memStore = new kv.MemStore();
-    const dagStore = new dag.TestStore(memStore);
+    const dagStore = new dag.TestStore();
 
     await dagStore.withWrite(async dagWrite => {
       const map = new BTreeWrite(dagWrite);
@@ -324,8 +322,7 @@ test('exclusive regular map', async () => {
   const t = async (keys: string[], startKey: string, expected: string[]) => {
     const testDesc = `keys: ${keys}, startKey: ${startKey}, expected: ${expected}`;
 
-    const memStore = new kv.MemStore();
-    const dagStore = new dag.TestStore(memStore);
+    const dagStore = new dag.TestStore();
 
     await dagStore.withWrite(async dagWrite => {
       const map = new BTreeWrite(dagWrite);
@@ -365,8 +362,7 @@ test('exclusive index map', async () => {
   ) => {
     const testDesc = `entries: ${entries}, startSecondaryKey ${startSecondaryKey}, startKey: ${startKey}, expected: ${expected}`;
 
-    const memStore = new kv.MemStore();
-    const dagStore = new dag.TestStore(memStore);
+    const dagStore = new dag.TestStore();
 
     await dagStore.withWrite(async dagWrite => {
       const map = new BTreeWrite(dagWrite);
@@ -619,8 +615,7 @@ test('scan index startKey', async () => {
     opts: ScanOptions,
     expected: ScanItem[],
   ) => {
-    const memStore = new kv.MemStore();
-    const dagStore = new dag.TestStore(memStore);
+    const dagStore = new dag.TestStore();
 
     await dagStore.withWrite(async dagWrite => {
       const map = await makeBTreeWrite(dagWrite, entries);

--- a/src/db/visitor.test.ts
+++ b/src/db/visitor.test.ts
@@ -6,14 +6,12 @@ import {
   addLocal,
   addSnapshot,
   Chain,
-  createGenesis,
 } from './test-helpers';
 import {hashOf, initHasher} from '../hash';
 import type {Node} from '../btree/node';
 import type {ReadonlyJSONValue} from '../json';
 import {Visitor} from './visitor';
 import {Commit, newLocal} from './commit';
-import {addSyncSnapshot} from '../sync/test-helpers';
 
 setup(async () => {
   await initHasher();
@@ -119,7 +117,6 @@ test('test that we get to the data nodes', async () => {
     await dagWrite.commit();
     return localCommit2;
   });
-  debugger;
   await t(localCommit2, [
     [
       ['k', 42],

--- a/src/db/visitor.test.ts
+++ b/src/db/visitor.test.ts
@@ -39,13 +39,13 @@ test('test that we get to the data nodes', async () => {
   };
 
   await addGenesis(chain, dagStore);
-  await t(chain[0], []);
+  await t(chain[0], [[]]);
 
   await addLocal(chain, dagStore);
-  await t(chain[1], [[['local', '1']]]);
+  await t(chain[1], [[['local', '1']], []]);
 
   await addIndexChange(chain, dagStore);
-  await t(chain[2], [[['local', '1']], [['\u00001\u0000local', '1']]]);
+  await t(chain[2], [[['local', '1']], [['\u00001\u0000local', '1']], []]);
 
   await addLocal(chain, dagStore);
   await t(chain[3], [
@@ -53,6 +53,7 @@ test('test that we get to the data nodes', async () => {
     [['\u00003\u0000local', '3']],
     [['local', '1']],
     [['\u00001\u0000local', '1']],
+    [],
   ]);
 
   await addSnapshot(chain, dagStore, [['k', 42]]);

--- a/src/db/visitor.test.ts
+++ b/src/db/visitor.test.ts
@@ -1,0 +1,66 @@
+import {expect} from '@esm-bundle/chai';
+import * as dag from '../dag/mod';
+import {
+  addGenesis,
+  addIndexChange,
+  addLocal,
+  addSnapshot,
+  Chain,
+} from './test-helpers';
+import {initHasher} from '../hash';
+import type {DataNode} from '../btree/node';
+import type {ReadonlyJSONValue} from '../json';
+import {Visitor} from './visitor';
+import type {Commit} from './commit';
+
+setup(async () => {
+  await initHasher();
+});
+
+test('test that we get to the data nodes', async () => {
+  const dagStore = new dag.TestStore();
+
+  const log: ReadonlyJSONValue[] = [];
+  const chain: Chain = [];
+
+  class TestVisitor extends Visitor {
+    override async visitBTreeDataNode(chunk: dag.Chunk<DataNode>) {
+      log.push(chunk.data[1]);
+    }
+  }
+
+  const t = async (commit: Commit, expected: ReadonlyJSONValue[]) => {
+    log.length = 0;
+    await dagStore.withRead(async dagRead => {
+      const visitor = new TestVisitor(dagRead);
+      await visitor.visitCommit(commit.chunk.hash);
+      expect(log).to.deep.equal(expected);
+    });
+  };
+
+  await addGenesis(chain, dagStore);
+  await t(chain[0], []);
+
+  await addLocal(chain, dagStore);
+  await t(chain[1], [[['local', '1']]]);
+
+  await addIndexChange(chain, dagStore);
+  await t(chain[2], [[['local', '1']], [['\u00001\u0000local', '1']]]);
+
+  await addLocal(chain, dagStore);
+  await t(chain[3], [
+    [['local', '3']],
+    [['\u00003\u0000local', '3']],
+    [['local', '1']],
+    [['\u00001\u0000local', '1']],
+  ]);
+
+  await addSnapshot(chain, dagStore, [['k', 42]]);
+  await t(chain[4], [
+    [
+      ['k', 42],
+      ['local', '3'],
+    ],
+    [['\u00003\u0000local', '3']],
+  ]);
+});

--- a/src/db/visitor.ts
+++ b/src/db/visitor.ts
@@ -50,19 +50,16 @@ export class Visitor {
     ]);
   }
 
-  async visitCommitMeta(meta: Meta): Promise<void> {
+  visitCommitMeta(meta: Meta): Promise<void> {
     switch (meta.type) {
       case MetaTyped.IndexChange:
-        await this.visitIndexChangeMeta(meta);
-        break;
+        return this.visitIndexChangeMeta(meta);
 
       case MetaTyped.Local:
-        await this.visitLocalMeta(meta);
-        break;
+        return this.visitLocalMeta(meta);
 
       case MetaTyped.Snapshot:
-        await this.visitSnapshot(meta);
-        break;
+        return this.visitSnapshot(meta);
     }
   }
 
@@ -87,8 +84,8 @@ export class Visitor {
     }
   }
 
-  async visitIndexChangeMeta(meta: IndexChangeMeta): Promise<void> {
-    await this._visitBasisHash(meta.basisHash, false);
+  visitIndexChangeMeta(meta: IndexChangeMeta): Promise<void> {
+    return this._visitBasisHash(meta.basisHash, false);
   }
 
   visitCommitValue(valueHash: Hash): Promise<void> {

--- a/src/db/visitor.ts
+++ b/src/db/visitor.ts
@@ -1,0 +1,144 @@
+import {assert} from '../asserts';
+import {assertBTreeNode} from '../btree/mod';
+import {
+  assertCommitData,
+  CommitData,
+  IndexChangeMeta,
+  IndexRecord,
+  LocalMeta,
+  Meta,
+  MetaTyped,
+  SnapshotMeta,
+} from './commit';
+import type * as dag from '../dag/mod';
+import {emptyHash, Hash} from '../hash';
+import {DataNode, InternalNode, isInternalNode} from '../btree/node';
+
+export class Visitor {
+  readonly dagRead: dag.Read;
+  private _visitedHashes: Set<Hash> = new Set();
+
+  constructor(dagRead: dag.Read) {
+    this.dagRead = dagRead;
+  }
+
+  async visitCommit(h: Hash, allowWeak = false): Promise<void> {
+    if (this._visitedHashes.has(h)) {
+      return;
+    }
+    this._visitedHashes.add(h);
+
+    const chunk = await this.dagRead.getChunk(h);
+    if (!chunk) {
+      if (allowWeak) {
+        return;
+      }
+      throw new Error(`Chunk ${h} not found`);
+    }
+
+    const {data} = chunk;
+    assertCommitData(data);
+    await this.visitCommitChunk(chunk as dag.Chunk<CommitData>);
+  }
+
+  async visitCommitChunk(chunk: dag.Chunk<CommitData>): Promise<void> {
+    const {data} = chunk;
+    await Promise.all([
+      this.visitCommitMeta(data.meta),
+      this.visitCommitValue(data.valueHash),
+      this.visitCommitIndexes(data.indexes),
+    ]);
+  }
+
+  async visitCommitMeta(meta: Meta): Promise<void> {
+    switch (meta.type) {
+      case MetaTyped.IndexChange:
+        await this.visitIndexChangeMeta(meta);
+        break;
+
+      case MetaTyped.Local:
+        await this.visitLocalMeta(meta);
+        break;
+
+      case MetaTyped.Snapshot:
+        await this.visitSnapshot(meta);
+        break;
+    }
+  }
+
+  private async _visitBasisHash(
+    basisHash: Hash | null,
+    allowWeak: boolean,
+  ): Promise<void> {
+    if (basisHash !== null) {
+      await this.visitCommit(basisHash, allowWeak);
+    }
+  }
+
+  async visitSnapshot(meta: SnapshotMeta): Promise<void> {
+    // basisHash is weak for Snapshot Commits
+    await this._visitBasisHash(meta.basisHash, true);
+  }
+
+  async visitLocalMeta(meta: LocalMeta): Promise<void> {
+    await this._visitBasisHash(meta.basisHash, false);
+    if (meta.originalHash !== null) {
+      await this.visitCommit(meta.originalHash, false);
+    }
+  }
+
+  async visitIndexChangeMeta(meta: IndexChangeMeta): Promise<void> {
+    await this._visitBasisHash(meta.basisHash, false);
+  }
+
+  visitCommitValue(valueHash: Hash): Promise<void> {
+    return this.visitBTreeNode(valueHash);
+  }
+
+  async visitBTreeNode(h: Hash): Promise<void> {
+    // we use the emptyHash for an empty btree
+    if (h === emptyHash) {
+      return;
+    }
+
+    if (this._visitedHashes.has(h)) {
+      return;
+    }
+    this._visitedHashes.add(h);
+
+    const chunk = await this.dagRead.getChunk(h);
+    assert(chunk);
+    const {data} = chunk;
+    assertBTreeNode(data);
+
+    await this.visitBTreeNodeChunk(chunk as dag.Chunk<InternalNode | DataNode>);
+  }
+
+  async visitBTreeNodeChunk(
+    chunk: dag.Chunk<InternalNode | DataNode>,
+  ): Promise<void> {
+    const {data} = chunk;
+    if (isInternalNode(data)) {
+      await this.visitBTreeInternalNode(chunk as dag.Chunk<InternalNode>);
+    } else {
+      await this.visitBTreeDataNode(chunk as dag.Chunk<DataNode>);
+    }
+  }
+
+  async visitBTreeInternalNode(chunk: dag.Chunk<InternalNode>): Promise<void> {
+    const {data} = chunk;
+    await Promise.all(
+      data[1].map(entry => this.visitBTreeNode(entry[1] as Hash)),
+    );
+  }
+
+  async visitBTreeDataNode(_chunk: dag.Chunk<DataNode>): Promise<void> {
+    // empty
+  }
+
+  async visitCommitIndexes(indexes: readonly IndexRecord[]): Promise<void> {
+    await Promise.all(
+      indexes.map(async index => this.visitBTreeNode(index.valueHash)),
+    );
+  }
+}

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -117,6 +117,10 @@ export async function initHasher(): Promise<unknown> {
   return hasherPromise;
 }
 
+// Temp hashes needs to have the same length as non temp hashes. This is
+// important because we split B+Tree nodes based on the size and we want the
+// size to be the same independent of whether the hash is temp or not.
+
 export const newTempHash = makeNewTempHashFunction();
 
 export function makeNewTempHashFunction(): () => Hash {

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -48,7 +48,7 @@ const stringToUint8Array: (s: string) => Uint8Array =
     : s => encoder.encode(s);
 
 const hashRe = /^[0-9a-v]{32}$/;
-const tempHashRe = /^\/t\/[0-9]{29}$/;
+const tempHashRe = /^t\/[0-9]{30}$/;
 
 /**
  * Computes a SHA512 hash of the given data.
@@ -117,16 +117,19 @@ export async function initHasher(): Promise<unknown> {
   return hasherPromise;
 }
 
-let tempHashCounter = 0;
+export const newTempHash = makeNewTempHashFunction();
 
-const tempPrefix = '/t/';
+export function makeNewTempHashFunction(): () => Hash {
+  let tempHashCounter = 0;
+  const tempPrefix = 't/';
 
-export function newTempHash(): Hash {
-  // Must not overlap with hashOf results
-  return (tempPrefix +
-    (tempHashCounter++)
-      .toString()
-      .padStart(HASH_LENGTH - tempPrefix.length, '0')) as unknown as Hash;
+  return () => {
+    // Must not overlap with hashOf results
+    return (tempPrefix +
+      (tempHashCounter++)
+        .toString()
+        .padStart(HASH_LENGTH - tempPrefix.length, '0')) as unknown as Hash;
+  };
 }
 
 export function isHash(v: unknown): v is Hash {

--- a/src/kv/mod.ts
+++ b/src/kv/mod.ts
@@ -1,4 +1,4 @@
-export type {Read, Store, Write} from './store';
+export type {Read, Store, Write, Value} from './store';
 export {MemStore} from './mem-store';
 export {IDBStore} from './idb-store';
 export {TestMemStore} from './test-mem-store';

--- a/src/kv/test-mem-store.ts
+++ b/src/kv/test-mem-store.ts
@@ -5,7 +5,7 @@ export class TestMemStore extends MemStore {
   /**
    * This exposes the underlying map for testing purposes.
    */
-  entries(): Iterable<[string, Value]> {
+  entries(): IterableIterator<[string, Value]> {
     return this._map.entries();
   }
 

--- a/src/sync/persist-gather-visitor.test.ts
+++ b/src/sync/persist-gather-visitor.test.ts
@@ -76,7 +76,7 @@ test('dag with only temp hashes gathers eveything', async () => {
   await testGatheredChunks();
 });
 
-test('dag with some permanent hashes and some tempt hashes on top', async () => {
+test('dag with some permanent hashes and some temp hashes on top', async () => {
   const kvStore = new TestMemStore();
   const perdag = new dag.TestStore(kvStore);
   const chain: Chain = [];

--- a/src/sync/persist-gather-visitor.test.ts
+++ b/src/sync/persist-gather-visitor.test.ts
@@ -1,0 +1,181 @@
+import {expect} from '@esm-bundle/chai';
+import * as dag from '../dag/mod';
+import {initHasher, makeNewTempHashFunction, newTempHash} from '../hash';
+import {
+  addGenesis,
+  addIndexChange,
+  addLocal,
+  addSnapshot,
+  Chain,
+} from '../db/test-helpers';
+import {PersistGatherVisitor} from './persist-gather-visitor';
+import {TestMemStore} from '../kv/test-mem-store';
+import type {Value} from '../kv/store';
+import {stringCompare} from '../prolly/string-compare';
+
+setup(async () => {
+  await initHasher();
+});
+
+test('dag with no temp hashes gathers nothing', async () => {
+  const dagStore = new dag.TestStore();
+
+  const chain: Chain = [];
+  await addGenesis(chain, dagStore);
+  await addLocal(chain, dagStore);
+  await addIndexChange(chain, dagStore);
+  await addLocal(chain, dagStore);
+
+  await dagStore.withRead(async dagRead => {
+    for (const commit of chain) {
+      const visitor = new PersistGatherVisitor(dagRead);
+      await visitor.visitCommit(commit.chunk.hash);
+      expect(visitor.gatheredChunks).to.be.empty;
+    }
+  });
+
+  await addSnapshot(chain, dagStore, undefined);
+
+  await dagStore.withRead(async dagRead => {
+    const visitor = new PersistGatherVisitor(dagRead);
+    await visitor.visitCommit(chain[chain.length - 1].chunk.hash);
+    expect(visitor.gatheredChunks).to.be.empty;
+  });
+});
+
+function sortByHash(
+  arr: IterableIterator<dag.Chunk<Value>>,
+): dag.Chunk<Value>[] {
+  return [...arr].sort((a, b) => stringCompare(String(a.hash), String(b.hash)));
+}
+
+test('dag with only temp hashes gathers eveything', async () => {
+  const kvStore = new TestMemStore();
+  const dagStore = new dag.TestStore(kvStore, newTempHash, () => void 0);
+  const chain: Chain = [];
+
+  const testGatheredChunks = async () => {
+    await dagStore.withRead(async dagRead => {
+      const visitor = new PersistGatherVisitor(dagRead);
+      await visitor.visitCommit(chain[chain.length - 1].chunk.hash);
+      expect(sortByHash(dagStore.chunks())).to.deep.equal(
+        sortByHash(visitor.gatheredChunks.values()),
+      );
+    });
+  };
+
+  await addGenesis(chain, dagStore);
+  await addLocal(chain, dagStore);
+  await testGatheredChunks();
+
+  await addIndexChange(chain, dagStore);
+  await addLocal(chain, dagStore);
+  await testGatheredChunks();
+
+  await addSnapshot(chain, dagStore, undefined);
+  await testGatheredChunks();
+});
+
+test('dag with some permanent hashes and some tempt hashes on top', async () => {
+  const kvStore = new TestMemStore();
+  const perdag = new dag.TestStore(kvStore);
+  const chain: Chain = [];
+
+  await addGenesis(chain, perdag);
+  await addLocal(chain, perdag);
+
+  await perdag.withRead(async dagRead => {
+    const visitor = new PersistGatherVisitor(dagRead);
+    await visitor.visitCommit(chain[chain.length - 1].chunk.hash);
+    expect(visitor.gatheredChunks).to.be.empty;
+  });
+
+  const memdag = new dag.TestStore(
+    kvStore,
+    makeNewTempHashFunction(),
+    () => void 0,
+  );
+
+  await addLocal(chain, memdag);
+
+  await memdag.withRead(async dagRead => {
+    const visitor = new PersistGatherVisitor(dagRead);
+    await visitor.visitCommit(chain[chain.length - 1].chunk.hash);
+    expect(Object.fromEntries(visitor.gatheredChunks)).to.deep.equal({
+      't/000000000000000000000000000000': {
+        data: [0, [['local', '2']]],
+        hash: 't/000000000000000000000000000000',
+        meta: [],
+      },
+      't/000000000000000000000000000001': {
+        data: {
+          indexes: [],
+          meta: {
+            basisHash: 'b69dbef5na7teqlacuio939dcfi7sc1q',
+            mutationID: 2,
+            mutatorArgsJSON: [2],
+            mutatorName: 'mutator_name_2',
+            originalHash: null,
+            type: 2,
+          },
+          valueHash: 't/000000000000000000000000000000',
+        },
+        hash: 't/000000000000000000000000000001',
+        meta: [
+          't/000000000000000000000000000000',
+          'b69dbef5na7teqlacuio939dcfi7sc1q',
+        ],
+      },
+    });
+  });
+
+  await addSnapshot(
+    chain,
+    perdag,
+    Object.entries({
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4,
+    }),
+  );
+  await addIndexChange(chain, memdag);
+
+  await memdag.withRead(async dagRead => {
+    const visitor = new PersistGatherVisitor(dagRead);
+    await visitor.visitCommit(chain[chain.length - 1].chunk.hash);
+    expect(Object.fromEntries(visitor.gatheredChunks)).to.deep.equal({
+      't/000000000000000000000000000002': {
+        data: [0, [['\u00002\u0000local', '2']]],
+        hash: 't/000000000000000000000000000002',
+        meta: [],
+      },
+      't/000000000000000000000000000003': {
+        data: {
+          indexes: [
+            {
+              definition: {
+                jsonPointer: '',
+                keyPrefix: 'local',
+                name: '4',
+              },
+              valueHash: 't/000000000000000000000000000002',
+            },
+          ],
+          meta: {
+            basisHash: 'itibu92mh4kb91a7mer7fhl4bi65mpe0',
+            lastMutationID: 3,
+            type: 1,
+          },
+          valueHash: 'nv13uk6dcs4eu565hqts1uc70h8ouk9a',
+        },
+        hash: 't/000000000000000000000000000003',
+        meta: [
+          'nv13uk6dcs4eu565hqts1uc70h8ouk9a',
+          'itibu92mh4kb91a7mer7fhl4bi65mpe0',
+          't/000000000000000000000000000002',
+        ],
+      },
+    });
+  });
+});

--- a/src/sync/persist-gather-visitor.test.ts
+++ b/src/sync/persist-gather-visitor.test.ts
@@ -111,7 +111,7 @@ test('dag with some permanent hashes and some temp hashes on top', async () => {
         data: {
           indexes: [],
           meta: {
-            basisHash: 'b69dbef5na7teqlacuio939dcfi7sc1q',
+            basisHash: 'kf7ac7jta5b86iu74e3sqk49ec0tq6d3',
             mutationID: 2,
             mutatorArgsJSON: [2],
             mutatorName: 'mutator_name_2',
@@ -123,7 +123,7 @@ test('dag with some permanent hashes and some temp hashes on top', async () => {
         hash: 't/000000000000000000000000000001',
         meta: [
           't/000000000000000000000000000000',
-          'b69dbef5na7teqlacuio939dcfi7sc1q',
+          'kf7ac7jta5b86iu74e3sqk49ec0tq6d3',
         ],
       },
     });

--- a/src/sync/persist-gather-visitor.ts
+++ b/src/sync/persist-gather-visitor.ts
@@ -1,0 +1,40 @@
+import * as db from '../db/mod';
+import {Hash, isTempHash} from '../hash';
+import type * as dag from '../dag/mod';
+import type * as btree from '../btree/mod';
+import type {ReadonlyJSONValue} from '../json';
+
+export class PersistGatherVisitor extends db.Visitor {
+  private readonly _gatheredChunks: Map<Hash, dag.Chunk> = new Map();
+
+  get gatheredChunks(): ReadonlyMap<Hash, dag.Chunk> {
+    return this._gatheredChunks;
+  }
+
+  override async visitCommitChunk(
+    chunk: dag.Chunk<db.CommitData>,
+  ): Promise<void> {
+    if (this._visitChunk(chunk)) {
+      // Recurse down the tree
+      return super.visitCommitChunk(chunk);
+    }
+    // Not a temp hash, no need to visit anything else.
+  }
+
+  override async visitBTreeNodeChunk(
+    chunk: dag.Chunk<btree.Node>,
+  ): Promise<void> {
+    if (this._visitChunk(chunk)) {
+      return super.visitBTreeNodeChunk(chunk);
+    }
+  }
+
+  private _visitChunk(chunk: dag.Chunk<ReadonlyJSONValue>): boolean {
+    if (isTempHash(chunk.hash)) {
+      // If this is a temp hash, then this is a chunk that has not yet been persisted.
+      this._gatheredChunks.set(chunk.hash, chunk);
+      return true;
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
Add a DB/Dag Visitor -- This walks the entire dag using a semantic
visitor, which knows what each chunk represents because it started
from a commit.

Then implement the PersistGatherVisitor as a visitor extending the Dag Visitor
which stops the traversal when it finds a non temp hash. It collects all
the chunks it sees and exposes them as a property.

Towards #671 