### PR TITLE
feat: Simplified Dueling Dags - Implement initing a new client including bootstraping from existing client state.

### DIFF
--- a/src/db/commit.ts
+++ b/src/db/commit.ts
@@ -2,6 +2,7 @@ import type * as dag from '../dag/mod';
 import type {ReadonlyJSONValue} from '../json';
 import {assertJSONValue} from '../json';
 import {
+  assert,
   assertArray,
   assertNotNull,
   assertNotUndefined,

--- a/src/db/commit.ts
+++ b/src/db/commit.ts
@@ -2,7 +2,6 @@ import type * as dag from '../dag/mod';
 import type {ReadonlyJSONValue} from '../json';
 import {assertJSONValue} from '../json';
 import {
-  assert,
   assertArray,
   assertNotNull,
   assertNotUndefined,

--- a/src/sync/clients.test.ts
+++ b/src/sync/clients.test.ts
@@ -1,12 +1,24 @@
 import {expect} from '@esm-bundle/chai';
-import { assertNotUndefined } from '../asserts';
-import { BTreeRead } from '../btree/read';
+import {assertNotUndefined} from '../asserts';
+import {BTreeRead} from '../btree/read';
 import * as dag from '../dag/mod';
-import { fromChunk, SnapshotMeta } from '../db/commit';
+import {fromChunk, SnapshotMeta} from '../db/commit';
 import {assertHash, hashOf, initHasher, newTempHash} from '../hash';
-import {getClient, getClients, initClient, setClient, setClients} from './clients';
+import {
+  getClient,
+  getClients,
+  initClient,
+  setClient,
+  setClients,
+} from './clients';
 import {SinonFakeTimers, useFakeTimers} from 'sinon';
-import { addGenesis, addIndexChange, addLocal, addSnapshot, Chain } from '../db/test-helpers';
+import {
+  addGenesis,
+  addIndexChange,
+  addLocal,
+  addSnapshot,
+  Chain,
+} from '../db/test-helpers';
 
 let clock: SinonFakeTimers;
 setup(async () => {
@@ -540,11 +552,13 @@ test('getClients throws errors if chunk pointed to by clients head does not cont
 test('initClient creates new empty snapshot when no existing snapshot to bootstrap from', async () => {
   const dagStore = new dag.TestStore();
   clock.tick(4000);
-  const [clientId, client] = await dagStore.withWrite(async (write: dag.Write) => {
-    const clientInfo = await initClient(write);
-    await write.commit();
-    return clientInfo;
-  });
+  const [clientId, client] = await dagStore.withWrite(
+    async (write: dag.Write) => {
+      const clientInfo = await initClient(write);
+      await write.commit();
+      return clientInfo;
+    },
+  );
 
   await dagStore.withRead(async (read: dag.Read) => {
     // Newly inited client was added to the client map.
@@ -567,7 +581,7 @@ test('initClient creates new empty snapshot when no existing snapshot to bootstr
 
 test('initClient bootstraps from base snapshot of client with highest heartbeat', async () => {
   const dagStore = new dag.TestStore();
-  
+
   const chain: Chain = [];
   await addGenesis(chain, dagStore);
   await addSnapshot(chain, dagStore, [['foo', 'bar']]);
@@ -597,18 +611,20 @@ test('initClient bootstraps from base snapshot of client with highest heartbeat'
     await write.commit();
   });
 
-  const [clientId, client] = await dagStore.withWrite(async (write: dag.Write) => {
-    const clientInfo = await initClient(write);
-    await write.commit();
-    return clientInfo;
-  });
+  const [clientId, client] = await dagStore.withWrite(
+    async (write: dag.Write) => {
+      const clientInfo = await initClient(write);
+      await write.commit();
+      return clientInfo;
+    },
+  );
 
   await dagStore.withRead(async (read: dag.Read) => {
     // Newly inited client was added to the client map.
     expect(await getClient(clientId, read)).to.deep.equal(client);
     expect(client.heartbeatTimestampMs).to.equal(clock.now);
 
-    // new client's head hash points to points to a commit that matches client2BaseSnapshoCommit 
+    // new client's head hash points to points to a commit that matches client2BaseSnapshoCommit
     // but with a local mutation id of 0
     const headChunk = await read.getChunk(client.headHash);
     assertNotUndefined(headChunk);
@@ -616,10 +632,13 @@ test('initClient bootstraps from base snapshot of client with highest heartbeat'
     expect(commit.isSnapshot()).to.be.true;
     const snapshotMeta = commit.meta as SnapshotMeta;
     expect(client2BaseSnapshotCommit.isSnapshot()).to.be.true;
-    const client2BaseSnapshotMeta = client2BaseSnapshotCommit.meta as SnapshotMeta;
+    const client2BaseSnapshotMeta =
+      client2BaseSnapshotCommit.meta as SnapshotMeta;
 
     expect(snapshotMeta.basisHash).to.equal(client2BaseSnapshotMeta.basisHash);
-    expect(snapshotMeta.cookieJSON).to.equal(client2BaseSnapshotMeta.cookieJSON);
+    expect(snapshotMeta.cookieJSON).to.equal(
+      client2BaseSnapshotMeta.cookieJSON,
+    );
     expect(commit.mutationID).to.equal(0);
     expect(commit.indexes).to.not.be.empty;
     expect(commit.indexes).to.deep.equal(client2BaseSnapshotCommit.indexes);

--- a/src/sync/clients.test.ts
+++ b/src/sync/clients.test.ts
@@ -561,11 +561,11 @@ test('initClient creates new empty snapshot when no existing snapshot to bootstr
   );
 
   await dagStore.withRead(async (read: dag.Read) => {
-    // Newly inited client was added to the client map.
+    // New client was added to the client map.
     expect(await getClient(clientId, read)).to.deep.equal(client);
     expect(client.heartbeatTimestampMs).to.equal(clock.now);
 
-    // new client's head hash points to an empty snapshot with an empty btree
+    // New client's head hash points to an empty snapshot with an empty btree.
     const headChunk = await read.getChunk(client.headHash);
     assertNotUndefined(headChunk);
     const commit = await fromChunk(headChunk);
@@ -611,6 +611,7 @@ test('initClient bootstraps from base snapshot of client with highest heartbeat'
     await write.commit();
   });
 
+  clock.tick(4000);
   const [clientId, client] = await dagStore.withWrite(
     async (write: dag.Write) => {
       const clientInfo = await initClient(write);
@@ -620,12 +621,12 @@ test('initClient bootstraps from base snapshot of client with highest heartbeat'
   );
 
   await dagStore.withRead(async (read: dag.Read) => {
-    // Newly inited client was added to the client map.
+    // New client was added to the client map.
     expect(await getClient(clientId, read)).to.deep.equal(client);
     expect(client.heartbeatTimestampMs).to.equal(clock.now);
 
-    // new client's head hash points to points to a commit that matches client2BaseSnapshoCommit
-    // but with a local mutation id of 0
+    // New client's head hash points to a commit that matches client2BaseSnapshoCommit
+    // but with a local mutation id of 0.
     const headChunk = await read.getChunk(client.headHash);
     assertNotUndefined(headChunk);
     const commit = await fromChunk(headChunk);

--- a/src/sync/clients.ts
+++ b/src/sync/clients.ts
@@ -4,10 +4,13 @@ import type {ReadonlyJSONValue} from '../json';
 import {assertNumber, assertObject} from '../asserts';
 import {hasOwn} from '../has-own';
 import type {ClientID} from './client-id';
+import {uuid as makeUuid} from './uuid';
+import {Commit, newSnapshot} from '../db/commit';
+import {BTreeWrite} from '../btree/write';
 
 type ClientMap = Map<ClientID, Client>;
 
-type Client = {
+export type Client = {
   /**
    * A UNIX timestamp in milliseconds updated by the client once a minute
    * while it is active and everytime the client persists its state to
@@ -91,4 +94,56 @@ export async function setClient(
   const clients = await getClients(dagWrite);
   clients.set(id, client);
   return setClients(clients, dagWrite);
+}
+
+export async function initClient(
+  dagStore: dag.Store,
+): Promise<[ClientID, Client]> {
+  return dagStore.withWrite(async dagWrite => {
+    const clients = await getClients(dagWrite);
+    const newClientID = makeUuid();
+    let bootstrapClient: Client | undefined;
+    clients.forEach(client => {
+      if (
+        !bootstrapClient ||
+        bootstrapClient.heartbeatTimestampMs < client.heartbeatTimestampMs
+      ) {
+        bootstrapClient = client;
+      }
+    });
+
+    let newClientCommit;
+    if (bootstrapClient) {
+      const bootstrapCommit = await Commit.baseSnapshot(
+        bootstrapClient.headHash,
+        dagWrite,
+      );
+      // Copy the commit with one change: set last mutation id to 0
+      newClientCommit = newSnapshot(
+        dagWrite.createChunk,
+        bootstrapCommit.meta.basisHash,
+        0 /* lastMutationID */,
+        bootstrapCommit.meta.cookieJSON,
+        bootstrapCommit.valueHash,
+        bootstrapCommit.indexes,
+      );
+    } else {
+      const valueHash = await new BTreeWrite(dagWrite).flush();
+      newClientCommit = newSnapshot(
+        dagWrite.createChunk,
+        null /* basisHash */,
+        0 /* lastMutationID */,
+        null /* cookie */,
+        valueHash,
+        [],
+      );
+    }
+
+    const newClient = {
+      heartbeatTimestampMs: Date.now(),
+      headHash: newClientCommit.chunk.hash,
+    };
+    await setClient(newClientID, newClient, dagWrite);
+    return [newClientID, newClient];
+  });
 }

--- a/src/sync/clients.ts
+++ b/src/sync/clients.ts
@@ -141,7 +141,5 @@ export async function initClient(
   };
   await setClient(newClientID, newClient, dagWrite);
 
-  await dagWrite.commit();
-
   return [newClientID, newClient];
 }

--- a/src/sync/clients.ts
+++ b/src/sync/clients.ts
@@ -143,7 +143,7 @@ export async function initClient(
     await setClient(newClientID, newClient, dagWrite);
 
     await dagWrite.commit();
-    
+
     return [newClientID, newClient];
   });
 }

--- a/src/sync/clients.ts
+++ b/src/sync/clients.ts
@@ -103,8 +103,11 @@ export async function initClient(
   const newClientID = makeUuid();
   let bootstrapClient;
   for (const client of clients.values()) {
-    if (!bootstrapClient || bootstrapClient.heartbeatTimestampMs < client.heartbeatTimestampMs) {
-      bootstrapClient = client
+    if (
+      !bootstrapClient ||
+      bootstrapClient.heartbeatTimestampMs < client.heartbeatTimestampMs
+    ) {
+      bootstrapClient = client;
     }
   }
 

--- a/src/sync/clients.ts
+++ b/src/sync/clients.ts
@@ -141,6 +141,9 @@ export async function initClient(
       headHash: newClientCommit.chunk.hash,
     };
     await setClient(newClientID, newClient, dagWrite);
+
+    await dagWrite.commit();
+    
     return [newClientID, newClient];
   });
 }


### PR DESCRIPTION
Simplified Dueling Dags always creates a new Client for each new tab.  To enable fast startup of new tabs utilizing previous stored data Simplified Dueling Dags bootstraps new clients by forking an existing Client's state. 

When forking from another Client, the fork should be based on the existing Client's most recent base snapshot (which may not be its latest head).  This is necessary because pending mutations (LocalMutationCommits) cannot be forked as the last mutation id series is different per client.

It is important that the last mutation id for the new client be set to 0, since a replicache server implementation will start clients for which they do not have a last mutation id stored at last mutation id 0.  If the server receives a request from a client with a non-0 last mutation id, for which it does not have a last mutation id stored, it knows that it is unsafe for it to execute mutations form the client, as it could result in re-running mutations or otherwise failing to guarantee sequential execution of mutations.  This tells the server that this is an old client that it has GC'd (we need some way to signal this to the client so it can reset itself, see https://github.com/rocicorp/replicache/issues/335). 

When choosing a Client to bootstrap from, it is safe to pick any Client, but it is ideal to chose the Client with the most recent snapshot from the server.  Currently the age of snapshots is not stored, so this implementation uses a heuristic of choosing the base snapshot of the Client with the newest heartbeat timestamp. 

See larger design at https://www.notion.so/Simplified-DD1-1ed242a8c1094d9ca3734c46d65ffce4#64e4299105dd490a9ffbc6c9c771f5d2

Part of #671