### PR TITLE
refactor: remove default value of Meta for Commit's  M type param to improve typing of Commit

### DIFF
--- a/src/db/commit.test.ts
+++ b/src/db/commit.test.ts
@@ -117,7 +117,7 @@ test('chain', async () => {
 });
 
 test('load roundtrip', async () => {
-  const t = (chunk: dag.Chunk, expected: Commit | Error) => {
+  const t = (chunk: dag.Chunk, expected: Commit<Meta> | Error) => {
     {
       if (expected instanceof Error) {
         expect(() => fromChunk(chunk)).to.throw(
@@ -357,12 +357,12 @@ function createChunk<V extends Value>(
   return dag.createChunk(data, refs, dag.defaultChunkHasher);
 }
 
-async function makeCommit(
-  meta: Meta,
+async function makeCommit<M extends Meta>(
+  meta: M,
   valueHash: Hash,
   refs: Hash[],
-): Promise<dag.Chunk> {
-  const data: CommitData = {
+): Promise<dag.Chunk<CommitData<M>>> {
+  const data: CommitData<M> = {
     meta,
     valueHash,
     indexes: [],

--- a/src/db/read.ts
+++ b/src/db/read.ts
@@ -1,7 +1,7 @@
 import {IndexRead} from './index';
 import * as dag from '../dag/mod';
 import {convert, scan, ScanOptions, ScanOptionsInternal} from './scan';
-import {Commit, DEFAULT_HEAD_NAME} from './commit';
+import {Commit, DEFAULT_HEAD_NAME, Meta} from './commit';
 import type {ReadonlyJSONValue} from '../json';
 import {BTreeRead, BTreeWrite, Entry} from '../btree/mod';
 import type {Hash} from '../hash';
@@ -107,15 +107,15 @@ export async function fromWhence(
 export function readCommit(
   whence: Whence,
   dagRead: dag.Write,
-): Promise<[Hash, Commit, BTreeWrite]>;
+): Promise<[Hash, Commit<Meta>, BTreeWrite]>;
 export function readCommit(
   whence: Whence,
   dagRead: dag.Read,
-): Promise<[Hash, Commit, BTreeRead]>;
+): Promise<[Hash, Commit<Meta>, BTreeRead]>;
 export async function readCommit(
   whence: Whence,
   dagRead: dag.Read,
-): Promise<[Hash, Commit, BTreeRead]> {
+): Promise<[Hash, Commit<Meta>, BTreeRead]> {
   let hash: Hash;
   switch (whence.type) {
     case WhenceType.Hash:
@@ -139,7 +139,9 @@ export async function readCommit(
   return [hash, commit, map];
 }
 
-export function readIndexesForRead(commit: Commit): Map<string, IndexRead> {
+export function readIndexesForRead(
+  commit: Commit<Meta>,
+): Map<string, IndexRead> {
   const m = new Map();
   for (const index of commit.indexes) {
     m.set(index.definition.name, new IndexRead(index, undefined));

--- a/src/db/test-helpers.ts
+++ b/src/db/test-helpers.ts
@@ -1,12 +1,12 @@
 import {expect} from '@esm-bundle/chai';
 import type * as dag from '../dag/mod';
-import {Commit, DEFAULT_HEAD_NAME} from './commit';
+import {Commit, DEFAULT_HEAD_NAME, Meta} from './commit';
 import {readCommit, whenceHead} from './read';
 import {initDB, Write, readIndexesForWrite} from './write';
 import {LogContext} from '../logger';
 import type {JSONValue} from '../json';
 
-export type Chain = Commit[];
+export type Chain = Commit<Meta>[];
 
 export async function addGenesis(
   chain: Chain,
@@ -18,7 +18,7 @@ export async function addGenesis(
   return chain;
 }
 
-export async function createGenesis(store: dag.Store): Promise<Commit> {
+export async function createGenesis(store: dag.Store): Promise<Commit<Meta>> {
   await store.withWrite(async w => {
     await initDB(w, DEFAULT_HEAD_NAME);
   });
@@ -43,7 +43,7 @@ export async function createLocal(
   entries: [string, JSONValue][],
   store: dag.Store,
   i: number,
-): Promise<Commit> {
+): Promise<Commit<Meta>> {
   const lc = new LogContext();
   await store.withWrite(async dagWrite => {
     const w = await Write.newLocal(
@@ -80,7 +80,7 @@ export async function createIndex(
   prefix: string,
   jsonPointer: string,
   store: dag.Store,
-): Promise<Commit> {
+): Promise<Commit<Meta>> {
   const lc = new LogContext();
   await store.withWrite(async dagWrite => {
     const w = await Write.newIndexChange(

--- a/src/db/visitor.test.ts
+++ b/src/db/visitor.test.ts
@@ -11,7 +11,7 @@ import {hashOf, initHasher} from '../hash';
 import type {Node} from '../btree/node';
 import type {ReadonlyJSONValue} from '../json';
 import {Visitor} from './visitor';
-import {Commit, newLocal} from './commit';
+import {Commit, Meta, newLocal} from './commit';
 
 setup(async () => {
   await initHasher();
@@ -29,7 +29,7 @@ test('test that we get to the data nodes', async () => {
     }
   }
 
-  const t = async (commit: Commit, expected: ReadonlyJSONValue[]) => {
+  const t = async (commit: Commit<Meta>, expected: ReadonlyJSONValue[]) => {
     log.length = 0;
     await dagStore.withRead(async dagRead => {
       const visitor = new TestVisitor(dagRead);

--- a/src/db/visitor.ts
+++ b/src/db/visitor.ts
@@ -43,10 +43,10 @@ export class Visitor {
 
     const {data} = chunk;
     assertCommitData(data);
-    await this.visitCommitChunk(chunk as dag.Chunk<CommitData>);
+    await this.visitCommitChunk(chunk as dag.Chunk<CommitData<Meta>>);
   }
 
-  async visitCommitChunk(chunk: dag.Chunk<CommitData>): Promise<void> {
+  async visitCommitChunk(chunk: dag.Chunk<CommitData<Meta>>): Promise<void> {
     const {data} = chunk;
     await Promise.all([
       this._visitCommitMeta(data.meta),

--- a/src/db/write.ts
+++ b/src/db/write.ts
@@ -2,6 +2,7 @@ import type * as dag from '../dag/mod';
 import type {ReadonlyJSONValue} from '../json';
 import {
   Commit,
+  Meta as CommitMeta,
   DEFAULT_HEAD_NAME,
   IndexDefinition,
   IndexRecord,
@@ -46,7 +47,7 @@ const enum MetaType {
 
 export class Write extends Read {
   private readonly _dagWrite: dag.Write;
-  private readonly _basis: Commit | undefined;
+  private readonly _basis: Commit<CommitMeta> | undefined;
   private readonly _meta: Meta;
 
   declare map: BTreeWrite;
@@ -56,7 +57,7 @@ export class Write extends Read {
   constructor(
     dagWrite: dag.Write,
     map: BTreeWrite,
-    basis: Commit | undefined,
+    basis: Commit<CommitMeta> | undefined,
     meta: Meta,
     indexes: Map<string, IndexWrite>,
   ) {
@@ -434,7 +435,9 @@ export async function maybeInitDefaultDB(dagStore: dag.Store): Promise<void> {
   });
 }
 
-export function readIndexesForWrite(commit: Commit): Map<string, IndexWrite> {
+export function readIndexesForWrite(
+  commit: Commit<CommitMeta>,
+): Map<string, IndexWrite> {
   const m = new Map();
   for (const index of commit.indexes) {
     m.set(index.definition.name, new IndexWrite(index, undefined));

--- a/src/migrate/migrate-0-to-1.test.ts
+++ b/src/migrate/migrate-0-to-1.test.ts
@@ -15,7 +15,7 @@ import * as db from '../db/mod';
 import * as sync from '../sync/mod';
 import * as utf8 from '../utf8';
 import * as prolly from '../prolly/mod';
-import {CommitData, MetaTyped} from '../db/commit';
+import {CommitData, MetaTyped, SnapshotMeta} from '../db/commit';
 import {hashOf, initHasher} from '../hash';
 
 setup(async () => {
@@ -183,7 +183,7 @@ test('migrateCommit', async () => {
   const entries: prolly.Entry[] = [['a', 42]];
   const entriesHash = hashOf('entries-hash');
 
-  const commit: CommitData = {
+  const commit: CommitData<SnapshotMeta> = {
     meta: {
       type: MetaTyped.Snapshot,
       basisHash: null,

--- a/src/migrate/migrate-1-to-2.ts
+++ b/src/migrate/migrate-1-to-2.ts
@@ -5,7 +5,7 @@ import {assertEntries} from '../prolly/mod';
 import * as sync from '../sync/mod';
 import type {LogContext} from '../logger';
 import {BTreeWrite} from '../btree/mod';
-import {IndexRecord, MetaTyped} from '../db/commit';
+import {IndexRecord, Meta, MetaTyped} from '../db/commit';
 import type {Hash} from '../hash';
 import {setCurrentVersion} from './migrate-0-to-1';
 
@@ -96,7 +96,7 @@ export async function migrateMaybeWeakCommit(
   const basisHash = basisHashP && (await basisHashP);
   const originalHash = originalHashP && (await originalHashP);
 
-  let newCommit: db.Commit;
+  let newCommit: db.Commit<Meta>;
   switch (commit.meta.type) {
     case MetaTyped.IndexChange:
       newCommit = db.newIndexChange(

--- a/src/sync/persist-gather-visitor.ts
+++ b/src/sync/persist-gather-visitor.ts
@@ -3,6 +3,7 @@ import {Hash, isTempHash} from '../hash';
 import type * as dag from '../dag/mod';
 import type * as btree from '../btree/mod';
 import type {HashType} from '../db/visitor';
+import type { Meta } from '../db/commit';
 
 export class PersistGatherVisitor extends db.Visitor {
   private readonly _gatheredChunks: Map<Hash, dag.Chunk> = new Map();
@@ -20,7 +21,7 @@ export class PersistGatherVisitor extends db.Visitor {
   }
 
   override async visitCommitChunk(
-    chunk: dag.Chunk<db.CommitData>,
+    chunk: dag.Chunk<db.CommitData<Meta>>,
   ): Promise<void> {
     this._gatheredChunks.set(chunk.hash, chunk);
     return super.visitCommitChunk(chunk);

--- a/src/sync/persist-gather-visitor.ts
+++ b/src/sync/persist-gather-visitor.ts
@@ -3,7 +3,7 @@ import {Hash, isTempHash} from '../hash';
 import type * as dag from '../dag/mod';
 import type * as btree from '../btree/mod';
 import type {HashType} from '../db/visitor';
-import type { Meta } from '../db/commit';
+import type {Meta} from '../db/commit';
 
 export class PersistGatherVisitor extends db.Visitor {
   private readonly _gatheredChunks: Map<Hash, dag.Chunk> = new Map();

--- a/src/sync/pull.test.ts
+++ b/src/sync/pull.test.ts
@@ -35,6 +35,7 @@ import {LogContext} from '../logger';
 import {emptyHash, initHasher} from '../hash';
 import {stringCompare} from '../prolly/string-compare';
 import {asyncIterableToArray} from '../async-iterable-to-array';
+import type {SnapshotMeta} from '../db/commit';
 
 setup(async () => {
   await initHasher();
@@ -49,8 +50,9 @@ test('begin try pull', async () => {
   await addIndexChange(chain, store);
   const startingNumCommits = chain.length;
   const baseSnapshot = chain[1];
-  const [baseLastMutationID, baseCookie] =
-    Commit.snapshotMetaParts(baseSnapshot);
+  const [baseLastMutationID, baseCookie] = Commit.snapshotMetaParts(
+    baseSnapshot as Commit<SnapshotMeta>,
+  );
   const baseValueMap = new Map([['foo', '"bar"']]);
 
   const requestID = 'requestID';
@@ -458,8 +460,9 @@ test('begin try pull', async () => {
         const chunk = await read.getChunk(syncHeadHash);
         assertNotUndefined(chunk);
         const syncHead = db.fromChunk(chunk);
-        const [gotLastMutationID, gotCookie] =
-          Commit.snapshotMetaParts(syncHead);
+        const [gotLastMutationID, gotCookie] = Commit.snapshotMetaParts(
+          syncHead as Commit<SnapshotMeta>,
+        );
         expect(expSyncHead.lastMutationID).to.equal(gotLastMutationID);
         expect(expSyncHead.cookie).to.deep.equal(gotCookie);
         // Check the value is what's expected.
@@ -762,8 +765,9 @@ test('changed keys', async () => {
     await addSnapshot(chain, store, entries);
 
     const baseSnapshot = chain[chain.length - 1];
-    const [baseLastMutationID, baseCookie] =
-      Commit.snapshotMetaParts(baseSnapshot);
+    const [baseLastMutationID, baseCookie] = Commit.snapshotMetaParts(
+      baseSnapshot as Commit<SnapshotMeta>,
+    );
 
     const requestID = 'request_id';
     const clientID = 'test_client_id';

--- a/src/sync/pull.ts
+++ b/src/sync/pull.ts
@@ -18,6 +18,7 @@ import * as btree from '../btree/mod';
 import {BTreeRead} from '../btree/mod';
 import {updateIndexes} from '../db/write';
 import {emptyHash, Hash} from '../hash';
+import type {Meta} from '../db/commit';
 
 export const PULL_VERSION = 0;
 
@@ -388,8 +389,8 @@ function assertResult(v: any): asserts v is Result {
   assertHTTPRequestInfo(v.httpRequestInfo);
 }
 async function addChangedKeysForIndexes(
-  mainCommit: db.Commit,
-  syncCommit: db.Commit,
+  mainCommit: db.Commit<Meta>,
+  syncCommit: db.Commit<Meta>,
   read: dag.Read,
   changedKeysMap: ChangedKeysMap,
 ) {

--- a/src/sync/test-helpers.ts
+++ b/src/sync/test-helpers.ts
@@ -3,6 +3,7 @@ import type {Chain} from '../db/test-helpers';
 import type * as dag from '../dag/mod';
 import * as db from '../db/mod';
 import * as sync from '../sync/mod';
+import type {SnapshotMeta} from '../db/commit';
 
 // See db.test_helpers for addLocal, addSnapshot, etc. We can't put addLocalRebase
 // there because sync depends on db, and addLocalRebase depends on sync.
@@ -19,7 +20,7 @@ export async function addSyncSnapshot(
 ): Promise<Chain> {
   expect(chain.length >= 2).to.be.true;
 
-  let maybeBaseSnapshot: db.Commit | undefined;
+  let maybeBaseSnapshot: db.Commit<SnapshotMeta> | undefined;
   for (let i = chain.length - 1; i > 0; i--) {
     const commit = chain[i - 1];
     if (commit.isSnapshot()) {


### PR DESCRIPTION
### Problem
Having a default value of Meta for Commit's M type param led to less specific typing in many places. 

### Solution
Remove the default and make typing more specific where possible.