### PR TITLE
fix: Provide more details to logger when push or pull fails

### DIFF
--- a/src/puller.ts
+++ b/src/puller.ts
@@ -95,9 +95,13 @@ function assertPatchOperation(p: unknown): asserts p is PatchOperation {
  */
 export class PullError extends Error {
   name = 'PullError';
-  cause?: Error;
-  constructor(cause?: Error) {
+  // causedBy is used instead of cause, because while cause has been proposed as a
+  // JavaScript language standard for this purpose (see
+  // https://github.com/tc39/proposal-error-cause) current browser behavior is
+  // inconsistent.
+  causedBy?: Error;
+  constructor(causedBy?: Error) {
     super('Failed to pull');
-    this.cause = cause;
+    this.causedBy = causedBy;
   }
 }

--- a/src/pusher.ts
+++ b/src/pusher.ts
@@ -16,9 +16,13 @@ export const defaultPusher: Pusher = async request => {
  */
 export class PushError extends Error {
   name = 'PushError';
-  cause?: Error;
-  constructor(cause?: Error) {
+  // causedBy is used instead of cause, because while cause has been proposed as a
+  // JavaScript language standard for this purpose (see
+  // https://github.com/tc39/proposal-error-cause) current browser behavior is
+  // inconsistent.
+  causedBy?: Error;
+  constructor(causedBy?: Error) {
     super('Failed to push');
-    this.cause = cause;
+    this.causedBy = causedBy;
   }
 }

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -2790,7 +2790,7 @@ test('online', async () => {
     log.push(b);
   };
 
-  const info = sinon.stub(console, 'info');
+  const consoleError = sinon.stub(console, 'error');
 
   fetchMock.post(pushURL, async () => {
     await sleep(10);
@@ -2805,17 +2805,17 @@ test('online', async () => {
   await tickAFewTimes();
 
   expect(rep.online).to.equal(false);
-  expect(info.callCount).to.be.greaterThan(0);
+  expect(consoleError.callCount).to.be.greaterThan(0);
   expect(log).to.deep.equal([false]);
 
-  info.resetHistory();
+  consoleError.resetHistory();
 
   fetchMock.post(pushURL, {});
   await rep.mutate.addData({a: 1});
 
   await tickAFewTimes(20);
 
-  expect(info.callCount).to.equal(0);
+  expect(consoleError.callCount).to.equal(0);
   expect(rep.online).to.equal(true);
   expect(log).to.deep.equal([false, true]);
 });

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -715,8 +715,10 @@ export class Replicache<MD extends MutatorDefs = {}> {
 
       if (e instanceof PushError || e instanceof PullError) {
         online = false;
+        this._logger.error?.(`${name} threw:\n`, e, '\nwith cause:\n', e.cause);
+      } else {
+        this._logger.error?.(`${name} threw:`, e);
       }
-      this._logger.info?.(`${name} returned: ${e}`);
       return false;
     } finally {
       if (this._online !== online) {

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -717,7 +717,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
         online = false;
         this._logger.error?.(`${name} threw:\n`, e, '\nwith cause:\n', e.cause);
       } else {
-        this._logger.error?.(`${name} threw:`, e);
+        this._logger.error?.(`${name} threw:\n`, e);
       }
       return false;
     } finally {

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -715,7 +715,12 @@ export class Replicache<MD extends MutatorDefs = {}> {
 
       if (e instanceof PushError || e instanceof PullError) {
         online = false;
-        this._logger.error?.(`${name} threw:\n`, e, '\nwith cause:\n', e.cause);
+        this._logger.error?.(
+          `${name} threw:\n`,
+          e,
+          '\nwith cause:\n',
+          e.causedBy,
+        );
       } else {
         this._logger.error?.(`${name} threw:\n`, e);
       }


### PR DESCRIPTION
### Problem
Push and pull error logging lacks sufficient detail to debug errors.

A pull failure currently logs to info (and a push error logs essentially the same):
`Pull returned: PullError: Failed to pull`

Not the most useful logging.  However, our `PushError` and `PullError` classes have a `cause?: Error` property with details on the underlying cause, it is just not logged.

### Solution
If the error is a `PushError` or `PullError`, log the cause.

Update log format to include stack traces for both the error, and cause.

Also update to use `error` instead of `info` logging.

Closes #690

Example error log message:
![image](https://user-images.githubusercontent.com/19158916/142683140-a1310a5a-1a38-4576-9102-59af7ba5d864.png)


