### PR TITLE
refactor: Optimize scan to reduce for await/yield*

### DIFF
--- a/src/btree/node.test.ts
+++ b/src/btree/node.test.ts
@@ -268,7 +268,7 @@ test('empty read tree', async () => {
     const r = new BTreeRead(dagRead);
     expect(await r.get('a')).to.be.undefined;
     expect(await r.has('b')).to.be.false;
-    expect(await asyncIterToArray(r.scan({}))).to.deep.equal([]);
+    expect(await asyncIterToArray(r.scan({}, x => x))).to.deep.equal([]);
   });
 });
 
@@ -286,7 +286,7 @@ test('empty write tree', async () => {
     );
     expect(await w.get('a')).to.be.undefined;
     expect(await w.has('b')).to.be.false;
-    expect(await asyncIterToArray(w.scan({}))).to.deep.equal([]);
+    expect(await asyncIterToArray(w.scan({}, x => x))).to.deep.equal([]);
 
     const h = await w.flush();
     expect(h).to.equal(emptyTreeHash);
@@ -1219,9 +1219,13 @@ test('scan', async () => {
     await doRead(rootHash, dagStore, async r => {
       const res: Entry<ReadonlyJSONValue>[] = [];
       const onLimitKeyCalls: string[] = [];
-      const scanResult = r.scan(options, inclusiveLimitKey => {
-        onLimitKeyCalls.push(inclusiveLimitKey);
-      });
+      const scanResult = r.scan(
+        options,
+        x => x,
+        inclusiveLimitKey => {
+          onLimitKeyCalls.push(inclusiveLimitKey);
+        },
+      );
       for await (const e of scanResult) {
         res.push(e);
       }

--- a/src/btree/node.ts
+++ b/src/btree/node.ts
@@ -224,13 +224,14 @@ export class DataNodeImpl extends NodeImpl<ReadonlyJSONValue> {
     return this._splice(tree, i, 1);
   }
 
-  async *scan(
+  async *scan<R>(
     _tree: BTreeRead,
     prefix: string,
     fromKey: string,
     limit: number,
+    convertEntry: (entry: Entry<ReadonlyJSONValue>) => R,
     onLimitKey?: (inclusiveLimitKey: string) => void,
-  ): AsyncGenerator<Entry<ReadonlyJSONValue>, number, unknown> {
+  ): AsyncGenerator<R, number, unknown> {
     const {entries} = this;
     let i = binarySearch(fromKey, entries);
     if (i < 0) {
@@ -244,7 +245,7 @@ export class DataNodeImpl extends NodeImpl<ReadonlyJSONValue> {
       if (onLimitKey && limit === 1) {
         onLimitKey(entries[i][0]);
       }
-      yield entries[i];
+      yield convertEntry(entries[i]);
     }
     return limit;
   }
@@ -447,13 +448,14 @@ export class InternalNodeImpl extends NodeImpl<Hash> {
     return this._mergeAndPartition(tree, i, childNode);
   }
 
-  async *scan(
+  async *scan<R>(
     tree: BTreeRead,
     prefix: string,
     fromKey: string,
     limit: number,
+    convertEntry: (entry: Entry<ReadonlyJSONValue>) => R,
     onLimitKey?: (inclusiveLimitKey: string) => void,
-  ): AsyncGenerator<Entry<ReadonlyJSONValue>, number> {
+  ): AsyncGenerator<R, number> {
     const {entries} = this;
     let i = binarySearch(fromKey, entries);
     if (i < 0) {
@@ -464,7 +466,14 @@ export class InternalNodeImpl extends NodeImpl<Hash> {
     }
     for (; i < entries.length && limit > 0; i++) {
       const childNode = await tree.getNode(entries[i][1]);
-      limit = yield* childNode.scan(tree, prefix, fromKey, limit, onLimitKey);
+      limit = yield* childNode.scan(
+        tree,
+        prefix,
+        fromKey,
+        limit,
+        convertEntry,
+        onLimitKey,
+      );
     }
     return limit;
   }

--- a/src/btree/write.ts
+++ b/src/btree/write.ts
@@ -127,27 +127,28 @@ export class BTreeWrite extends BTreeRead {
     return this._rwLock.withRead(() => super.isEmpty());
   }
 
-  override async *scan(
+  override async *scan<R>(
     options: ScanOptionsInternal,
-  ): AsyncGenerator<Entry<ReadonlyJSONValue>> {
-    yield* runRead(this._rwLock, super.scan(options));
+    convertEntry: (entry: Entry<ReadonlyJSONValue>) => R,
+  ): AsyncIterableIterator<R> {
+    yield* runRead(this._rwLock, super.scan(options, convertEntry));
   }
 
-  override async *keys(): AsyncGenerator<string, void> {
+  override async *keys(): AsyncIterableIterator<string> {
     yield* runRead(this._rwLock, super.keys());
   }
 
-  async *entries(): AsyncGenerator<ReadonlyEntry<ReadonlyJSONValue>, void> {
+  async *entries(): AsyncIterableIterator<ReadonlyEntry<ReadonlyJSONValue>> {
     yield* runRead(this._rwLock, super.entries());
   }
 
   override async *diff(
     last: BTreeRead,
-  ): AsyncGenerator<DiffResult<ReadonlyJSONValue>, void> {
+  ): AsyncIterableIterator<DiffResult<ReadonlyJSONValue>> {
     yield* runRead(this._rwLock, super.diff(last));
   }
 
-  override async *diffKeys(last: BTreeRead): AsyncGenerator<string, void> {
+  override async *diffKeys(last: BTreeRead): AsyncIterableIterator<string> {
     yield* runRead(this._rwLock, super.diffKeys(last));
   }
 
@@ -266,8 +267,8 @@ export class BTreeWrite extends BTreeRead {
 }
 async function* runRead<T>(
   lock: RWLock,
-  ai: AsyncGenerator<T>,
-): AsyncGenerator<T> {
+  ai: AsyncIterableIterator<T>,
+): AsyncIterableIterator<T> {
   const release = await lock.read();
   try {
     yield* ai;

--- a/src/db/scan.ts
+++ b/src/db/scan.ts
@@ -63,7 +63,7 @@ export type ScanItem = {
   val: ReadonlyJSONValue;
 };
 
-export async function* scan<R>(
+export function scan<R>(
   map: BTreeRead,
   opts: ScanOptionsInternal,
   convertEntry: (entry: Entry<ReadonlyJSONValue>) => R,
@@ -74,9 +74,7 @@ export async function* scan<R>(
   // map key or an encoded IndexKey in an index map. Without encoding regular
   // prolly map keys we need to rely on the opts to tell us what we expect.
 
-  for await (const entry of map.scan(opts, onLimitKey)) {
-    yield convertEntry(entry);
-  }
+  return map.scan(opts, convertEntry, onLimitKey);
 }
 
 export function convert(source: ScanOptions): ScanOptionsInternal {

--- a/src/db/write.ts
+++ b/src/db/write.ts
@@ -210,7 +210,7 @@ export class Write extends Read {
     }
 
     const indexMap = new BTreeWrite(this._dagWrite);
-    for await (const entry of this.map.scan({prefix: keyPrefix})) {
+    for await (const entry of this.map.scan({prefix: keyPrefix}, x => x)) {
       await indexValue(
         lc,
         indexMap,


### PR DESCRIPTION
There are two kinds of optimizations in here:

1. Get rid of intermediate for await loops.
2. Get rid of yield*

Both of these adds extra Promise and IteratorResult objects.

By passing the convertEntry function all the way down into the BTree
iterator we do not need the intermediate for await loops.

In a few places we can return the async iterable iterator instead of
yield* it. This only works if the function/method is not `async` of
`async *`.

Towards #711