### PR TITLE
fix: correct log levels for push and pull errors to follow style guidelines

### DIFF
--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -2790,7 +2790,7 @@ test('online', async () => {
     log.push(b);
   };
 
-  const consoleError = sinon.stub(console, 'error');
+  const consoleInfoStub = sinon.stub(console, 'info');
 
   fetchMock.post(pushURL, async () => {
     await sleep(10);
@@ -2805,17 +2805,17 @@ test('online', async () => {
   await tickAFewTimes();
 
   expect(rep.online).to.equal(false);
-  expect(consoleError.callCount).to.be.greaterThan(0);
+  expect(consoleInfoStub.callCount).to.be.greaterThan(0);
   expect(log).to.deep.equal([false]);
 
-  consoleError.resetHistory();
+  consoleInfoStub.resetHistory();
 
   fetchMock.post(pushURL, {});
   await rep.mutate.addData({a: 1});
 
   await tickAFewTimes(20);
 
-  expect(consoleError.callCount).to.equal(0);
+  expect(consoleInfoStub.callCount).to.equal(0);
   expect(rep.online).to.equal(true);
   expect(log).to.deep.equal([false, true]);
 });

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -715,14 +715,14 @@ export class Replicache<MD extends MutatorDefs = {}> {
 
       if (e instanceof PushError || e instanceof PullError) {
         online = false;
-        this._logger.error?.(
+        this._logger.info?.(
           `${name} threw:\n`,
           e,
           '\nwith cause:\n',
           e.causedBy,
         );
       } else {
-        this._logger.error?.(`${name} threw:\n`, e);
+        this._logger.info?.(`${name} threw:\n`, e);
       }
       return false;
     } finally {
@@ -1163,7 +1163,7 @@ function checkStatus(
 ): boolean {
   const {httpStatusCode, errorMessage} = data;
   if (errorMessage || httpStatusCode >= 400) {
-    logger.error?.(
+    logger.info?.(
       `Got error response from server (${serverURL}) doing ${verb}: ${httpStatusCode}` +
         (errorMessage ? `: ${errorMessage}` : ''),
     );

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -1163,7 +1163,7 @@ function checkStatus(
 ): boolean {
   const {httpStatusCode, errorMessage} = data;
   if (errorMessage || httpStatusCode >= 400) {
-    logger.info?.(
+    logger.error?.(
       `Got error response from server (${serverURL}) doing ${verb}: ${httpStatusCode}` +
         (errorMessage ? `: ${errorMessage}` : ''),
     );


### PR DESCRIPTION
### Problem
Push and pull errors are being logged at level `error`, which violates our style guide for log levels: https://github.com/rocicorp/replicache/blob/main/CONTRIBUTING.md#style-general

### Solution
Update to use `info` level instead.