### PR TITLE
fix: Remove log spew from test

### DIFF
--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -1481,9 +1481,9 @@ testWithBothStores(
 
     await tickAFewTimes();
     fetchMock.reset();
-    fetchMock.postAny({});
 
     rep.pullURL = 'https://diff.com/pull';
+    fetchMock.post(rep.pullURL, {lastMutationID: 0, patch: []});
 
     rep.pull();
     await tickAFewTimes();

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -22,24 +22,23 @@ export default {
     {
       name: 'Main',
       files: [
-        'src/replicache.test.ts',
-        // 'src/*.test.ts',
-        // 'src/dag/*.test.ts',
-        // 'src/db/*.test.ts',
-        // 'src/kv/*.test.ts',
-        // 'src/prolly/*.test.ts',
-        // 'src/sync/*.test.ts',
-        // 'src/migrate/*.test.ts',
-        // 'src/btree/*.test.ts',
+        'src/*.test.ts',
+        'src/dag/*.test.ts',
+        'src/db/*.test.ts',
+        'src/kv/*.test.ts',
+        'src/prolly/*.test.ts',
+        'src/sync/*.test.ts',
+        'src/migrate/*.test.ts',
+        'src/btree/*.test.ts',
         // src/worker-tests/ intentioanly excluded, see separate Worker group below
       ],
+      browsers: [firefox, chromium, webkit],
+    },
+    {
+      name: 'Worker',
+      files: 'src/worker-tests/worker.test.ts',
+      // Only Chrome supports modules in workers at the moment
       browsers: [chromium],
     },
-    // {
-    //   name: 'Worker',
-    //   files: 'src/worker-tests/worker.test.ts',
-    //   // Only Chrome supports modules in workers at the moment
-    //   browsers: [chromium],
-    // },
   ],
 };

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -22,23 +22,24 @@ export default {
     {
       name: 'Main',
       files: [
-        'src/*.test.ts',
-        'src/dag/*.test.ts',
-        'src/db/*.test.ts',
-        'src/kv/*.test.ts',
-        'src/prolly/*.test.ts',
-        'src/sync/*.test.ts',
-        'src/migrate/*.test.ts',
-        'src/btree/*.test.ts',
+        'src/replicache.test.ts',
+        // 'src/*.test.ts',
+        // 'src/dag/*.test.ts',
+        // 'src/db/*.test.ts',
+        // 'src/kv/*.test.ts',
+        // 'src/prolly/*.test.ts',
+        // 'src/sync/*.test.ts',
+        // 'src/migrate/*.test.ts',
+        // 'src/btree/*.test.ts',
         // src/worker-tests/ intentioanly excluded, see separate Worker group below
       ],
-      browsers: [firefox, chromium, webkit],
-    },
-    {
-      name: 'Worker',
-      files: 'src/worker-tests/worker.test.ts',
-      // Only Chrome supports modules in workers at the moment
       browsers: [chromium],
     },
+    // {
+    //   name: 'Worker',
+    //   files: 'src/worker-tests/worker.test.ts',
+    //   // Only Chrome supports modules in workers at the moment
+    //   browsers: [chromium],
+    // },
   ],
 };


### PR DESCRIPTION
The mock fetch was returning `{}` which is not a valid PullResponse