### PR TITLE
fix: Silence and check error message

### DIFF
--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -1505,6 +1505,8 @@ testWithBothStores(
 
     let pullerCallCount = 0;
 
+    const consoleErrorStub = sinon.stub(console, 'error');
+
     rep.puller = () => {
       pullerCallCount++;
       return Promise.resolve({
@@ -1520,6 +1522,11 @@ testWithBothStores(
 
     expect(fetchMock.calls()).to.have.length(0);
     expect(pullerCallCount).to.be.greaterThan(0);
+
+    expect(consoleErrorStub.firstCall.args[0]).to.equal(
+      'Got error response from server () doing pull: 500: Test failure',
+    );
+    consoleErrorStub.restore();
 
     await tickAFewTimes();
     fetchMock.reset();

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -1163,6 +1163,8 @@ function checkStatus(
 ): boolean {
   const {httpStatusCode, errorMessage} = data;
   if (errorMessage || httpStatusCode >= 400) {
+    // TODO(arv): Maybe we should not log the server URL when the error comes
+    // from a Pusher/Puller?
     logger.error?.(
       `Got error response from server (${serverURL}) doing ${verb}: ${httpStatusCode}` +
         (errorMessage ? `: ${errorMessage}` : ''),


### PR DESCRIPTION
The test was hitting `console.error` which is good because it means the
code works. But we do not want errors to escape the tests. Instead
install a stub for console.error and check that it was called.