### PR TITLE
feat: Add Persist Writer

### DIFF
--- a/src/btree/mod.ts
+++ b/src/btree/mod.ts
@@ -2,4 +2,5 @@ export {BTreeRead} from './read';
 export {BTreeWrite} from './write';
 export {changedKeys} from './changed-keys';
 export {assertBTreeNode} from './node';
+export {getRefs} from './node';
 export type {Entry, Node, InternalNode, DataNode} from './node';

--- a/src/btree/node.ts
+++ b/src/btree/node.ts
@@ -22,10 +22,7 @@ export type DataNode = BaseNode<ReadonlyJSONValue>;
 export type Node = DataNode | InternalNode;
 
 export function getRefs(node: Node): ReadonlyArray<Hash> {
-  if (node[NODE_LEVEL] === 0) {
-    return [];
-  }
-  return node[NODE_ENTRIES].map(e => e[1]) as ReadonlyArray<Hash>;
+  return isInternalNode(node) ? node[NODE_ENTRIES].map(e => e[1]) : [];
 }
 
 export const enum DiffResultOp {

--- a/src/btree/node.ts
+++ b/src/btree/node.ts
@@ -21,6 +21,13 @@ export type DataNode = BaseNode<ReadonlyJSONValue>;
 
 export type Node = DataNode | InternalNode;
 
+export function getRefs(node: Node): ReadonlyArray<Hash> {
+  if (node[NODE_LEVEL] === 0) {
+    return [];
+  }
+  return node[NODE_ENTRIES].map(e => e[1]) as ReadonlyArray<Hash>;
+}
+
 export const enum DiffResultOp {
   Add,
   Delete,

--- a/src/db/hash-type.ts
+++ b/src/db/hash-type.ts
@@ -1,0 +1,4 @@
+export const enum HashType {
+  AllowWeak,
+  RequireStrong,
+}

--- a/src/db/mod.ts
+++ b/src/db/mod.ts
@@ -22,7 +22,8 @@ export {
 export {getRoot} from './root';
 export {decodeIndexKey} from './index';
 export {Visitor} from './visitor';
+export {Transformer} from './transformer';
 
-export type {LocalMeta, IndexRecord, CommitData} from './commit';
+export type {LocalMeta, IndexRecord, CommitData, Meta} from './commit';
 export type {ScanOptions} from './scan';
 export type {Whence} from './read';

--- a/src/db/transformer.test.ts
+++ b/src/db/transformer.test.ts
@@ -1,0 +1,139 @@
+import {expect} from '@esm-bundle/chai';
+import * as dag from '../dag/mod';
+import {
+  addGenesis,
+  addIndexChange,
+  addLocal,
+  addSnapshot,
+  Chain,
+} from './test-helpers';
+import {Commit} from './commit';
+import type {IndexRecord, Meta} from './commit';
+import {Transformer} from './transformer';
+import {Hash, initHasher} from '../hash';
+import {BTreeRead, BTreeWrite, Entry} from '../btree/mod';
+import type {DataNode} from '../btree/node';
+import type {ReadonlyJSONValue} from '../json';
+import {assert} from '../asserts';
+
+setup(async () => {
+  await initHasher();
+});
+
+test('noops transformBTreeInternalEntry', async () => {
+  const dagStore = new dag.TestStore();
+
+  await dagStore.withWrite(async dagWrite => {
+    const transformer = new Transformer(dagWrite);
+
+    const dataNode: DataNode = [0, [['k', 42]]];
+    const chunk = dagWrite.createChunk(dataNode, []);
+    await dagWrite.putChunk(chunk);
+    const entry: Entry<Hash> = ['key', chunk.hash];
+
+    expect(await transformer.transformBTreeInternalEntry(entry)).to.equal(
+      entry,
+    );
+  });
+});
+
+test('transformBTreeNode - noop', async () => {
+  const dagStore = new dag.TestStore();
+
+  await dagStore.withWrite(async dagWrite => {
+    const transformer = new Transformer(dagWrite);
+
+    const map = new BTreeWrite(dagWrite);
+    await map.put('key', 'value');
+    const valueHash = await map.flush();
+
+    expect(await transformer.transformBTreeNode(valueHash)).to.equal(valueHash);
+  });
+});
+
+test('transformCommit - noop', async () => {
+  const dagStore = new dag.TestStore();
+
+  const testChain = async (chain: Commit<Meta>[]) => {
+    await dagStore.withWrite(async write => {
+      const transformer = new Transformer(write);
+
+      for (const commit of chain) {
+        const h = commit.chunk.hash;
+        expect(await transformer.transformCommit(h)).to.equal(h);
+      }
+    });
+  };
+
+  const chain: Chain = [];
+  await addGenesis(chain, dagStore);
+  await addLocal(chain, dagStore);
+  await addIndexChange(chain, dagStore);
+  await addLocal(chain, dagStore);
+  await testChain(chain);
+
+  await addSnapshot(chain, dagStore, [['k', 42]]);
+  await addLocal(chain, dagStore);
+  await testChain(chain.slice(-2));
+});
+
+test('transformIndexRecord - noop', async () => {
+  const dagStore = new dag.TestStore();
+
+  await dagStore.withWrite(async write => {
+    const transformer = new Transformer(write);
+
+    const map = new BTreeWrite(write);
+    await map.put('key', 'value');
+    const valueHash = await map.flush();
+
+    const index: IndexRecord = {
+      definition: {
+        jsonPointer: '',
+        keyPrefix: '',
+        name: 'index',
+      },
+      valueHash,
+    };
+
+    expect(await transformer.transformIndexRecord(index)).to.equal(index);
+  });
+});
+
+test('transforms data entry', async () => {
+  const dagStore = new dag.TestStore();
+
+  class TestTransformer extends Transformer {
+    override async transformBTreeDataEntry(
+      entry: Entry<ReadonlyJSONValue>,
+    ): Promise<Entry<ReadonlyJSONValue>> {
+      if (entry[0] === 'k') {
+        return ['k', entry[0] + ' - Changed!'];
+      }
+      return entry;
+    }
+  }
+
+  const chain: Chain = [];
+  await addGenesis(chain, dagStore);
+  await addSnapshot(chain, dagStore, [['k', 42]]);
+  await addLocal(chain, dagStore);
+
+  await dagStore.withWrite(async write => {
+    const transformer = new TestTransformer(write);
+
+    const h = chain[2].chunk.hash;
+    const h2 = await transformer.transformCommit(h);
+
+    await write.setHead('test', h2);
+    await write.commit();
+  });
+
+  await dagStore.withRead(async read => {
+    const headHash = await read.getHead('test');
+    assert(headHash);
+    const commit = await Commit.fromHash(headHash, read);
+    const map = new BTreeRead(read, commit.valueHash);
+    expect(await map.get('k')).to.equal('k - Changed!');
+  });
+});

--- a/src/db/transformer.test.ts
+++ b/src/db/transformer.test.ts
@@ -20,7 +20,7 @@ setup(async () => {
   await initHasher();
 });
 
-test('noops transformBTreeInternalEntry', async () => {
+test('transformBTreeInternalEntry - noop', async () => {
   const dagStore = new dag.TestStore();
 
   await dagStore.withWrite(async dagWrite => {

--- a/src/db/transformer.ts
+++ b/src/db/transformer.ts
@@ -1,0 +1,291 @@
+import {assert} from '../asserts';
+import {assertBTreeNode} from '../btree/node';
+import * as btree from '../btree/mod';
+import {
+  IndexChangeMeta,
+  Meta,
+  MetaTyped,
+  SnapshotMeta,
+  getRefs as getRefsFromCommitData,
+  assertCommitData,
+} from './commit';
+import type {Hash} from '../hash';
+import type * as db from './mod';
+import type * as dag from '../dag/mod';
+import type {ReadonlyJSONValue} from '../json';
+import {HashType} from './hash-type';
+import type {Value} from '../kv/store';
+
+export class Transformer {
+  readonly dagWrite: dag.Write;
+  private readonly _transforming: Map<Hash, Promise<Hash>> = new Map();
+
+  constructor(dagWrite: dag.Write) {
+    this.dagWrite = dagWrite;
+  }
+
+  private _withTransformingCache(
+    h: Hash,
+    f: () => Promise<Hash>,
+  ): Promise<Hash> {
+    const newHash = this._transforming.get(h);
+    if (newHash !== undefined) {
+      return newHash;
+    }
+
+    const p = f();
+    this._transforming.set(h, p);
+    return p;
+  }
+
+  private _transformCommitWithCache(
+    h: Hash,
+    hashType = HashType.RequireStrong,
+  ): Promise<Hash> {
+    return this._withTransformingCache(h, () =>
+      this.transformCommit(h, hashType),
+    );
+  }
+
+  async transformCommit(
+    h: Hash,
+    hashType = HashType.RequireStrong,
+  ): Promise<Hash> {
+    const chunk = await this.getChunk(h);
+    if (!chunk) {
+      if (hashType === HashType.AllowWeak) {
+        return h;
+      }
+      throw new Error(`Chunk ${h} not found`);
+    }
+    const {data} = chunk;
+    assertCommitData(data);
+
+    const newCommitData = await this._transformCommitData(data);
+    return this._maybWriteChunk(h, newCommitData, data, getRefsFromCommitData);
+  }
+
+  protected shouldForceWrite(_h: Hash): boolean {
+    return false;
+  }
+
+  protected getChunk(h: Hash): Promise<dag.Chunk | undefined> {
+    return this.dagWrite.getChunk(h);
+  }
+
+  private async _maybWriteChunk<D extends Value>(
+    h: Hash,
+    newData: D,
+    oldData: D,
+    getRefs: (data: D) => readonly Hash[],
+  ): Promise<Hash> {
+    if (newData !== oldData || this.shouldForceWrite(h)) {
+      const newChunk = this.dagWrite.createChunk(newData, getRefs(newData));
+      await this.dagWrite.putChunk(newChunk);
+      return newChunk.hash;
+    }
+    return h;
+  }
+
+  private async _transformCommitData<M extends db.Meta>(
+    data: db.CommitData<M>,
+  ): Promise<db.CommitData<M>> {
+    const meta = await this._transformCommitMeta(data.meta);
+    const valueHash = await this._transformCommitValue(data.valueHash);
+    const indexes = await this._transformIndexRecords(data.indexes);
+
+    if (
+      meta === data.meta &&
+      valueHash === data.valueHash &&
+      indexes === data.indexes
+    ) {
+      return data;
+    }
+    return {
+      meta: meta as M,
+      valueHash,
+      indexes,
+    };
+  }
+
+  private _transformCommitMeta(meta: Meta): Promise<Meta> {
+    switch (meta.type) {
+      case MetaTyped.IndexChange:
+        return this._transformIndexChangeMeta(meta);
+
+      case MetaTyped.Local:
+        return this._transformLocalMeta(meta);
+
+      case MetaTyped.Snapshot:
+        return this._transformSnapshot(meta);
+    }
+  }
+
+  private _transformBasisHash(
+    basisHash: Hash | null,
+    hashType: HashType,
+  ): Promise<Hash> | null {
+    if (basisHash !== null) {
+      return this._transformCommitWithCache(basisHash, hashType);
+    }
+    return null;
+  }
+
+  private async _transformSnapshot(meta: SnapshotMeta): Promise<SnapshotMeta> {
+    // basisHash is weak for Snapshot Commits
+    const basisHash = await this._transformBasisHash(
+      meta.basisHash,
+      HashType.AllowWeak,
+    );
+    if (basisHash === meta.basisHash) {
+      return meta;
+    }
+    return {
+      basisHash,
+      type: meta.type,
+      lastMutationID: meta.lastMutationID,
+      cookieJSON: meta.cookieJSON,
+    };
+  }
+
+  private async _transformLocalMeta(meta: db.LocalMeta): Promise<db.LocalMeta> {
+    const basisHash = await this._transformBasisHash(
+      meta.basisHash,
+      HashType.RequireStrong,
+    );
+    // originalHash is weak for Local Commits
+    const originalHash =
+      meta.originalHash &&
+      (await this._transformCommitWithCache(
+        meta.originalHash,
+        HashType.AllowWeak,
+      ));
+    if (basisHash === meta.basisHash && originalHash === meta.originalHash) {
+      return meta;
+    }
+    return {
+      basisHash,
+      type: meta.type,
+      mutationID: meta.mutationID,
+      mutatorName: meta.mutatorName,
+      mutatorArgsJSON: meta.mutatorArgsJSON,
+      originalHash,
+    };
+  }
+
+  private async _transformIndexChangeMeta(
+    meta: IndexChangeMeta,
+  ): Promise<IndexChangeMeta> {
+    const basisHash = await this._transformBasisHash(
+      meta.basisHash,
+      HashType.RequireStrong,
+    );
+    if (basisHash === meta.basisHash) {
+      return meta;
+    }
+    return {
+      basisHash,
+      type: meta.type,
+      lastMutationID: meta.lastMutationID,
+    };
+  }
+
+  private _transformCommitValue(valueHash: Hash): Promise<Hash> {
+    return this._transformBTreeNodeWithCache(valueHash);
+  }
+
+  private _transformBTreeNodeWithCache(h: Hash): Promise<Hash> {
+    return this._withTransformingCache(h, () => this.transformBTreeNode(h));
+  }
+
+  async transformBTreeNode(h: Hash): Promise<Hash> {
+    const chunk = await this.getChunk(h);
+    assert(chunk, `Missing chunk: ${h}`);
+    const {data} = chunk;
+    assertBTreeNode(data);
+
+    const newData = await this.transformBTreeNodeData(data);
+    return this._maybWriteChunk(h, newData, data, btree.getRefs);
+  }
+
+  transformBTreeNodeData(data: btree.DataNode): Promise<btree.DataNode>;
+  transformBTreeNodeData(data: btree.InternalNode): Promise<btree.InternalNode>;
+  async transformBTreeNodeData(data: btree.Node): Promise<btree.Node> {
+    const level = data[0];
+    const entries = data[1];
+    let newEntries: btree.Node[1];
+    if (level === 0) {
+      newEntries = await this._transformBTreeDataEntries(entries);
+    } else {
+      newEntries = await this._transformBTreeInternalEntries(
+        entries as btree.InternalNode[1],
+      );
+    }
+    if (newEntries === entries) {
+      return data;
+    }
+
+    // Changed. Need to create a new chunk.
+    return [level, newEntries];
+  }
+
+  async transformBTreeDataEntry(
+    entry: btree.Entry<ReadonlyJSONValue>,
+  ): Promise<btree.Entry<ReadonlyJSONValue>> {
+    return entry;
+  }
+
+  private async _transformBTreeDataEntries(
+    entries: readonly btree.Entry<ReadonlyJSONValue>[],
+  ): Promise<readonly btree.Entry<ReadonlyJSONValue>[]> {
+    return this._transformArray(entries, this.transformBTreeDataEntry);
+  }
+
+  async transformBTreeInternalEntry(
+    entry: btree.Entry<Hash>,
+  ): Promise<btree.Entry<Hash>> {
+    const hash = await this._transformBTreeNodeWithCache(entry[1]);
+    if (hash === entry[1]) {
+      return entry;
+    }
+    return [entry[0], hash];
+  }
+
+  private async _transformBTreeInternalEntries(
+    entries: readonly btree.Entry<Hash>[],
+  ): Promise<readonly btree.Entry<Hash>[]> {
+    return this._transformArray(entries, this.transformBTreeInternalEntry);
+  }
+
+  private async _transformArray<T>(
+    values: readonly T[],
+    itemTransform: (item: T) => Promise<T>,
+  ): Promise<readonly T[]> {
+    const newValues = await Promise.all(values.map(itemTransform));
+    for (let i = 0; i < newValues.length; i++) {
+      if (values[i] !== newValues[i]) {
+        return newValues;
+      }
+    }
+    return values;
+  }
+
+  private _transformIndexRecords(
+    indexes: readonly db.IndexRecord[],
+  ): Promise<readonly db.IndexRecord[]> {
+    return this._transformArray(indexes, index =>
+      this.transformIndexRecord(index),
+    );
+  }
+
+  async transformIndexRecord(index: db.IndexRecord): Promise<db.IndexRecord> {
+    const valueHash = await this._transformBTreeNodeWithCache(index.valueHash);
+    if (valueHash === index.valueHash) {
+      return index;
+    }
+    return {
+      definition: index.definition,
+      valueHash,
+    };
+  }
+}

--- a/src/db/visitor.ts
+++ b/src/db/visitor.ts
@@ -13,11 +13,7 @@ import {
 import type * as dag from '../dag/mod';
 import {emptyHash, Hash} from '../hash';
 import {InternalNode, isInternalNode, Node} from '../btree/node';
-
-export const enum HashType {
-  AllowWeak,
-  RequireStrong,
-}
+import {HashType} from './hash-type';
 
 export class Visitor {
   readonly dagRead: dag.Read;

--- a/src/sync/persist-gather-visitor.ts
+++ b/src/sync/persist-gather-visitor.ts
@@ -2,7 +2,7 @@ import * as db from '../db/mod';
 import {Hash, isTempHash} from '../hash';
 import type * as dag from '../dag/mod';
 import type * as btree from '../btree/mod';
-import type {HashType} from '../db/visitor';
+import type {HashType} from '../db/hash-type';
 import type {Meta} from '../db/commit';
 
 export class PersistGatherVisitor extends db.Visitor {

--- a/src/sync/persist-write-transformer.test.ts
+++ b/src/sync/persist-write-transformer.test.ts
@@ -1,0 +1,249 @@
+import {assert} from '@esm-bundle/chai';
+import * as dag from '../dag/mod';
+import type * as btree from '../btree/mod';
+import {initHasher, isTempHash, newTempHash} from '../hash';
+import {addGenesis, addIndexChange, addLocal, Chain} from '../db/test-helpers';
+import {
+  GatheredChunks,
+  PersistWriteTransformer,
+} from './persost-write-transformer';
+import {
+  Commit,
+  CommitData,
+  Meta,
+  newIndexChange,
+  newLocal,
+  newSnapshot,
+} from '../db/mod';
+import {BTreeRead, BTreeWrite} from '../btree/mod';
+import type {Value} from '../kv/mod';
+import {asyncIterableToArray} from '../async-iterable-to-array';
+
+setup(async () => {
+  await initHasher();
+});
+
+test('Nothing gachered, nothing written', async () => {
+  const dagStore = new dag.TestStore();
+
+  const chain: Chain = [];
+  await addGenesis(chain, dagStore);
+  await addLocal(chain, dagStore);
+  await addIndexChange(chain, dagStore);
+  await addLocal(chain, dagStore);
+
+  const gatheredChunks: GatheredChunks = new Map();
+
+  const snapshot = Object.fromEntries(dagStore.kvStore.entries());
+
+  class TestTransformer extends PersistWriteTransformer {
+    override transformBTreeNodeData(
+      data: btree.DataNode,
+    ): Promise<btree.DataNode>;
+    override transformBTreeNodeData(
+      data: btree.InternalNode,
+    ): Promise<btree.InternalNode>;
+    override transformBTreeNodeData(data: btree.Node): Promise<btree.Node> {
+      assert.fail('should not be called with data: ' + JSON.stringify(data));
+    }
+  }
+
+  await dagStore.withWrite(async dagWrite => {
+    for (const commit of chain) {
+      const transformer = new TestTransformer(dagWrite, gatheredChunks);
+      const newHash = await transformer.transformCommit(commit.chunk.hash);
+      assert.equal(newHash, commit.chunk.hash);
+    }
+  });
+
+  assert.deepEqual(Object.fromEntries(dagStore.kvStore.entries()), snapshot);
+});
+
+test('single new commit on top of snapshot is written', async () => {
+  const dagStore = new dag.TestStore();
+
+  const chain: Chain = [];
+  await addGenesis(chain, dagStore);
+
+  const t = async (c: Commit<Meta>) => {
+    assert.isTrue(isTempHash(c.chunk.hash));
+
+    const gatheredChunks: GatheredChunks = new Map([[c.chunk.hash, c.chunk]]);
+
+    const newHash = await dagStore.withWrite(async dagWrite => {
+      const transformer = new PersistWriteTransformer(dagWrite, gatheredChunks);
+      const newHash = await transformer.transformCommit(c.chunk.hash);
+      assert.notEqual(newHash, c.chunk.hash);
+      await dagWrite.setHead('test', newHash);
+      await dagWrite.commit();
+      return newHash;
+    });
+
+    assert.isFalse(isTempHash(newHash));
+
+    await dagStore.withRead(async dagRead => {
+      const newChunk = await dagRead.getChunk(newHash);
+      const snapshotCommit = chain[0];
+
+      assert.equal(
+        (newChunk?.data as CommitData<Meta>)?.valueHash,
+        snapshotCommit.valueHash,
+      );
+
+      assert.deepEqual(newChunk?.data, c.chunk.data);
+      assert.deepEqual(newChunk?.data, c.chunk.data);
+      assert.notEqual(newChunk?.hash, c.chunk.hash);
+    });
+  };
+
+  const {valueHash, indexes, chunk} = chain[0];
+  const basisHash = chunk.hash;
+  const lastMutationID = 123;
+  const cookieJSON = 'monster';
+  const createChunk: dag.CreateChunk = (data, refs) =>
+    dag.createChunk(data, refs, newTempHash);
+
+  const mutationID = lastMutationID + 1;
+  const mutatorName = 'test';
+  const mutatorArgsJSON = {data: 42};
+  const originalHash = null;
+
+  await t(
+    newLocal(
+      createChunk,
+      basisHash,
+      mutationID,
+      mutatorName,
+      mutatorArgsJSON,
+      originalHash,
+      valueHash,
+      indexes,
+    ),
+  );
+
+  await t(
+    newSnapshot(
+      createChunk,
+      basisHash,
+      lastMutationID,
+      cookieJSON,
+      valueHash,
+      indexes,
+    ),
+  );
+
+  await t(
+    newIndexChange(createChunk, basisHash, lastMutationID, valueHash, indexes),
+  );
+});
+
+test('single new snapshot with new btree on top of snapshot is written', async () => {
+  const memdag = new dag.TestStore(undefined, newTempHash, () => undefined);
+  const perdag = new dag.TestStore();
+
+  const chain: Chain = [];
+  await addGenesis(chain, perdag);
+
+  const {indexes, chunk} = chain[0];
+  const basisHash = chunk.hash;
+  const lastMutationID = 123;
+  const cookieJSON = 'monster';
+  const createChunk: dag.CreateChunk = (data, refs) =>
+    dag.createChunk(data, refs, newTempHash);
+
+  const entries = Object.entries({
+    memdag: true,
+    perdag: false,
+  });
+
+  const treeChunk = await memdag.withWrite(async dagWrite => {
+    const tree = new BTreeWrite(dagWrite);
+    for (const [k, v] of entries) {
+      await tree.put(k, v);
+    }
+    const h = await tree.flush();
+    await dagWrite.setHead('tree', h);
+    await dagWrite.commit();
+    const chunk = await dagWrite.getChunk(h);
+    return chunk as dag.Chunk<btree.DataNode>;
+  });
+  assert.isTrue(isTempHash(treeChunk.hash));
+
+  const snapshotBefore = Object.fromEntries(perdag.kvStore.entries());
+  assert.deepEqual(snapshotBefore, {
+    'c/mdcncodijhl6jk2o8bb7m0hg15p3sf24/d': [0, []],
+    'c/9lrb08p9b7jqo8oad3aef60muj4td8ke/d': {
+      meta: {type: 3, basisHash: null, lastMutationID: 0, cookieJSON: null},
+      valueHash: 'mdcncodijhl6jk2o8bb7m0hg15p3sf24',
+      indexes: [],
+    },
+    'c/9lrb08p9b7jqo8oad3aef60muj4td8ke/m': [
+      'mdcncodijhl6jk2o8bb7m0hg15p3sf24',
+    ],
+    'h/main': '9lrb08p9b7jqo8oad3aef60muj4td8ke',
+    'c/mdcncodijhl6jk2o8bb7m0hg15p3sf24/r': 1,
+    'c/9lrb08p9b7jqo8oad3aef60muj4td8ke/r': 1,
+  });
+
+  const c = newSnapshot(
+    createChunk,
+    basisHash,
+    lastMutationID,
+    cookieJSON,
+    treeChunk.hash,
+    indexes,
+  );
+  assert.isTrue(isTempHash(c.chunk.hash));
+
+  const gatheredChunks: GatheredChunks = new Map([
+    [c.chunk.hash, c.chunk as dag.Chunk<Value>],
+    [treeChunk.hash, treeChunk as dag.Chunk<Value>],
+  ]);
+
+  const newHash = await perdag.withWrite(async dagWrite => {
+    const transformer = new PersistWriteTransformer(dagWrite, gatheredChunks);
+    const newHash = await transformer.transformCommit(c.chunk.hash);
+    assert.notEqual(newHash, c.chunk.hash);
+    await dagWrite.setHead('main', newHash);
+    await dagWrite.removeHead('test');
+    await dagWrite.commit();
+    return newHash;
+  });
+
+  assert.isFalse(isTempHash(newHash));
+
+  await perdag.withRead(async dagRead => {
+    const newCommit = await Commit.fromHash(newHash, dagRead);
+    assert.isFalse(isTempHash(newCommit.valueHash));
+    const newTree = new BTreeRead(dagRead, newCommit.valueHash);
+    const newEntries = await asyncIterableToArray(newTree.entries());
+    assert.deepEqual(newEntries, entries);
+  });
+
+  const snapshotAfter = Object.fromEntries(perdag.kvStore.entries());
+  assert.deepEqual(snapshotAfter, {
+    'h/main': 'joi3b834ue0iql9tmfpkjc50ihml4mbl',
+    'c/8prggufvsba8bja61khrh70ut4daptcn/d': [
+      0,
+      [
+        ['memdag', true],
+        ['perdag', false],
+      ],
+    ],
+    'c/joi3b834ue0iql9tmfpkjc50ihml4mbl/d': {
+      meta: {
+        type: 3,
+        basisHash: '9lrb08p9b7jqo8oad3aef60muj4td8ke',
+        lastMutationID: 123,
+        cookieJSON: 'monster',
+      },
+      valueHash: '8prggufvsba8bja61khrh70ut4daptcn',
+      indexes: [],
+    },
+    'c/joi3b834ue0iql9tmfpkjc50ihml4mbl/m': [
+      '8prggufvsba8bja61khrh70ut4daptcn',
+    ],
+    'c/8prggufvsba8bja61khrh70ut4daptcn/r': 1,
+    'c/joi3b834ue0iql9tmfpkjc50ihml4mbl/r': 1,
+  });
+});

--- a/src/sync/persist-write-transformer.test.ts
+++ b/src/sync/persist-write-transformer.test.ts
@@ -6,7 +6,7 @@ import {addGenesis, addIndexChange, addLocal, Chain} from '../db/test-helpers';
 import {
   GatheredChunks,
   PersistWriteTransformer,
-} from './persost-write-transformer';
+} from './persist-write-transformer';
 import {
   Commit,
   CommitData,
@@ -23,7 +23,7 @@ setup(async () => {
   await initHasher();
 });
 
-test('Nothing gachered, nothing written', async () => {
+test('Nothing gathered, nothing written', async () => {
   const dagStore = new dag.TestStore();
 
   const chain: Chain = [];
@@ -44,6 +44,7 @@ test('Nothing gachered, nothing written', async () => {
       data: btree.InternalNode,
     ): Promise<btree.InternalNode>;
     override transformBTreeNodeData(data: btree.Node): Promise<btree.Node> {
+      // Since the gathered chunks is empty, we should not be writing anything.
       assert.fail('should not be called with data: ' + JSON.stringify(data));
     }
   }

--- a/src/sync/persost-write-transformer.ts
+++ b/src/sync/persost-write-transformer.ts
@@ -1,0 +1,43 @@
+import * as db from '../db/mod';
+import type * as dag from '../dag/mod';
+import type {Hash} from '../hash';
+import type {HashType} from '../db/hash-type';
+
+export type GatheredChunks = ReadonlyMap<Hash, dag.Chunk>;
+
+export class PersistWriteTransformer extends db.Transformer {
+  private readonly _gatheredChunks: GatheredChunks;
+
+  constructor(dagWrite: dag.Write, gatheredChunks: GatheredChunks) {
+    super(dagWrite);
+    this._gatheredChunks = gatheredChunks;
+  }
+
+  protected override shouldForceWrite(h: Hash): boolean {
+    return this._gatheredChunks.has(h);
+  }
+
+  protected override getChunk(hash: Hash): Promise<dag.Chunk | undefined> {
+    const gatheredChunk = this._gatheredChunks.get(hash);
+    return gatheredChunk
+      ? Promise.resolve(gatheredChunk)
+      : super.getChunk(hash);
+  }
+
+  override async transformCommit(
+    hash: Hash,
+    hashType?: HashType,
+  ): Promise<Hash> {
+    if (this._gatheredChunks.has(hash)) {
+      return super.transformCommit(hash, hashType);
+    }
+    return hash;
+  }
+
+  override async transformBTreeNode(hash: Hash): Promise<Hash> {
+    if (this._gatheredChunks.has(hash)) {
+      return super.transformBTreeNode(hash);
+    }
+    return hash;
+  }
+}


### PR DESCRIPTION
Use a Transformer to transform one dag tree into another.

Then use this to implement a Persist Writer which uses the previous
gathered chunks to determine what to write.

Towards #671