### PR TITLE
feat: Add Persist Fixup Transformer

### DIFF
--- a/src/dag/chunk.test.ts
+++ b/src/dag/chunk.test.ts
@@ -1,7 +1,7 @@
 import {expect} from '@esm-bundle/chai';
 import {Hash, hashOf, initHasher, parse} from '../hash';
 import type {Value} from '../kv/store';
-import {defaultChunkHasher, createChunk, readChunk} from './chunk';
+import {defaultChunkHasher, createChunk, createChunkWithHash} from './chunk';
 import type {Chunk} from './chunk';
 
 setup(async () => {
@@ -16,7 +16,7 @@ test('round trip', async () => {
     expect(c.meta).to.deep.equal(refs);
 
     const buf = c.meta;
-    const c2 = readChunk(hash, data, buf);
+    const c2 = createChunkWithHash(hash, data, buf);
     expect(c).to.deep.equal(c2);
   };
 

--- a/src/dag/chunk.ts
+++ b/src/dag/chunk.ts
@@ -44,7 +44,7 @@ export function createChunk<V extends Value>(
   return new ChunkImpl(hash, data, refs);
 }
 
-export function readChunk<V extends Value>(
+export function createChunkWithHash<V extends Value>(
   hash: Hash,
   data: V,
   refs: Refs,

--- a/src/dag/mod.ts
+++ b/src/dag/mod.ts
@@ -1,7 +1,7 @@
 export {Read, metaFromFlatbuffer, metaToFlatbuffer} from './read';
 export {Write, fromLittleEndian, toLittleEndian} from './write';
 export type {Chunk, CreateChunk} from './chunk';
-export {createChunk, defaultChunkHasher} from './chunk';
+export {createChunk, defaultChunkHasher, createChunkWithHash} from './chunk';
 export {Store} from './store';
 export {TestStore} from './test-store';
 export * from './key';

--- a/src/dag/read.ts
+++ b/src/dag/read.ts
@@ -1,5 +1,5 @@
 import type * as kv from '../kv/mod';
-import {assertMeta, Chunk, readChunk} from './chunk';
+import {assertMeta, Chunk, createChunkWithHash} from './chunk';
 import {chunkDataKey, chunkMetaKey, headKey} from './key';
 import * as flatbuffers from 'flatbuffers';
 import {Meta as MetaFB} from './generated/meta/meta.js';
@@ -32,7 +32,7 @@ export class Read {
     } else {
       refs = [];
     }
-    return readChunk(hash, data, refs);
+    return createChunkWithHash(hash, data, refs);
   }
 
   async getHead(name: string): Promise<Hash | undefined> {

--- a/src/dag/test-store.ts
+++ b/src/dag/test-store.ts
@@ -1,6 +1,11 @@
 import {parse as parseHash} from '../hash';
 import {Store} from './store';
-import {Chunk, ChunkHasher, defaultChunkHasher, readChunk} from './chunk';
+import {
+  Chunk,
+  ChunkHasher,
+  defaultChunkHasher,
+  createChunkWithHash,
+} from './chunk';
 import {assertNotTempHash, Hash} from '../hash';
 import {chunkMetaKey, parse as parseKey} from './key';
 import {KeyType} from './key';
@@ -24,7 +29,7 @@ export class TestStore extends Store {
       const pk = parseKey(key);
       if (pk.type === KeyType.ChunkData) {
         const refsValue = this.kvStore.map().get(chunkMetaKey(pk.hash));
-        yield readChunk(pk.hash, value, toRefs(refsValue));
+        yield createChunkWithHash(pk.hash, value, toRefs(refsValue));
       }
     }
   }

--- a/src/dag/write.test.ts
+++ b/src/dag/write.test.ts
@@ -1,6 +1,6 @@
 import {expect} from '@esm-bundle/chai';
 import {MemStore} from '../kv/mod';
-import {defaultChunkHasher, readChunk} from './chunk';
+import {defaultChunkHasher, createChunkWithHash} from './chunk';
 import {chunkDataKey, chunkMetaKey, chunkRefCountKey, headKey} from './key';
 import {Write} from './write';
 import type * as kv from '../kv/mod';
@@ -215,7 +215,7 @@ test('roundtrip', async () => {
   const t = async (name: string, data: Value, refs: Hash[]) => {
     const kv = new MemStore();
     const hash = defaultChunkHasher(data);
-    const c = readChunk(hash, data, refs);
+    const c = createChunkWithHash(hash, data, refs);
     await kv.withWrite(async kvw => {
       const w = new Write(kvw, defaultChunkHasher, assertNotTempHash);
       await w.putChunk(c);

--- a/src/db/mod.ts
+++ b/src/db/mod.ts
@@ -20,7 +20,7 @@ export {
   assertCommitData,
 } from './commit';
 export {getRoot} from './root';
-export {decodeIndexKey} from './index';
+export {decodeIndexKey, encodeIndexKey} from './index';
 export {Visitor} from './visitor';
 export {Transformer} from './transformer';
 

--- a/src/db/transformer.ts
+++ b/src/db/transformer.ts
@@ -53,6 +53,10 @@ export class Transformer {
     h: Hash,
     hashType = HashType.RequireStrong,
   ): Promise<Hash> {
+    if (this.shouldSkip(h)) {
+      return h;
+    }
+
     const chunk = await this.getChunk(h);
     if (!chunk) {
       if (hashType === HashType.AllowWeak) {
@@ -65,6 +69,10 @@ export class Transformer {
 
     const newCommitData = await this._transformCommitData(data);
     return this._maybeWriteChunk(h, newCommitData, data, getRefsFromCommitData);
+  }
+
+  protected shouldSkip(_h: Hash): boolean {
+    return false;
   }
 
   protected shouldForceWrite(_h: Hash): boolean {
@@ -209,6 +217,10 @@ export class Transformer {
   }
 
   async transformBTreeNode(h: Hash): Promise<Hash> {
+    if (this.shouldSkip(h)) {
+      return h;
+    }
+
     const chunk = await this.getChunk(h);
     assert(chunk, `Missing chunk: ${h}`);
     const {data} = chunk;

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,5 +1,6 @@
 import {createSHA512} from 'hash-wasm';
 import type {IHasher} from 'hash-wasm/dist/lib/WASMInterface';
+import {assert} from './asserts';
 
 const BYTE_LENGTH = 20;
 
@@ -154,4 +155,13 @@ export function assertHash(v: unknown): asserts v is Hash {
   if (!isHash(v)) {
     throw new Error(`Invalid hash: '${v}'`);
   }
+}
+
+/**
+ * Generates a fake hash useful for testing.
+ */
+export function fakeHash(s: string): Hash {
+  const fake = 'fake';
+  assert(/[a-v0-9]/.test(s), 'Fake hash must be a valid substring of a hash');
+  return (fake + s.padStart(HASH_LENGTH - fake.length, '0')) as unknown as Hash;
 }

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -163,5 +163,6 @@ export function assertHash(v: unknown): asserts v is Hash {
 export function fakeHash(s: string): Hash {
   const fake = 'fake';
   assert(/[a-v0-9]/.test(s), 'Fake hash must be a valid substring of a hash');
+  assert(s.length <= HASH_LENGTH - fake.length, 'Fake hash is too long');
   return (fake + s.padStart(HASH_LENGTH - fake.length, '0')) as unknown as Hash;
 }

--- a/src/kv/test-mem-store.ts
+++ b/src/kv/test-mem-store.ts
@@ -2,6 +2,10 @@ import {MemStore} from './mem-store';
 import type {Value} from './store';
 
 export class TestMemStore extends MemStore {
+  snapshot(): Record<string, Value> {
+    return Object.fromEntries(this._map.entries());
+  }
+
   /**
    * This exposes the underlying map for testing purposes.
    */

--- a/src/sync/persist-fixup-transformer.test.ts
+++ b/src/sync/persist-fixup-transformer.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../hash';
 import {BTreeWrite} from '../btree/write';
 import {PersistFixupTransformer} from './persist-fixup-transformer';
+import type {ReadonlyJSONValue} from '../json';
 
 setup(async () => {
   await initHasher();
@@ -38,7 +39,9 @@ test('fixup of a single snapshot commit with empty btree', async () => {
     return [c.chunk.hash, valueHash];
   });
 
-  assert.deepEqual(memdag.kvStore.snapshot(), {
+  const snapshot = memdag.kvStore.snapshot();
+
+  assert.deepEqual(snapshot, {
     'c/t/000000000000000000000000000000/d': [0, []],
     'c/t/000000000000000000000000000001/d': {
       meta: {type: 3, basisHash: null, lastMutationID: 0, cookieJSON: null},
@@ -195,6 +198,157 @@ test('fixup of a single snapshot commit with empty btree', async () => {
   }
 });
 
+test('fixup base snapshot when there is a local commit on top of it', async () => {
+  const memdag = new dag.TestStore(
+    undefined,
+    makeNewTempHashFunction(),
+    () => undefined,
+  );
+
+  const [snapshotCommit, localCommit, valueHash] = await memdag.withWrite(
+    async dagWrite => {
+      const tree = new BTreeWrite(dagWrite);
+      const valueHash = await tree.flush();
+      const snapshotCommit = db.newSnapshot(
+        dagWrite.createChunk,
+        null,
+        0,
+        null,
+        valueHash,
+        [],
+      );
+      await dagWrite.putChunk(snapshotCommit.chunk);
+
+      const localCommit = db.newLocal(
+        dagWrite.createChunk,
+        snapshotCommit.chunk.hash,
+        1,
+        'test',
+        {v: 42},
+        null,
+        fakeHash('value'),
+        [],
+      );
+      await dagWrite.putChunk(localCommit.chunk);
+
+      await dagWrite.setHead('test', localCommit.chunk.hash);
+      await dagWrite.commit();
+      return [snapshotCommit, localCommit, valueHash];
+    },
+  );
+
+  assert.deepEqual(memdag.kvStore.snapshot(), {
+    'c/fake00000000000000000000000value/r': 1,
+    'c/t/000000000000000000000000000000/d': [0, []],
+    'c/t/000000000000000000000000000000/r': 1,
+    'c/t/000000000000000000000000000001/d': {
+      indexes: [],
+      meta: {
+        basisHash: null,
+        cookieJSON: null,
+        lastMutationID: 0,
+        type: 3,
+      },
+      valueHash: 't/000000000000000000000000000000',
+    },
+    'c/t/000000000000000000000000000001/m': [
+      't/000000000000000000000000000000',
+    ],
+    'c/t/000000000000000000000000000001/r': 1,
+    'c/t/000000000000000000000000000002/d': {
+      indexes: [],
+      meta: {
+        basisHash: 't/000000000000000000000000000001',
+        mutationID: 1,
+        mutatorArgsJSON: {
+          v: 42,
+        },
+        mutatorName: 'test',
+        originalHash: null,
+        type: 2,
+      },
+      valueHash: 'fake00000000000000000000000value',
+    },
+    'c/t/000000000000000000000000000002/m': [
+      'fake00000000000000000000000value',
+      't/000000000000000000000000000001',
+    ],
+    'c/t/000000000000000000000000000002/r': 1,
+    'h/test': 't/000000000000000000000000000002',
+  });
+
+  // These mappings do not contain the local commit. This is simulating that a
+  // local commit happened after we got the result back from the perdag persist
+  // part.
+  const mappings = new Map([
+    [snapshotCommit.chunk.hash, fakeHash('snapshot')],
+    [valueHash, fakeHash('value')],
+  ]);
+
+  const newLocalCommitHash = await memdag.withWrite(async dagWrite => {
+    const transformer = new PersistFixupTransformer(dagWrite, mappings);
+    const newLocalCommitHash = await transformer.transformCommit(
+      localCommit.chunk.hash,
+    );
+
+    await dagWrite.setHead('test', newLocalCommitHash);
+    await dagWrite.commit();
+    return newLocalCommitHash;
+  });
+
+  assert.notEqual(newLocalCommitHash, localCommit.chunk.hash);
+
+  assert.deepEqual(memdag.kvStore.snapshot(), {
+    'c/fake00000000000000000000000value/d': [0, []],
+    'c/fake00000000000000000000000value/r': 2,
+    'c/fake00000000000000000000snapshot/d': {
+      indexes: [],
+      meta: {
+        basisHash: null,
+        cookieJSON: null,
+        lastMutationID: 0,
+        type: 3,
+      },
+      valueHash: 'fake00000000000000000000000value',
+    },
+    'c/fake00000000000000000000snapshot/m': [
+      'fake00000000000000000000000value',
+    ],
+    'c/fake00000000000000000000snapshot/r': 1,
+    'c/t/000000000000000000000000000003/d': {
+      indexes: [],
+      meta: {
+        basisHash: 'fake00000000000000000000snapshot',
+        mutationID: 1,
+        mutatorArgsJSON: {
+          v: 42,
+        },
+        mutatorName: 'test',
+        originalHash: null,
+        type: 2,
+      },
+      valueHash: 'fake00000000000000000000000value',
+    },
+    'c/t/000000000000000000000000000003/m': [
+      'fake00000000000000000000000value',
+      'fake00000000000000000000snapshot',
+    ],
+    'c/t/000000000000000000000000000003/r': 1,
+    'h/test': 't/000000000000000000000000000003',
+  });
+});
+
+async function makeBTree(
+  dagWrite: dag.Write,
+  entries: [string, ReadonlyJSONValue][],
+): Promise<BTreeWrite> {
+  const tree = new BTreeWrite(dagWrite, undefined, 2, 4, () => 1, 0);
+  for (const [k, v] of entries) {
+    await tree.put(k, v);
+  }
+  return tree;
+}
+
 test('fixup of a single snapshot commit with a btree with internal nodes', async () => {
   const memdag = new dag.TestStore(
     undefined,
@@ -212,10 +366,7 @@ test('fixup of a single snapshot commit with a btree with internal nodes', async
   });
 
   const [headHash, valueHash] = await memdag.withWrite(async dagWrite => {
-    const tree = new BTreeWrite(dagWrite, undefined, 2, 4, () => 1, 0);
-    for (const [k, v] of entries) {
-      await tree.put(k, v);
-    }
+    const tree = await makeBTree(dagWrite, entries);
 
     const valueHash = await tree.flush();
     const c = db.newSnapshot(
@@ -353,4 +504,297 @@ test('fixup of a single snapshot commit with a btree with internal nodes', async
       'c/fake000000000000000000000000head/r': 1,
     },
   );
+});
+
+test('fixup of a base snapshot with an index', async () => {
+  const memdag = new dag.TestStore(
+    undefined,
+    makeNewTempHashFunction(),
+    () => undefined,
+  );
+
+  const entries = Object.entries({
+    a: {a: '0'},
+    b: {a: '1'},
+    c: {a: '2'},
+    d: {a: '3'},
+    e: {a: '4'},
+    f: {b: '5'},
+  });
+
+  const indexEntries: [string, ReadonlyJSONValue][] = [
+    [db.encodeIndexKey(['0', 'a']), {a: '0'}],
+    [db.encodeIndexKey(['1', 'b']), {a: '1'}],
+    [db.encodeIndexKey(['2', 'c']), {a: '2'}],
+    [db.encodeIndexKey(['3', 'd']), {a: '3'}],
+    [db.encodeIndexKey(['4', 'e']), {a: '4'}],
+  ];
+
+  const [headHash, valueHash, indexHash] = await memdag.withWrite(
+    async dagWrite => {
+      const tree = await makeBTree(dagWrite, entries);
+      const valueHash = await tree.flush();
+
+      const indexTree = await makeBTree(dagWrite, indexEntries);
+      const indexHash = await indexTree.flush();
+
+      const c = db.newSnapshot(dagWrite.createChunk, null, 0, null, valueHash, [
+        {
+          definition: {
+            jsonPointer: '/a',
+            keyPrefix: '',
+            name: 'idx',
+          },
+          valueHash: indexHash,
+        },
+      ]);
+      await dagWrite.putChunk(c.chunk);
+      await dagWrite.setHead('test', c.chunk.hash);
+      await dagWrite.commit();
+      return [c.chunk.hash, valueHash, indexHash];
+    },
+  );
+
+  const snapshot = memdag.kvStore.snapshot();
+
+  assert.deepEqual(snapshot, {
+    'c/t/000000000000000000000000000000/d': [
+      0,
+      [
+        ['a', {a: '0'}],
+        ['b', {a: '1'}],
+      ],
+    ],
+    'c/t/000000000000000000000000000001/d': [
+      0,
+      [
+        ['c', {a: '2'}],
+        ['d', {a: '3'}],
+        ['e', {a: '4'}],
+        ['f', {b: '5'}],
+      ],
+    ],
+    'c/t/000000000000000000000000000002/d': [
+      1,
+      [
+        ['b', 't/000000000000000000000000000000'],
+        ['f', 't/000000000000000000000000000001'],
+      ],
+    ],
+    'c/t/000000000000000000000000000002/m': [
+      't/000000000000000000000000000000',
+      't/000000000000000000000000000001',
+    ],
+    'c/t/000000000000000000000000000003/d': [
+      0,
+      [
+        ['\u00000\u0000a', {a: '0'}],
+        ['\u00001\u0000b', {a: '1'}],
+      ],
+    ],
+    'c/t/000000000000000000000000000004/d': [
+      0,
+      [
+        ['\u00002\u0000c', {a: '2'}],
+        ['\u00003\u0000d', {a: '3'}],
+        ['\u00004\u0000e', {a: '4'}],
+      ],
+    ],
+    'c/t/000000000000000000000000000005/d': [
+      1,
+      [
+        ['\u00001\u0000b', 't/000000000000000000000000000003'],
+        ['\u00004\u0000e', 't/000000000000000000000000000004'],
+      ],
+    ],
+    'c/t/000000000000000000000000000005/m': [
+      't/000000000000000000000000000003',
+      't/000000000000000000000000000004',
+    ],
+    'c/t/000000000000000000000000000006/d': {
+      meta: {type: 3, basisHash: null, lastMutationID: 0, cookieJSON: null},
+      valueHash: 't/000000000000000000000000000002',
+      indexes: [
+        {
+          definition: {jsonPointer: '/a', keyPrefix: '', name: 'idx'},
+          valueHash: 't/000000000000000000000000000005',
+        },
+      ],
+    },
+    'c/t/000000000000000000000000000006/m': [
+      't/000000000000000000000000000002',
+      't/000000000000000000000000000005',
+    ],
+    'h/test': 't/000000000000000000000000000006',
+    'c/t/000000000000000000000000000000/r': 1,
+    'c/t/000000000000000000000000000001/r': 1,
+    'c/t/000000000000000000000000000003/r': 1,
+    'c/t/000000000000000000000000000004/r': 1,
+    'c/t/000000000000000000000000000002/r': 1,
+    'c/t/000000000000000000000000000005/r': 1,
+    'c/t/000000000000000000000000000006/r': 1,
+  });
+
+  const mappings = new Map([
+    [headHash, fakeHash('head')],
+    [valueHash, fakeHash('value')],
+    [indexHash, fakeHash('index')],
+    [parseHash('t/000000000000000000000000000000'), fakeHash('data0')],
+    [parseHash('t/000000000000000000000000000001'), fakeHash('data1')],
+    [parseHash('t/000000000000000000000000000003'), fakeHash('data3')],
+    [parseHash('t/000000000000000000000000000004'), fakeHash('data4')],
+  ]);
+
+  const newHeadHash = await memdag.withWrite(async dagWrite => {
+    const transformer = new PersistFixupTransformer(dagWrite, mappings);
+    const newHeadHash = await transformer.transformCommit(headHash);
+
+    await dagWrite.setHead('test', newHeadHash);
+    await dagWrite.commit();
+    return newHeadHash;
+  });
+
+  assert.equal(newHeadHash, fakeHash('head'));
+
+  assert.deepEqual(memdag.kvStore.snapshot(), {
+    'c/fake000000000000000000000000head/d': {
+      indexes: [
+        {
+          definition: {
+            jsonPointer: '/a',
+            keyPrefix: '',
+            name: 'idx',
+          },
+          valueHash: 'fake00000000000000000000000index',
+        },
+      ],
+      meta: {
+        basisHash: null,
+        cookieJSON: null,
+        lastMutationID: 0,
+        type: 3,
+      },
+      valueHash: 'fake00000000000000000000000value',
+    },
+    'c/fake000000000000000000000000head/m': [
+      'fake00000000000000000000000value',
+      'fake00000000000000000000000index',
+    ],
+    'c/fake000000000000000000000000head/r': 1,
+    'c/fake00000000000000000000000data0/d': [
+      0,
+      [
+        [
+          'a',
+          {
+            a: '0',
+          },
+        ],
+        [
+          'b',
+          {
+            a: '1',
+          },
+        ],
+      ],
+    ],
+    'c/fake00000000000000000000000data0/r': 1,
+    'c/fake00000000000000000000000data1/d': [
+      0,
+      [
+        [
+          'c',
+          {
+            a: '2',
+          },
+        ],
+        [
+          'd',
+          {
+            a: '3',
+          },
+        ],
+        [
+          'e',
+          {
+            a: '4',
+          },
+        ],
+        [
+          'f',
+          {
+            b: '5',
+          },
+        ],
+      ],
+    ],
+    'c/fake00000000000000000000000data1/r': 1,
+    'c/fake00000000000000000000000data3/d': [
+      0,
+      [
+        [
+          '\u00000\u0000a',
+          {
+            a: '0',
+          },
+        ],
+        [
+          '\u00001\u0000b',
+          {
+            a: '1',
+          },
+        ],
+      ],
+    ],
+    'c/fake00000000000000000000000data3/r': 1,
+    'c/fake00000000000000000000000data4/d': [
+      0,
+      [
+        [
+          '\u00002\u0000c',
+          {
+            a: '2',
+          },
+        ],
+        [
+          '\u00003\u0000d',
+          {
+            a: '3',
+          },
+        ],
+        [
+          '\u00004\u0000e',
+          {
+            a: '4',
+          },
+        ],
+      ],
+    ],
+    'c/fake00000000000000000000000data4/r': 1,
+    'c/fake00000000000000000000000index/d': [
+      1,
+      [
+        ['\u00001\u0000b', 'fake00000000000000000000000data3'],
+        ['\u00004\u0000e', 'fake00000000000000000000000data4'],
+      ],
+    ],
+    'c/fake00000000000000000000000index/m': [
+      'fake00000000000000000000000data3',
+      'fake00000000000000000000000data4',
+    ],
+    'c/fake00000000000000000000000index/r': 1,
+    'c/fake00000000000000000000000value/d': [
+      1,
+      [
+        ['b', 'fake00000000000000000000000data0'],
+        ['f', 'fake00000000000000000000000data1'],
+      ],
+    ],
+    'c/fake00000000000000000000000value/m': [
+      'fake00000000000000000000000data0',
+      'fake00000000000000000000000data1',
+    ],
+    'c/fake00000000000000000000000value/r': 1,
+    'h/test': 'fake000000000000000000000000head',
+  });
 });

--- a/src/sync/persist-fixup-transformer.test.ts
+++ b/src/sync/persist-fixup-transformer.test.ts
@@ -232,8 +232,6 @@ test('fixup of a single snapshot commit with a btree with internal nodes', async
     return [c.chunk.hash, valueHash];
   });
 
-  // console.log(JSON.stringify(memdag.kvStore.snapshot(), null, 2));
-
   assert.deepEqual(
     memdag.kvStore.snapshot(),
 
@@ -303,8 +301,6 @@ test('fixup of a single snapshot commit with a btree with internal nodes', async
   });
 
   assert.equal(newHeadHash, fakeHash('head'));
-
-  // console.log(JSON.stringify(memdag.kvStore.snapshot(), null, 2));
 
   assert.deepEqual(
     memdag.kvStore.snapshot(),

--- a/src/sync/persist-fixup-transformer.test.ts
+++ b/src/sync/persist-fixup-transformer.test.ts
@@ -1,0 +1,360 @@
+import {assert} from '@esm-bundle/chai';
+import * as dag from '../dag/mod';
+import * as db from '../db/mod';
+import {
+  fakeHash,
+  initHasher,
+  makeNewTempHashFunction,
+  parse as parseHash,
+} from '../hash';
+import {BTreeWrite} from '../btree/write';
+import {PersistFixupTransformer} from './persist-fixup-transformer';
+
+setup(async () => {
+  await initHasher();
+});
+
+test('fixup of a single snapshot commit with empty btree', async () => {
+  const memdag = new dag.TestStore(
+    undefined,
+    makeNewTempHashFunction(),
+    () => undefined,
+  );
+
+  const [headHash, valueHash] = await memdag.withWrite(async dagWrite => {
+    const tree = new BTreeWrite(dagWrite);
+    const valueHash = await tree.flush();
+    const c = db.newSnapshot(
+      dagWrite.createChunk,
+      null,
+      0,
+      null,
+      valueHash,
+      [],
+    );
+    await dagWrite.putChunk(c.chunk);
+    await dagWrite.setHead('test', c.chunk.hash);
+    await dagWrite.commit();
+    return [c.chunk.hash, valueHash];
+  });
+
+  assert.deepEqual(memdag.kvStore.snapshot(), {
+    'c/t/000000000000000000000000000000/d': [0, []],
+    'c/t/000000000000000000000000000001/d': {
+      meta: {type: 3, basisHash: null, lastMutationID: 0, cookieJSON: null},
+      valueHash: 't/000000000000000000000000000000',
+      indexes: [],
+    },
+    'c/t/000000000000000000000000000001/m': [
+      't/000000000000000000000000000000',
+    ],
+    'h/test': 't/000000000000000000000000000001',
+    'c/t/000000000000000000000000000000/r': 1,
+    'c/t/000000000000000000000000000001/r': 1,
+  });
+
+  const mappings = new Map([
+    [headHash, fakeHash('head')],
+    [valueHash, fakeHash('value')],
+  ]);
+
+  const newHeadHash = await memdag.withWrite(async dagWrite => {
+    const transformer = new PersistFixupTransformer(dagWrite, mappings);
+    const newHeadHash = await transformer.transformCommit(headHash);
+
+    await dagWrite.setHead('test', newHeadHash);
+    await dagWrite.commit();
+    return newHeadHash;
+  });
+
+  assert.equal(newHeadHash, fakeHash('head'));
+
+  assert.deepEqual(memdag.kvStore.snapshot(), {
+    'h/test': 'fake000000000000000000000000head',
+    'c/fake00000000000000000000000value/d': [0, []],
+    'c/fake000000000000000000000000head/d': {
+      meta: {type: 3, basisHash: null, lastMutationID: 0, cookieJSON: null},
+      valueHash: 'fake00000000000000000000000value',
+      indexes: [],
+    },
+    'c/fake000000000000000000000000head/m': [
+      'fake00000000000000000000000value',
+    ],
+    'c/fake00000000000000000000000value/r': 1,
+    'c/fake000000000000000000000000head/r': 1,
+  });
+
+  // Now add a local commit on top of the snapshot commit.
+  {
+    const headHash = await memdag.withWrite(async dagWrite => {
+      const c = db.newLocal(
+        dagWrite.createChunk,
+        newHeadHash,
+        1,
+        'test',
+        {v: 42},
+        null,
+        fakeHash('value'),
+        [],
+      );
+      await dagWrite.putChunk(c.chunk);
+      await dagWrite.setHead('test', c.chunk.hash);
+      await dagWrite.commit();
+      return c.chunk.hash;
+    });
+
+    assert.deepEqual(memdag.kvStore.snapshot(), {
+      'c/fake000000000000000000000000head/d': {
+        indexes: [],
+        meta: {
+          basisHash: null,
+          cookieJSON: null,
+          lastMutationID: 0,
+          type: 3,
+        },
+        valueHash: 'fake00000000000000000000000value',
+      },
+      'c/fake000000000000000000000000head/m': [
+        'fake00000000000000000000000value',
+      ],
+      'c/fake000000000000000000000000head/r': 1,
+      'c/fake00000000000000000000000value/d': [0, []],
+      'c/fake00000000000000000000000value/r': 2,
+      'c/t/000000000000000000000000000002/d': {
+        indexes: [],
+        meta: {
+          basisHash: 'fake000000000000000000000000head',
+          mutationID: 1,
+          mutatorArgsJSON: {
+            v: 42,
+          },
+          mutatorName: 'test',
+          originalHash: null,
+          type: 2,
+        },
+        valueHash: 'fake00000000000000000000000value',
+      },
+      'c/t/000000000000000000000000000002/m': [
+        'fake00000000000000000000000value',
+        'fake000000000000000000000000head',
+      ],
+      'c/t/000000000000000000000000000002/r': 1,
+      'h/test': 't/000000000000000000000000000002',
+    });
+
+    const mappings = new Map([[headHash, fakeHash('head2')]]);
+
+    const newHeadHash2 = await memdag.withWrite(async dagWrite => {
+      const transformer = new PersistFixupTransformer(dagWrite, mappings);
+      const newHeadHash = await transformer.transformCommit(headHash);
+
+      await dagWrite.setHead('test', newHeadHash);
+      await dagWrite.commit();
+      return newHeadHash;
+    });
+
+    assert.deepEqual(memdag.kvStore.snapshot(), {
+      'c/fake000000000000000000000000head/d': {
+        indexes: [],
+        meta: {
+          basisHash: null,
+          cookieJSON: null,
+          lastMutationID: 0,
+          type: 3,
+        },
+        valueHash: 'fake00000000000000000000000value',
+      },
+      'c/fake000000000000000000000000head/m': [
+        'fake00000000000000000000000value',
+      ],
+      'c/fake000000000000000000000000head/r': 1,
+      'c/fake00000000000000000000000head2/d': {
+        indexes: [],
+        meta: {
+          basisHash: 'fake000000000000000000000000head',
+          mutationID: 1,
+          mutatorArgsJSON: {
+            v: 42,
+          },
+          mutatorName: 'test',
+          originalHash: null,
+          type: 2,
+        },
+        valueHash: 'fake00000000000000000000000value',
+      },
+      'c/fake00000000000000000000000head2/m': [
+        'fake00000000000000000000000value',
+        'fake000000000000000000000000head',
+      ],
+      'c/fake00000000000000000000000head2/r': 1,
+      'c/fake00000000000000000000000value/d': [0, []],
+      'c/fake00000000000000000000000value/r': 2,
+      'h/test': 'fake00000000000000000000000head2',
+    });
+    assert.equal(newHeadHash2, fakeHash('head2'));
+  }
+});
+
+test('fixup of a single snapshot commit with a btree with internal nodes', async () => {
+  const memdag = new dag.TestStore(
+    undefined,
+    makeNewTempHashFunction(),
+    () => undefined,
+  );
+
+  const entries = Object.entries({
+    a: 0,
+    b: 1,
+    c: 2,
+    d: 3,
+    e: 4,
+    f: 5,
+  });
+
+  const [headHash, valueHash] = await memdag.withWrite(async dagWrite => {
+    const tree = new BTreeWrite(dagWrite, undefined, 2, 4, () => 1, 0);
+    for (const [k, v] of entries) {
+      await tree.put(k, v);
+    }
+
+    const valueHash = await tree.flush();
+    const c = db.newSnapshot(
+      dagWrite.createChunk,
+      null,
+      0,
+      null,
+      valueHash,
+      [],
+    );
+    await dagWrite.putChunk(c.chunk);
+    await dagWrite.setHead('test', c.chunk.hash);
+    await dagWrite.commit();
+    return [c.chunk.hash, valueHash];
+  });
+
+  // console.log(JSON.stringify(memdag.kvStore.snapshot(), null, 2));
+
+  assert.deepEqual(
+    memdag.kvStore.snapshot(),
+
+    {
+      'c/t/000000000000000000000000000000/d': [
+        0,
+        [
+          ['a', 0],
+          ['b', 1],
+        ],
+      ],
+      'c/t/000000000000000000000000000001/d': [
+        0,
+        [
+          ['c', 2],
+          ['d', 3],
+          ['e', 4],
+          ['f', 5],
+        ],
+      ],
+      'c/t/000000000000000000000000000002/d': [
+        1,
+        [
+          ['b', 't/000000000000000000000000000000'],
+          ['f', 't/000000000000000000000000000001'],
+        ],
+      ],
+      'c/t/000000000000000000000000000002/m': [
+        't/000000000000000000000000000000',
+        't/000000000000000000000000000001',
+      ],
+      'c/t/000000000000000000000000000003/d': {
+        meta: {
+          type: 3,
+          basisHash: null,
+          lastMutationID: 0,
+          cookieJSON: null,
+        },
+        valueHash: 't/000000000000000000000000000002',
+        indexes: [],
+      },
+      'c/t/000000000000000000000000000003/m': [
+        't/000000000000000000000000000002',
+      ],
+      'h/test': 't/000000000000000000000000000003',
+      'c/t/000000000000000000000000000000/r': 1,
+      'c/t/000000000000000000000000000001/r': 1,
+      'c/t/000000000000000000000000000002/r': 1,
+      'c/t/000000000000000000000000000003/r': 1,
+    },
+  );
+
+  const mappings = new Map([
+    [headHash, fakeHash('head')],
+    [valueHash, fakeHash('value')],
+    [parseHash('t/000000000000000000000000000000'), fakeHash('data0')],
+    [parseHash('t/000000000000000000000000000001'), fakeHash('data1')],
+  ]);
+
+  const newHeadHash = await memdag.withWrite(async dagWrite => {
+    const transformer = new PersistFixupTransformer(dagWrite, mappings);
+    const newHeadHash = await transformer.transformCommit(headHash);
+
+    await dagWrite.setHead('test', newHeadHash);
+    await dagWrite.commit();
+    return newHeadHash;
+  });
+
+  assert.equal(newHeadHash, fakeHash('head'));
+
+  // console.log(JSON.stringify(memdag.kvStore.snapshot(), null, 2));
+
+  assert.deepEqual(
+    memdag.kvStore.snapshot(),
+
+    {
+      'h/test': 'fake000000000000000000000000head',
+      'c/fake00000000000000000000000data0/d': [
+        0,
+        [
+          ['a', 0],
+          ['b', 1],
+        ],
+      ],
+      'c/fake00000000000000000000000data1/d': [
+        0,
+        [
+          ['c', 2],
+          ['d', 3],
+          ['e', 4],
+          ['f', 5],
+        ],
+      ],
+      'c/fake00000000000000000000000value/d': [
+        1,
+        [
+          ['b', 'fake00000000000000000000000data0'],
+          ['f', 'fake00000000000000000000000data1'],
+        ],
+      ],
+      'c/fake00000000000000000000000value/m': [
+        'fake00000000000000000000000data0',
+        'fake00000000000000000000000data1',
+      ],
+      'c/fake000000000000000000000000head/d': {
+        meta: {
+          type: 3,
+          basisHash: null,
+          lastMutationID: 0,
+          cookieJSON: null,
+        },
+        valueHash: 'fake00000000000000000000000value',
+        indexes: [],
+      },
+      'c/fake000000000000000000000000head/m': [
+        'fake00000000000000000000000value',
+      ],
+      'c/fake00000000000000000000000data0/r': 1,
+      'c/fake00000000000000000000000data1/r': 1,
+      'c/fake00000000000000000000000value/r': 1,
+      'c/fake000000000000000000000000head/r': 1,
+    },
+  );
+});

--- a/src/sync/persist-fixup-transformer.ts
+++ b/src/sync/persist-fixup-transformer.ts
@@ -1,6 +1,5 @@
 import type * as kv from '../kv/mod';
 import * as dag from '../dag/mod';
-import type * as btree from '../btree/mod';
 import type {HashType} from '../db/hash-type';
 import * as db from '../db/mod';
 import type {Hash} from '../hash';

--- a/src/sync/persist-fixup-transformer.ts
+++ b/src/sync/persist-fixup-transformer.ts
@@ -1,6 +1,5 @@
 import type * as kv from '../kv/mod';
 import * as dag from '../dag/mod';
-import type {HashType} from '../db/hash-type';
 import * as db from '../db/mod';
 import {Hash, isTempHash} from '../hash';
 
@@ -25,31 +24,11 @@ export class PersistFixupTransformer extends db.Transformer {
     this._mappings = mappings;
   }
 
-  shouldSkipTransform(hash: Hash): boolean {
-    // TODO(arv): Move to base class
+  override shouldSkip(hash: Hash): boolean {
     if (isTempHash(hash)) {
       return false;
     }
     return !this._mappings.has(hash);
-
-    // What if hash is for a data node that is not in the mappings?
-  }
-
-  override async transformCommit(
-    oldHash: OldHash,
-    hashType?: HashType,
-  ): Promise<NewHash> {
-    if (this.shouldSkipTransform(oldHash)) {
-      return oldHash;
-    }
-    return super.transformCommit(oldHash, hashType);
-  }
-
-  override async transformBTreeNode(oldHash: OldHash): Promise<NewHash> {
-    if (this.shouldSkipTransform(oldHash)) {
-      return oldHash;
-    }
-    return super.transformBTreeNode(oldHash);
   }
 
   override shouldForceWrite(h: OldHash): boolean {

--- a/src/sync/persist-fixup-transformer.ts
+++ b/src/sync/persist-fixup-transformer.ts
@@ -1,0 +1,69 @@
+import type * as kv from '../kv/mod';
+import * as dag from '../dag/mod';
+import type * as btree from '../btree/mod';
+import type {HashType} from '../db/hash-type';
+import * as db from '../db/mod';
+import type {Hash} from '../hash';
+import {assert} from '../asserts';
+
+type OldHash = Hash;
+type NewHash = Hash;
+type Mappings = ReadonlyMap<OldHash, NewHash>;
+
+/**
+ * This transformer is used to fixup the hashes we got from the source dag (the
+ * perdag in our case) and rewrite the required chunks in the destination dag
+ * (the memdag).
+ */
+export class PersistFixupTransformer extends db.Transformer {
+  private readonly _mappings: Mappings;
+
+  constructor(dagWrite: dag.Write, mappings: Mappings) {
+    super(dagWrite);
+    this._mappings = mappings;
+  }
+
+  override async transformCommit(
+    oldHash: OldHash,
+    hashType?: HashType,
+  ): Promise<NewHash> {
+    const newHash = this._mappings.get(oldHash);
+    if (newHash === undefined) {
+      // If the hash is not in the mapping we do not need to recurse into the
+      // subtree.
+      return oldHash;
+    }
+    return super.transformCommit(oldHash, hashType);
+  }
+
+  override async transformBTreeNode(oldHash: OldHash): Promise<NewHash> {
+    const newHash = this._mappings.get(oldHash);
+    if (newHash === undefined) {
+      // If the hash is not in the mapping we do not need to recurse into the
+      // subtree.
+      return oldHash;
+    }
+    return super.transformBTreeNode(oldHash);
+  }
+
+  override shouldForceWrite(h: OldHash): boolean {
+    // If there is a mapping we need to write this chunk even if the data did
+    // not change. This happens for BTree data nodes for example because the
+    // hash it had in the memdag was using a temp hash but now we got a real
+    // hash from the perdag.
+    return this._mappings.has(h);
+  }
+
+  override async writeChunk<D extends kv.Value>(
+    oldHash: OldHash,
+    data: D,
+    getRefs: (data: D) => readonly Hash[],
+  ): Promise<Hash> {
+    const newHash = this._mappings.get(oldHash);
+    // We should not get here if there is no mapping.
+    assert(newHash);
+    const newChunk = dag.createChunkWithHash(newHash, data, getRefs(data));
+    await this.dagWrite.putChunk(newChunk);
+    return newHash;
+  }
+}

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -30,7 +30,7 @@ export default {
         'src/sync/*.test.ts',
         'src/migrate/*.test.ts',
         'src/btree/*.test.ts',
-        // src/worker-tests/ intentioanly excluded, see separate Worker group below
+        // src/worker-tests/ intentionally excluded, see separate Worker group below
       ],
       browsers: [firefox, chromium, webkit],
     },


### PR DESCRIPTION
This is another transformer that changes the hashes in a DAG. It walks
down the DAG and "rewrites" chunks with a new hash, provided as a
mapping from old hash to new hash. The old chunks will get garbage
collected as usual.

Towards #671