### PR TITLE
feat: A transformer that computes the chunk hash

### DIFF
--- a/src/base32-encode.ts
+++ b/src/base32-encode.ts
@@ -1,0 +1,35 @@
+const charTable = '0123456789abcdefghijklmnopqrstuv';
+
+export function encode(plain: Uint8Array): string {
+  let i = 0;
+  let shiftIndex = 0;
+  let digit = 0;
+  let encoded = '';
+  const {length} = plain;
+
+  // byte by byte isn't as pretty as quintet by quintet but tests a bit
+  // faster. will have to revisit.
+  while (i < length) {
+    const current = plain[i];
+
+    if (shiftIndex > 3) {
+      digit = current & (0xff >> shiftIndex);
+      shiftIndex = (shiftIndex + 5) % 8;
+      digit =
+        (digit << shiftIndex) |
+        ((i + 1 < length ? plain[i + 1] : 0) >> (8 - shiftIndex));
+      i++;
+    } else {
+      digit = (current >> (8 - (shiftIndex + 5))) & 0x1f;
+      shiftIndex = (shiftIndex + 5) % 8;
+      if (shiftIndex === 0) {
+        i++;
+      }
+    }
+
+    encoded += charTable[digit];
+  }
+
+  // No padding!
+  return encoded;
+}

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,10 +1,11 @@
 import {createSHA512} from 'hash-wasm';
 import type {IHasher} from 'hash-wasm/dist/lib/WASMInterface';
 import {assert} from './asserts';
+import {encode} from './base32-encode';
 
-const BYTE_LENGTH = 20;
+export const BYTE_LENGTH = 20;
 
-const HASH_LENGTH = 32;
+export const STRING_LENGTH = 32;
 
 // We use an opaque type so that we can make sure that a hash is always a hash.
 // TypeScript does not have direct support but we can use a trick described
@@ -25,8 +26,6 @@ declare const hashTag: unique symbol;
  * or `hashOf` (except for static unsafe cast of course).
  */
 export type Hash = {[hashTag]: true};
-
-const charTable = '0123456789abcdefghijklmnopqrstuv';
 
 let mem = new Uint8Array(1024 * 1024);
 const encoder = new TextEncoder();
@@ -49,7 +48,7 @@ const stringToUint8Array: (s: string) => Uint8Array =
     : s => encoder.encode(s);
 
 const hashRe = /^[0-9a-v]{32}$/;
-const tempHashRe = /^t\/[0-9]{30}$/;
+const tempHashRe = /^t\/[0-9a-v]{30}$/;
 
 /**
  * Computes a SHA512 hash of the given data.
@@ -73,39 +72,6 @@ export function parse(s: string): Hash {
 
 export const emptyHash = '00000000000000000000000000000000' as unknown as Hash;
 
-function encode(plain: Uint8Array): string {
-  let i = 0;
-  let shiftIndex = 0;
-  let digit = 0;
-  let encoded = '';
-
-  // byte by byte isn't as pretty as quintet by quintet but tests a bit
-  // faster. will have to revisit.
-  while (i < BYTE_LENGTH) {
-    const current = plain[i];
-
-    if (shiftIndex > 3) {
-      digit = current & (0xff >> shiftIndex);
-      shiftIndex = (shiftIndex + 5) % 8;
-      digit =
-        (digit << shiftIndex) |
-        ((i + 1 < BYTE_LENGTH ? plain[i + 1] : 0) >> (8 - shiftIndex));
-      i++;
-    } else {
-      digit = (current >> (8 - (shiftIndex + 5))) & 0x1f;
-      shiftIndex = (shiftIndex + 5) % 8;
-      if (shiftIndex === 0) {
-        i++;
-      }
-    }
-
-    encoded += charTable[digit];
-  }
-
-  // No padding!
-  return encoded;
-}
-
 let hasherPromise: Promise<IHasher> | undefined;
 let hasher: IHasher | undefined;
 
@@ -124,16 +90,14 @@ export async function initHasher(): Promise<unknown> {
 
 export const newTempHash = makeNewTempHashFunction();
 
-export function makeNewTempHashFunction(): () => Hash {
+export function makeNewTempHashFunction(tempPrefix = 't/'): () => Hash {
   let tempHashCounter = 0;
-  const tempPrefix = 't/';
-
   return () => {
     // Must not overlap with hashOf results
     return (tempPrefix +
       (tempHashCounter++)
         .toString()
-        .padStart(HASH_LENGTH - tempPrefix.length, '0')) as unknown as Hash;
+        .padStart(STRING_LENGTH - tempPrefix.length, '0')) as unknown as Hash;
   };
 }
 
@@ -163,6 +127,7 @@ export function assertHash(v: unknown): asserts v is Hash {
 export function fakeHash(s: string): Hash {
   const fake = 'fake';
   assert(/[a-v0-9]/.test(s), 'Fake hash must be a valid substring of a hash');
-  assert(s.length <= HASH_LENGTH - fake.length, 'Fake hash is too long');
-  return (fake + s.padStart(HASH_LENGTH - fake.length, '0')) as unknown as Hash;
+  assert(s.length <= STRING_LENGTH - fake.length, 'Fake hash is too long');
+  return (fake +
+    s.padStart(STRING_LENGTH - fake.length, '0')) as unknown as Hash;
 }

--- a/src/kv/test-mem-store.ts
+++ b/src/kv/test-mem-store.ts
@@ -6,6 +6,13 @@ export class TestMemStore extends MemStore {
     return Object.fromEntries(this._map.entries());
   }
 
+  restoreSnapshot(snapshot: Record<string, Value>): void {
+    this._map.clear();
+    for (const [k, v] of Object.entries(snapshot)) {
+      this._map.set(k, v);
+    }
+  }
+
   /**
    * This exposes the underlying map for testing purposes.
    */

--- a/src/sync/persist-compute-hash-transformer.test.ts
+++ b/src/sync/persist-compute-hash-transformer.test.ts
@@ -1,0 +1,133 @@
+import {assert} from '@esm-bundle/chai';
+import * as dag from '../dag/mod';
+import * as db from '../db/mod';
+import * as utf8 from '../utf8';
+import {
+  BYTE_LENGTH,
+  Hash,
+  makeNewTempHashFunction,
+  parse as parseHash,
+} from '../hash';
+import {BTreeWrite} from '../btree/write';
+import {PersistComputeHashTransformer} from './persist-compute-hash-transformer';
+import {encode} from '../base32-encode';
+import type {ReadonlyJSONValue} from '../json';
+
+test('fix hashes up of a single snapshot commit with empty btree', async () => {
+  const memdag = new dag.TestStore(
+    undefined,
+    makeNewTempHashFunction('t/aaa'),
+    () => undefined,
+  );
+
+  const [headChunk, treeChunk] = await memdag.withWrite(async dagWrite => {
+    const tree = new BTreeWrite(dagWrite);
+    const valueHash = await tree.flush();
+    const c = db.newSnapshot(
+      dagWrite.createChunk,
+      null,
+      0,
+      null,
+      valueHash,
+      [],
+    );
+    await dagWrite.putChunk(c.chunk);
+    await dagWrite.setHead('test', c.chunk.hash);
+    await dagWrite.commit();
+    return [c.chunk, await dagWrite.getChunk(valueHash)];
+  });
+
+  const snapshot = memdag.kvStore.snapshot();
+  assert.deepEqual(snapshot, {
+    'c/t/aaa000000000000000000000000000/d': [0, []],
+    'c/t/aaa000000000000000000000000001/d': {
+      meta: {type: 3, basisHash: null, lastMutationID: 0, cookieJSON: null},
+      valueHash: 't/aaa000000000000000000000000000',
+      indexes: [],
+    },
+    'c/t/aaa000000000000000000000000001/m': [
+      't/aaa000000000000000000000000000',
+    ],
+    'h/test': 't/aaa000000000000000000000000001',
+    'c/t/aaa000000000000000000000000000/r': 1,
+    'c/t/aaa000000000000000000000000001/r': 1,
+  });
+
+  if (!treeChunk) {
+    assert.fail();
+  }
+
+  const gatheredChunk = new Map([
+    [headChunk.hash, headChunk],
+    [treeChunk.hash, treeChunk],
+  ]);
+
+  const hashFunc = async (v: ReadonlyJSONValue): Promise<Hash> => {
+    const buf = await crypto.subtle.digest(
+      'SHA-512',
+      utf8.encode(JSON.stringify(v)),
+    );
+    const buf2 = new Uint8Array(buf, 0, BYTE_LENGTH);
+    return encode(buf2) as unknown as Hash;
+  };
+
+  const transformer = new PersistComputeHashTransformer(
+    gatheredChunk,
+    hashFunc,
+  );
+  const newHeadHash = await transformer.transformCommit(headChunk.hash);
+  assert.equal(newHeadHash, parseHash('9lrb08p9b7jqo8oad3aef60muj4td8ke'));
+
+  assert.deepEqual(Object.fromEntries(transformer.fixedChunks), {
+    'mdcncodijhl6jk2o8bb7m0hg15p3sf24': {
+      data: [0, []],
+      hash: 'mdcncodijhl6jk2o8bb7m0hg15p3sf24',
+      meta: [],
+    },
+    '9lrb08p9b7jqo8oad3aef60muj4td8ke': {
+      data: {
+        indexes: [],
+        meta: {
+          basisHash: null,
+          cookieJSON: null,
+          lastMutationID: 0,
+          type: 3,
+        },
+        valueHash: 'mdcncodijhl6jk2o8bb7m0hg15p3sf24',
+      },
+      hash: '9lrb08p9b7jqo8oad3aef60muj4td8ke',
+      meta: ['mdcncodijhl6jk2o8bb7m0hg15p3sf24'],
+    },
+  });
+
+  {
+    // And again but only with the snapshot commit
+    memdag.kvStore.restoreSnapshot(snapshot);
+
+    const gatheredChunk = new Map([[headChunk.hash, headChunk]]);
+
+    const transformer = new PersistComputeHashTransformer(
+      gatheredChunk,
+      hashFunc,
+    );
+    const newHeadHash = await transformer.transformCommit(headChunk.hash);
+    assert.equal(newHeadHash, parseHash('1fgr18o8m8p503lt3e9oaoct8k9ch47b'));
+
+    assert.deepEqual(Object.fromEntries(transformer.fixedChunks), {
+      '1fgr18o8m8p503lt3e9oaoct8k9ch47b': {
+        data: {
+          indexes: [],
+          meta: {
+            basisHash: null,
+            cookieJSON: null,
+            lastMutationID: 0,
+            type: 3,
+          },
+          valueHash: 't/aaa000000000000000000000000000',
+        },
+        hash: '1fgr18o8m8p503lt3e9oaoct8k9ch47b',
+        meta: ['t/aaa000000000000000000000000000'],
+      },
+    });
+  }
+});

--- a/src/sync/persist-compute-hash-transformer.ts
+++ b/src/sync/persist-compute-hash-transformer.ts
@@ -1,0 +1,44 @@
+import * as dag from '../dag/mod';
+import type {Hash} from '../hash';
+import type {Value} from '../kv/mod';
+import type {MaybePromise} from '../replicache';
+import {PersistWriteTransformer} from './persist-write-transformer';
+
+export type GatheredChunks = ReadonlyMap<Hash, dag.Chunk>;
+export type FixedChunks = ReadonlyMap<Hash, dag.Chunk>;
+
+/**
+ * This transformer computes the hashes
+ */
+export class PersistComputeHashTransformer extends PersistWriteTransformer<null> {
+  private readonly _fixedChunks: Map<Hash, dag.Chunk> = new Map();
+  private readonly _hashFunc: (value: Value) => MaybePromise<Hash>;
+
+  /**
+   * @param dagWrite The destination dag.
+   * @param gatheredChunks The chunks that were gathered on the source dag in
+   * a previous pass.
+   */
+  constructor(
+    gatheredChunks: GatheredChunks,
+    hashFunc: (value: Value) => MaybePromise<Hash>,
+  ) {
+    super(null, gatheredChunks);
+    this._hashFunc = hashFunc;
+  }
+
+  get fixedChunks(): FixedChunks {
+    return this._fixedChunks;
+  }
+
+  protected override async writeChunk<D extends Value>(
+    _h: Hash,
+    data: D,
+    getRefs: (data: D) => readonly Hash[],
+  ): Promise<Hash> {
+    const hash = await this._hashFunc(data);
+    const chunk = dag.createChunkWithHash(hash, data, getRefs(data));
+    this._fixedChunks.set(hash, chunk);
+    return hash;
+  }
+}

--- a/src/sync/persist-fixup-transformer.ts
+++ b/src/sync/persist-fixup-transformer.ts
@@ -16,11 +16,13 @@ type Mappings = ReadonlyMap<OldHash, NewHash>;
  * perdag in our case) and rewrite the required chunks in the destination dag
  * (the memdag).
  */
-export class PersistFixupTransformer extends db.Transformer {
+export class PersistFixupTransformer<
+  Tx = dag.Write,
+> extends db.Transformer<Tx> {
   private readonly _mappings: Mappings;
 
-  constructor(dagWrite: dag.Write, mappings: Mappings) {
-    super(dagWrite);
+  constructor(tx: Tx, mappings: Mappings) {
+    super(tx);
     this._mappings = mappings;
   }
 
@@ -39,7 +41,7 @@ export class PersistFixupTransformer extends db.Transformer {
     return this._mappings.has(h);
   }
 
-  override async writeChunk<D extends kv.Value>(
+  protected override async writeChunk<D extends kv.Value>(
     oldHash: OldHash,
     data: D,
     getRefs: (data: D) => readonly Hash[],


### PR DESCRIPTION
This does not need a `dag.Read` or `dag.Write`. It only operates on the
gathered chunks in the map from the previous step.

The input is a `Map<TempHash, Chunk<TempHash>>` and the output is the
same logical map but the hashes have been computed based on the chunk
data; `Map<PerHash, Chunk<PerHash>>`

Towards Implement Dueling Dags #671