### PR TITLE
fix: Persist Write Transformer should preserve hashes

### DIFF
--- a/src/db/transformer.test.ts
+++ b/src/db/transformer.test.ts
@@ -10,7 +10,7 @@ import {
 import {Commit} from './commit';
 import type {IndexRecord, Meta} from './commit';
 import {Transformer} from './transformer';
-import {Hash, initHasher, makeNewTempHashFunction} from '../hash';
+import {Hash, initHasher, makeNewFakeHashFunction} from '../hash';
 import {BTreeRead, BTreeWrite, Entry} from '../btree/mod';
 import type {DataNode} from '../btree/node';
 import type {ReadonlyJSONValue} from '../json';
@@ -108,7 +108,7 @@ test('transformIndexRecord - noop', async () => {
 test('transforms data entry', async () => {
   const dagStore = new dag.TestStore(
     undefined,
-    makeNewTempHashFunction(),
+    makeNewFakeHashFunction(),
     () => undefined,
   );
 

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -88,16 +88,21 @@ export async function initHasher(): Promise<unknown> {
 // important because we split B+Tree nodes based on the size and we want the
 // size to be the same independent of whether the hash is temp or not.
 
-export const newTempHash = makeNewTempHashFunction();
+export const newTempHash = makeNewFakeHashFunction();
 
-export function makeNewTempHashFunction(tempPrefix = 't/'): () => Hash {
+/**
+ * Creates a new fake hash function.
+ * @param prefix The prefix of the hash. If left out the prefix is 't/' which
+ * signifies a temp hash.
+ */
+export function makeNewFakeHashFunction(hashPrefix = 't/'): () => Hash {
   let tempHashCounter = 0;
   return () => {
     // Must not overlap with hashOf results
-    return (tempPrefix +
+    return (hashPrefix +
       (tempHashCounter++)
         .toString()
-        .padStart(STRING_LENGTH - tempPrefix.length, '0')) as unknown as Hash;
+        .padStart(STRING_LENGTH - hashPrefix.length, '0')) as unknown as Hash;
   };
 }
 

--- a/src/persist/compute-hash-transformer.test.ts
+++ b/src/persist/compute-hash-transformer.test.ts
@@ -5,7 +5,7 @@ import * as utf8 from '../utf8';
 import {
   BYTE_LENGTH,
   Hash,
-  makeNewTempHashFunction,
+  makeNewFakeHashFunction,
   parse as parseHash,
 } from '../hash';
 import {BTreeWrite} from '../btree/write';
@@ -16,7 +16,7 @@ import type {ReadonlyJSONValue} from '../json';
 test('fix hashes up of a single snapshot commit with empty btree', async () => {
   const memdag = new dag.TestStore(
     undefined,
-    makeNewTempHashFunction('t/aaa'),
+    makeNewFakeHashFunction('t/aaa'),
     () => undefined,
   );
 

--- a/src/persist/fixup-transformer.test.ts
+++ b/src/persist/fixup-transformer.test.ts
@@ -4,7 +4,7 @@ import * as db from '../db/mod';
 import {
   fakeHash,
   initHasher,
-  makeNewTempHashFunction,
+  makeNewFakeHashFunction,
   parse as parseHash,
 } from '../hash';
 import {BTreeWrite} from '../btree/write';
@@ -18,7 +18,7 @@ setup(async () => {
 test('fixup of a single snapshot commit with empty btree', async () => {
   const memdag = new dag.TestStore(
     undefined,
-    makeNewTempHashFunction(),
+    makeNewFakeHashFunction(),
     () => undefined,
   );
 
@@ -201,7 +201,7 @@ test('fixup of a single snapshot commit with empty btree', async () => {
 test('fixup base snapshot when there is a local commit on top of it', async () => {
   const memdag = new dag.TestStore(
     undefined,
-    makeNewTempHashFunction(),
+    makeNewFakeHashFunction(),
     () => undefined,
   );
 
@@ -352,7 +352,7 @@ async function makeBTree(
 test('fixup of a single snapshot commit with a btree with internal nodes', async () => {
   const memdag = new dag.TestStore(
     undefined,
-    makeNewTempHashFunction(),
+    makeNewFakeHashFunction(),
     () => undefined,
   );
 
@@ -509,7 +509,7 @@ test('fixup of a single snapshot commit with a btree with internal nodes', async
 test('fixup of a base snapshot with an index', async () => {
   const memdag = new dag.TestStore(
     undefined,
-    makeNewTempHashFunction(),
+    makeNewFakeHashFunction(),
     () => undefined,
   );
 

--- a/src/persist/gather-visitor.test.ts
+++ b/src/persist/gather-visitor.test.ts
@@ -1,6 +1,6 @@
 import {expect} from '@esm-bundle/chai';
 import * as dag from '../dag/mod';
-import {initHasher, makeNewTempHashFunction, newTempHash} from '../hash';
+import {initHasher, makeNewFakeHashFunction, newTempHash} from '../hash';
 import {
   addGenesis,
   addIndexChange,
@@ -92,7 +92,7 @@ test('dag with some permanent hashes and some temp hashes on top', async () => {
 
   const memdag = new dag.TestStore(
     kvStore,
-    makeNewTempHashFunction(),
+    makeNewFakeHashFunction(),
     () => void 0,
   );
 

--- a/src/persist/write-transformer.ts
+++ b/src/persist/write-transformer.ts
@@ -1,9 +1,13 @@
 import * as db from '../db/mod';
-import type * as dag from '../dag/mod';
+import * as dag from '../dag/mod';
 import type {Hash} from '../hash';
 import {assert} from '../asserts';
+import type {Value} from '../kv/store';
 
 export type GatheredChunks = ReadonlyMap<Hash, dag.Chunk>;
+
+type OldHash = Hash;
+type NewHash = Hash;
 
 /**
  * This transformer is used to persist chunks coming from a source dag (aka
@@ -24,16 +28,16 @@ export class WriteTransformer<Tx = dag.Write> extends db.Transformer<Tx> {
     this._gatheredChunks = gatheredChunks;
   }
 
-  override shouldSkip(hash: Hash): boolean {
+  override shouldSkip(oldhash: Hash): boolean {
     // Skip all chunks that we did not get from the source.
-    return !this._gatheredChunks.has(hash);
+    return !this._gatheredChunks.has(oldhash);
   }
 
-  protected override shouldForceWrite(h: Hash): boolean {
+  protected override shouldForceWrite(oldHash: Hash): boolean {
     // We want to write the chunk to the destination dag even if the chunk did
     // not change because the computed hash on the source is different than the
     // one computed on the destination.
-    return this._gatheredChunks.has(h);
+    return this._gatheredChunks.has(oldHash);
   }
 
   protected override async getChunk(
@@ -43,5 +47,21 @@ export class WriteTransformer<Tx = dag.Write> extends db.Transformer<Tx> {
     // We cannot get here is we did not gather a chunk for this hash.
     assert(gatheredChunk !== undefined);
     return gatheredChunk;
+  }
+
+  protected override async writeChunk<D extends Value>(
+    oldHash: OldHash,
+    newData: D,
+    getRefs: (data: D) => readonly NewHash[],
+  ): Promise<NewHash> {
+    // We want to preserve the chunk hashes here because those were compputed
+    // during an earlier pass.
+    const newChunk = dag.createChunkWithHash(
+      oldHash,
+      newData,
+      getRefs(newData),
+    );
+    await this.dagWrite.putChunk(newChunk);
+    return newChunk.hash;
   }
 }


### PR DESCRIPTION
Now we precompute the hashes of the chunks we are going to write so we
need to preserve the hashes of the chunks passed in.

Towards #671