### PR TITLE
feat: Add top level persist function

### DIFF
--- a/src/dag/test-store.ts
+++ b/src/dag/test-store.ts
@@ -33,6 +33,10 @@ export class TestStore extends Store {
       }
     }
   }
+
+  clear(): void {
+    this.kvStore.clear();
+  }
 }
 
 function toRefs(refs: unknown): Hash[] {

--- a/src/kv/test-mem-store.ts
+++ b/src/kv/test-mem-store.ts
@@ -23,4 +23,8 @@ export class TestMemStore extends MemStore {
   map(): Map<string, Value> {
     return this._map;
   }
+
+  clear(): void {
+    this._map.clear();
+  }
 }

--- a/src/persist/persist.test.ts
+++ b/src/persist/persist.test.ts
@@ -1,0 +1,173 @@
+import {expect} from '@esm-bundle/chai';
+import {SinonFakeTimers, useFakeTimers} from 'sinon';
+import {assert} from '../asserts';
+import type {Node} from '../btree/node';
+import * as dag from '../dag/mod';
+import * as db from '../db/mod';
+import {
+  addGenesis,
+  addIndexChange,
+  addLocal,
+  addSnapshot,
+  Chain,
+} from '../db/test-helpers';
+import {
+  assertHash,
+  assertNotTempHash,
+  Hash,
+  isTempHash,
+  makeNewFakeHashFunction,
+} from '../hash';
+import type {Value} from '../kv/store';
+import type {ClientID} from '../sync/client-id';
+import {getClient} from './clients';
+import {addSyncSnapshot} from '../sync/test-helpers';
+import {persist} from './persist';
+
+let clock: SinonFakeTimers;
+setup(() => {
+  clock = useFakeTimers(123456789);
+});
+
+teardown(() => {
+  clock.restore();
+});
+
+async function assertSameDagData(
+  clientID: ClientID,
+  memdag: dag.TestStore,
+  perdag: dag.TestStore,
+): Promise<void> {
+  const memdagHeadHash = await memdag.withRead(async dagRead => {
+    const headHash = await dagRead.getHead(db.DEFAULT_HEAD_NAME);
+    expect(isTempHash(headHash)).to.be.false;
+    return headHash;
+  });
+  const perdagClientHash = await perdag.withRead(async dagRead => {
+    const client = await getClient(clientID, dagRead);
+    assert(client);
+    return client.headHash;
+  });
+  expect(memdagHeadHash).to.equal(perdagClientHash);
+  assertHash(memdagHeadHash);
+
+  const memSnapshot = await getChunkSnapshot(memdag, memdagHeadHash);
+  const perSnapshot = await getChunkSnapshot(perdag, perdagClientHash);
+
+  expect(memSnapshot).to.deep.equal(perSnapshot);
+}
+
+test('persist pipeline', async () => {
+  const memdag = new dag.TestStore(
+    undefined,
+    makeNewFakeHashFunction('t/memdag'),
+    assertHash,
+  );
+  const perdag = new dag.TestStore(
+    undefined,
+    makeNewFakeHashFunction('perdag'),
+    assertNotTempHash,
+  );
+  const clientID = 'client-id';
+
+  const chain: Chain = [];
+
+  const reset = async () => {
+    memdag.clear();
+    perdag.clear();
+    chain.length = 0;
+    await addGenesis(chain, memdag);
+  };
+
+  const testPersist = async () => {
+    await persist(clientID, memdag, perdag);
+    await assertSameDagData(clientID, memdag, perdag);
+  };
+
+  await reset();
+  await testPersist();
+
+  await reset();
+  await addLocal(chain, memdag);
+  await testPersist();
+
+  await reset();
+  await addSnapshot(chain, memdag, [
+    ['a', 0],
+    ['b', 1],
+    ['c', 2],
+  ]);
+  await testPersist();
+
+  await reset();
+  await addLocal(chain, memdag);
+  await addSyncSnapshot(chain, memdag, 1);
+  await testPersist();
+
+  await reset();
+  await addLocal(chain, memdag);
+  await addLocal(chain, memdag);
+  await testPersist();
+
+  await reset();
+  await addLocal(chain, memdag);
+  await testPersist();
+  await addLocal(chain, memdag);
+  await testPersist();
+
+  await reset();
+  await addLocal(chain, memdag);
+  await addLocal(chain, memdag);
+  await addLocal(chain, memdag);
+  await testPersist();
+
+  await reset();
+  await addLocal(chain, memdag);
+  await addSnapshot(chain, memdag, [['changed', 3]]);
+  await testPersist();
+
+  await reset();
+  await addLocal(chain, memdag);
+  await addSnapshot(chain, memdag, [['changed', 4]]);
+  await addLocal(chain, memdag);
+  await testPersist();
+
+  await reset();
+  await addLocal(chain, memdag);
+  await addSnapshot(chain, memdag, [['changed', 5]]);
+  await addLocal(chain, memdag);
+  await addSyncSnapshot(chain, memdag, 3);
+  await testPersist();
+
+  await reset();
+  await addLocal(chain, memdag);
+  await addIndexChange(chain, memdag);
+  await testPersist();
+});
+
+class ChunkSnapshotVisitor extends db.Visitor {
+  snapshot: Record<string, Value> = {};
+
+  override visitCommitChunk(
+    chunk: dag.Chunk<db.CommitData<db.Meta>>,
+  ): Promise<void> {
+    this.snapshot[chunk.hash.toString()] = chunk.data;
+    return super.visitCommitChunk(chunk);
+  }
+
+  override visitBTreeNodeChunk(chunk: dag.Chunk<Node>): Promise<void> {
+    this.snapshot[chunk.hash.toString()] = chunk.data;
+    return super.visitBTreeNodeChunk(chunk);
+  }
+}
+
+async function getChunkSnapshot(
+  dagStore: dag.Store,
+  hash: Hash,
+): Promise<Record<string, Value>> {
+  return dagStore.withRead(async dagRead => {
+    const v = new ChunkSnapshotVisitor(dagRead);
+    await v.visitCommit(hash);
+    return v.snapshot;
+  });
+}

--- a/src/persist/persist.ts
+++ b/src/persist/persist.ts
@@ -1,0 +1,98 @@
+import {assert} from '../asserts';
+import type * as dag from '../dag/mod';
+import * as db from '../db/mod';
+import * as sync from '../sync/mod';
+import {Hash, nativeHashOf} from '../hash';
+import type {ClientID} from '../sync/client-id';
+import {Client, setClient} from './clients';
+import {ComputeHashTransformer, FixedChunks} from './compute-hash-transformer';
+import {GatherVisitor} from './gather-visitor';
+import {WriteTransformer} from './write-transformer';
+import {FixupTransformer} from './fixup-transformer';
+import type {ReadonlyJSONValue} from '../json';
+
+export async function persist(
+  clientID: ClientID,
+  memdag: dag.Store,
+  perdag: dag.Store,
+): Promise<void> {
+  // 1. Gather all temp chunks from main head on the memdag
+  const [gatheredChunks, mainHeadTempHash] = await gatherTempChunks(memdag);
+
+  // 2. Compute the hashes for these gathered chunks.\
+  const [fixedChunks, mappings, mainHeadHash] = await computeHashes(
+    gatheredChunks,
+    mainHeadTempHash,
+  );
+
+  // 3. write and fixup temp chunks to perdag
+  await writeFixedChunks(perdag, fixedChunks, mainHeadHash, clientID);
+
+  // 4. fixup the memdag with the new hashes
+  await fixupMemdagWithNewHashes(memdag, mappings);
+}
+
+async function gatherTempChunks(
+  memdag: dag.Store,
+): Promise<[ReadonlyMap<Hash, dag.Chunk>, Hash]> {
+  return await memdag.withRead(async dagRead => {
+    const mainHeadHash = await dagRead.getHead(db.DEFAULT_HEAD_NAME);
+    assert(mainHeadHash);
+    const visitor = new GatherVisitor(dagRead);
+    await visitor.visitCommit(mainHeadHash);
+    return [visitor.gatheredChunks, mainHeadHash];
+  });
+}
+
+async function computeHashes(
+  gatheredChunks: ReadonlyMap<Hash, dag.Chunk<ReadonlyJSONValue>>,
+  mainHeadTempHash: Hash,
+): Promise<[FixedChunks, ReadonlyMap<Hash, Hash>, Hash]> {
+  const transformer = new ComputeHashTransformer(gatheredChunks, nativeHashOf);
+  const mainHeadHash = await transformer.transformCommit(mainHeadTempHash);
+  const {fixedChunks, mappings} = transformer;
+  return [fixedChunks, mappings, mainHeadHash];
+}
+
+async function fixupMemdagWithNewHashes(
+  memdag: dag.Store,
+  mappings: ReadonlyMap<Hash, Hash>,
+) {
+  await memdag.withWrite(async dagWrite => {
+    for (const headName of [db.DEFAULT_HEAD_NAME, sync.SYNC_HEAD_NAME]) {
+      const headHash = await dagWrite.getHead(headName);
+      if (!headHash) {
+        if (headName === sync.SYNC_HEAD_NAME) {
+          // It is OK to not have a sync head.
+          break;
+        }
+        throw new Error(`No head found for ${headName}`);
+      }
+      const transformer = new FixupTransformer(dagWrite, mappings);
+      const newHeadHash = await transformer.transformCommit(headHash);
+      await dagWrite.setHead(headName, newHeadHash);
+    }
+    await dagWrite.commit();
+  });
+}
+
+async function writeFixedChunks(
+  perdag: dag.Store,
+  fixedChunks: FixedChunks,
+  mainHeadHash: Hash,
+  clientID: string,
+) {
+  await perdag.withWrite(async dagWrite => {
+    // TODO(arv): Maybe we can just write the chunks blinldy in here now that we fixed the hash?
+    const transformer = new WriteTransformer(dagWrite, fixedChunks);
+    const newMainHeadHash = await transformer.transformCommit(mainHeadHash);
+    assert(newMainHeadHash === mainHeadHash);
+    const client: Client = {
+      heartbeatTimestampMs: Date.now(),
+      headHash: newMainHeadHash,
+    };
+    // We need to set a head here or the chunks will be GC'd
+    await setClient(clientID, client, dagWrite);
+    await dagWrite.commit();
+  });
+}


### PR DESCRIPTION
This combines the different persist steps into a single function.

Towards #671