### PR TITLE
feat: Update Clients Map with retry logic

### DIFF
--- a/src/persist/clients.ts
+++ b/src/persist/clients.ts
@@ -20,7 +20,7 @@ export type Client = {
   /** The hash of the commit this session is currently at. */
   readonly headHash: Hash;
 };
-const CLIENTS_HEAD = 'clients';
+export const CLIENTS_HEAD = 'clients';
 
 function assertClient(value: unknown): asserts value is Client {
   assertObject(value);


### PR DESCRIPTION
For Simplified Dueling Dags we want to allow using an async native hash
function. That means that the hash of a chunk has to be computed
outside the DAG transaction (because of IDB's auto commit bug/feature).

This mostly works well on the perdag because it gets it's chunks from
the memdag using the persist function which allows us to precompute all
the hashes; except for the hash of the clients map.

To not require a sync hash function we instead precompute the hash of
the clients map outside the DAG transaction and then write it in the tx.
However, by doing this there is a small chance that the clients map
changed since we mutated it and computed the hash for it. If it did
change we now retry the update clients function with the new up to date
clients map.

There is one more compication going on here. We need to ensure that the
chunks are garbage collected between the transactions. This is done by
adding a temporary head.

Fixes #735