### PR TITLE
feat!: Include versions in IDB name

### DIFF
--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -83,7 +83,6 @@ async function replicacheForTestingNoDefaultURLs<MD extends MutatorDefs = {}>(
     ...rest
   }: ReplicacheOptions<MD> = {},
 ): Promise<ReplicacheTest<MD>> {
-  dbsToDrop.add(name);
   const rep = new ReplicacheTest<MD>({
     pullURL,
     pushDelay,
@@ -92,6 +91,7 @@ async function replicacheForTestingNoDefaultURLs<MD extends MutatorDefs = {}>(
     useMemstore,
     ...rest,
   });
+  dbsToDrop.add(rep.idbName);
   reps.add(rep);
   // Wait for open to be done.
   await rep.clientID;
@@ -955,8 +955,8 @@ testWithBothStores('name', async () => {
   await repA.close();
   await repB.close();
 
-  indexedDB.deleteDatabase('a');
-  indexedDB.deleteDatabase('b');
+  indexedDB.deleteDatabase(repA.idbName);
+  indexedDB.deleteDatabase(repB.idbName);
 });
 
 testWithBothStores('register with error', async () => {

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -49,6 +49,8 @@ export type Poke = {
 
 export const httpStatusUnauthorized = 401;
 
+const REPLICACHE_FORMAT_VERSION = 3;
+
 export type MaybePromise<T> = T | Promise<T>;
 
 type ToPromise<P> = P extends Promise<unknown> ? P : Promise<P>;
@@ -137,6 +139,15 @@ export class Replicache<MD extends MutatorDefs = {}> {
 
   /** The name of the Replicache database. */
   readonly name: string;
+
+  /**
+   * This is the name Replicache uses for the IndexedDB database where data is
+   * stored.
+   */
+  get idbName(): string {
+    const n = `${this.name}:${REPLICACHE_FORMAT_VERSION}`;
+    return this.schemaVersion ? `${n}:${this.schemaVersion}` : n;
+  }
 
   private readonly _useMemstore: boolean;
 
@@ -288,7 +299,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
     this.pusher = pusher;
     this._kvStore =
       experimentalKVStore ||
-      (this._useMemstore ? new MemStore() : new IDBStore(this.name));
+      (this._useMemstore ? new MemStore() : new IDBStore(this.idbName));
     this._dagStore = new dag.Store(
       this._kvStore,
       dag.defaultChunkHasher,


### PR DESCRIPTION
For Simplified Dueling Dags we need to ensure that different tabs
running different versions of Replicache do not interact with IDB data
it does not know how to read/write.

To achieve this the name if the IDB database now contains the
`REPLICACHE_FORMAT_VERSION` (which is currently at `3`).

The IDB name also contains the `schemaVersion` som if the schema changes
a fresh IDB database is used. The motivation is the same. Multiple tabs
with different schemaVersions should not interact with the same IDB
database.

BREAKING CHANGE

Towards #671