### PR TITLE
refactor: Use abstract db transformer

### DIFF
--- a/src/db/mod.ts
+++ b/src/db/mod.ts
@@ -22,7 +22,7 @@ export {
 export {getRoot} from './root';
 export {decodeIndexKey, encodeIndexKey} from './index';
 export {Visitor} from './visitor';
-export {Transformer} from './transformer';
+export {BaseTransformer, Transformer} from './transformer';
 
 export type {LocalMeta, IndexRecord, CommitData, Meta} from './commit';
 export type {ScanOptions} from './scan';

--- a/src/persist/compute-hash-transformer.ts
+++ b/src/persist/compute-hash-transformer.ts
@@ -11,7 +11,7 @@ export type FixedChunks = ReadonlyMap<Hash, dag.Chunk>;
 /**
  * This transformer computes the hashes
  */
-export class ComputeHashTransformer extends db.Transformer<null> {
+export class ComputeHashTransformer extends db.BaseTransformer {
   private readonly _fixedChunks: Map<Hash, dag.Chunk> = new Map();
   private readonly _gatheredChunks: GatheredChunks;
   private readonly _hashFunc: (value: Value) => MaybePromise<Hash>;
@@ -25,7 +25,7 @@ export class ComputeHashTransformer extends db.Transformer<null> {
     gatheredChunks: GatheredChunks,
     hashFunc: (value: Value) => MaybePromise<Hash>,
   ) {
-    super(null);
+    super();
     this._gatheredChunks = gatheredChunks;
     this._hashFunc = hashFunc;
   }
@@ -50,7 +50,7 @@ export class ComputeHashTransformer extends db.Transformer<null> {
     hash: Hash,
   ): Promise<dag.Chunk | undefined> {
     const gatheredChunk = this._gatheredChunks.get(hash);
-    // We cannot get here is we did not gather a chunk for this hash.
+    // We cannot get here if we did not gather a chunk for this hash.
     assert(gatheredChunk !== undefined);
     return gatheredChunk;
   }

--- a/src/persist/fixup-transformer.ts
+++ b/src/persist/fixup-transformer.ts
@@ -16,11 +16,11 @@ type Mappings = ReadonlyMap<OldHash, NewHash>;
  * perdag in our case) and rewrite the required chunks in the destination dag
  * (the memdag).
  */
-export class FixupTransformer<Tx = dag.Write> extends db.Transformer<Tx> {
+export class FixupTransformer extends db.Transformer {
   private readonly _mappings: Mappings;
 
-  constructor(tx: Tx, mappings: Mappings) {
-    super(tx);
+  constructor(dagWrite: dag.Write, mappings: Mappings) {
+    super(dagWrite);
     this._mappings = mappings;
   }
 


### PR DESCRIPTION
The old code was pretty silly and used runtime type checks. Now we use
an abstract base class and static type checking.