### PR TITLE
chore: Add test for persist sync head

### DIFF
--- a/src/db/mod.ts
+++ b/src/db/mod.ts
@@ -18,12 +18,25 @@ export {
   newLocal,
   newSnapshot,
   assertCommitData,
+  fromHash as commitFromHash,
+  fromHead as commitFromHead,
+  localMutations,
+  snapshotMetaParts,
+  baseSnapshot,
+  chain as commitChain,
 } from './commit';
 export {getRoot} from './root';
 export {decodeIndexKey, encodeIndexKey} from './index';
 export {Visitor} from './visitor';
 export {BaseTransformer, Transformer} from './transformer';
 
-export type {LocalMeta, IndexRecord, CommitData, Meta} from './commit';
+export type {
+  SnapshotMeta,
+  LocalMeta,
+  IndexChangeMeta,
+  IndexRecord,
+  CommitData,
+  Meta,
+} from './commit';
 export type {ScanOptions} from './scan';
 export type {Whence} from './read';

--- a/src/db/read.ts
+++ b/src/db/read.ts
@@ -1,7 +1,12 @@
 import {IndexRead} from './index';
 import * as dag from '../dag/mod';
 import {convert, scan, ScanOptions, ScanOptionsInternal} from './scan';
-import {Commit, DEFAULT_HEAD_NAME, Meta} from './commit';
+import {
+  Commit,
+  DEFAULT_HEAD_NAME,
+  fromHash as commitFromHash,
+  Meta,
+} from './commit';
 import type {ReadonlyJSONValue} from '../json';
 import {BTreeRead, BTreeWrite, Entry} from '../btree/mod';
 import type {Hash} from '../hash';
@@ -147,7 +152,7 @@ export async function readCommit(
     }
   }
 
-  const commit = await Commit.fromHash(hash, dagRead);
+  const commit = await commitFromHash(hash, dagRead);
   const map =
     dagRead instanceof dag.Write
       ? new BTreeWrite(dagRead, commit.valueHash)

--- a/src/db/transformer.test.ts
+++ b/src/db/transformer.test.ts
@@ -7,7 +7,7 @@ import {
   addSnapshot,
   Chain,
 } from './test-helpers';
-import {Commit} from './commit';
+import {Commit, fromHash as commitFromHash} from './commit';
 import type {IndexRecord, Meta} from './commit';
 import {Transformer} from './transformer';
 import {Hash, initHasher, makeNewFakeHashFunction} from '../hash';
@@ -148,7 +148,7 @@ test('transforms data entry', async () => {
   await dagStore.withRead(async read => {
     const headHash = await read.getHead('test');
     assert(headHash);
-    const commit = await Commit.fromHash(headHash, read);
+    const commit = await commitFromHash(headHash, read);
     const map = new BTreeRead(read, commit.valueHash);
     expect(await map.get('k')).to.equal('k - Changed!');
   });

--- a/src/persist/clients.ts
+++ b/src/persist/clients.ts
@@ -1,11 +1,12 @@
 import {assertHash, Hash} from '../hash';
 import type * as dag from '../dag/mod';
+import * as db from '../db/mod';
 import type {ReadonlyJSONValue} from '../json';
 import {assertNumber, assertObject} from '../asserts';
 import {hasOwn} from '../has-own';
 import type {ClientID} from '../sync/client-id';
 import {uuid as makeUuid} from '../sync/uuid';
-import {Commit, newSnapshot} from '../db/commit';
+import {newSnapshot} from '../db/commit';
 import {BTreeWrite} from '../btree/write';
 
 type ClientMap = Map<ClientID, Client>;
@@ -113,7 +114,7 @@ export async function initClient(
 
   let newClientCommit;
   if (bootstrapClient) {
-    const bootstrapCommit = await Commit.baseSnapshot(
+    const bootstrapCommit = await db.baseSnapshot(
       bootstrapClient.headHash,
       dagWrite,
     );

--- a/src/persist/persist.test.ts
+++ b/src/persist/persist.test.ts
@@ -3,6 +3,7 @@ import {SinonFakeTimers, useFakeTimers} from 'sinon';
 import {assert} from '../asserts';
 import type {Node} from '../btree/node';
 import * as dag from '../dag/mod';
+import * as sync from '../sync/mod';
 import * as db from '../db/mod';
 import {
   addGenesis,
@@ -163,11 +164,42 @@ suite('persist on top of different kinds of commits', () => {
     await addLocal(chain, memdag);
   });
 
-  test('local + snapshot + local + syncSnapshot', async () => {
+  test.only('local + snapshot + local + syncSnapshot', async () => {
     await addLocal(chain, memdag);
     await addSnapshot(chain, memdag, [['changed', 5]]);
     await addLocal(chain, memdag);
     await addSyncSnapshot(chain, memdag, 3);
+
+    const syncHeadCommitBefore = await memdag.withRead(async dagRead => {
+      const h = await dagRead.getHead(sync.SYNC_HEAD_NAME);
+      assert(h);
+      return db.commitFromHash(h, dagRead);
+    });
+
+    expect(
+      isTempHash(
+        (syncHeadCommitBefore.chunk.data as db.CommitData<db.SnapshotMeta>)
+          .valueHash,
+      ),
+    ).to.be.true;
+    await testPersist();
+
+    const syncHeadCommitAfter = await memdag.withRead(async dagRead => {
+      const h = await dagRead.getHead(sync.SYNC_HEAD_NAME);
+      assert(h);
+      return db.commitFromHash(h, dagRead);
+    });
+
+    expect(syncHeadCommitBefore.chunk.hash).to.not.equal(
+      syncHeadCommitAfter.chunk.hash,
+    );
+
+    expect(
+      isTempHash(
+        (syncHeadCommitAfter.chunk.data as db.CommitData<db.SnapshotMeta>)
+          .valueHash,
+      ),
+    ).to.be.false;
   });
 
   test('local + indexChange', async () => {

--- a/src/sync/pull.test.ts
+++ b/src/sync/pull.test.ts
@@ -50,7 +50,7 @@ test('begin try pull', async () => {
   await addIndexChange(chain, store);
   const startingNumCommits = chain.length;
   const baseSnapshot = chain[1];
-  const [baseLastMutationID, baseCookie] = Commit.snapshotMetaParts(
+  const [baseLastMutationID, baseCookie] = db.snapshotMetaParts(
     baseSnapshot as Commit<SnapshotMeta>,
   );
   const baseValueMap = new Map([['foo', '"bar"']]);
@@ -460,7 +460,7 @@ test('begin try pull', async () => {
         const chunk = await read.getChunk(syncHeadHash);
         assertNotUndefined(chunk);
         const syncHead = db.fromChunk(chunk);
-        const [gotLastMutationID, gotCookie] = Commit.snapshotMetaParts(
+        const [gotLastMutationID, gotCookie] = db.snapshotMetaParts(
           syncHead as Commit<SnapshotMeta>,
         );
         expect(expSyncHead.lastMutationID).to.equal(gotLastMutationID);
@@ -765,7 +765,7 @@ test('changed keys', async () => {
     await addSnapshot(chain, store, entries);
 
     const baseSnapshot = chain[chain.length - 1];
-    const [baseLastMutationID, baseCookie] = Commit.snapshotMetaParts(
+    const [baseLastMutationID, baseCookie] = db.snapshotMetaParts(
       baseSnapshot as Commit<SnapshotMeta>,
     );
 

--- a/src/sync/push.ts
+++ b/src/sync/push.ts
@@ -57,7 +57,7 @@ export async function push(
     if (!mainHeadHash) {
       throw new Error('Internal no main head');
     }
-    return await db.Commit.localMutations(mainHeadHash, dagRead);
+    return await db.localMutations(mainHeadHash, dagRead);
     // Important! Don't hold the lock through an HTTP request!
   });
   // Commit.pending gave us commits in head-first order; the bindings


### PR DESCRIPTION
Test that the sync head gets rewritten during persist.

Also, refactored the static Commit methods. statics are generally a bad
idea in JS because tree shaking is having trouble removing dead code.
The only valid use case is for "virtual dispatch" of static methods.