### PR TITLE
refactor: Make commit statics module functions

### DIFF
--- a/src/db/mod.ts
+++ b/src/db/mod.ts
@@ -18,12 +18,25 @@ export {
   newLocal,
   newSnapshot,
   assertCommitData,
+  fromHash as commitFromHash,
+  fromHead as commitFromHead,
+  localMutations,
+  snapshotMetaParts,
+  baseSnapshot,
+  chain as commitChain,
 } from './commit';
 export {getRoot} from './root';
 export {decodeIndexKey, encodeIndexKey} from './index';
 export {Visitor} from './visitor';
 export {BaseTransformer, Transformer} from './transformer';
 
-export type {LocalMeta, IndexRecord, CommitData, Meta} from './commit';
+export type {
+  SnapshotMeta,
+  LocalMeta,
+  IndexChangeMeta,
+  IndexRecord,
+  CommitData,
+  Meta,
+} from './commit';
 export type {ScanOptions} from './scan';
 export type {Whence} from './read';

--- a/src/db/read.ts
+++ b/src/db/read.ts
@@ -1,7 +1,12 @@
 import {IndexRead} from './index';
 import * as dag from '../dag/mod';
 import {convert, scan, ScanOptions, ScanOptionsInternal} from './scan';
-import {Commit, DEFAULT_HEAD_NAME, Meta} from './commit';
+import {
+  Commit,
+  DEFAULT_HEAD_NAME,
+  fromHash as commitFromHash,
+  Meta,
+} from './commit';
 import type {ReadonlyJSONValue} from '../json';
 import {BTreeRead, BTreeWrite, Entry} from '../btree/mod';
 import type {Hash} from '../hash';
@@ -147,7 +152,7 @@ export async function readCommit(
     }
   }
 
-  const commit = await Commit.fromHash(hash, dagRead);
+  const commit = await commitFromHash(hash, dagRead);
   const map =
     dagRead instanceof dag.Write
       ? new BTreeWrite(dagRead, commit.valueHash)

--- a/src/db/transformer.test.ts
+++ b/src/db/transformer.test.ts
@@ -7,7 +7,7 @@ import {
   addSnapshot,
   Chain,
 } from './test-helpers';
-import {Commit} from './commit';
+import {Commit, fromHash as commitFromHash} from './commit';
 import type {IndexRecord, Meta} from './commit';
 import {Transformer} from './transformer';
 import {Hash, initHasher, makeNewFakeHashFunction} from '../hash';
@@ -148,7 +148,7 @@ test('transforms data entry', async () => {
   await dagStore.withRead(async read => {
     const headHash = await read.getHead('test');
     assert(headHash);
-    const commit = await Commit.fromHash(headHash, read);
+    const commit = await commitFromHash(headHash, read);
     const map = new BTreeRead(read, commit.valueHash);
     expect(await map.get('k')).to.equal('k - Changed!');
   });

--- a/src/persist/clients.ts
+++ b/src/persist/clients.ts
@@ -1,11 +1,12 @@
 import {assertHash, Hash} from '../hash';
 import type * as dag from '../dag/mod';
+import * as db from '../db/mod';
 import type {ReadonlyJSONValue} from '../json';
 import {assertNumber, assertObject} from '../asserts';
 import {hasOwn} from '../has-own';
 import type {ClientID} from '../sync/client-id';
 import {uuid as makeUuid} from '../sync/uuid';
-import {Commit, newSnapshot} from '../db/commit';
+import {newSnapshot} from '../db/commit';
 import {BTreeWrite} from '../btree/write';
 
 type ClientMap = Map<ClientID, Client>;
@@ -113,7 +114,7 @@ export async function initClient(
 
   let newClientCommit;
   if (bootstrapClient) {
-    const bootstrapCommit = await Commit.baseSnapshot(
+    const bootstrapCommit = await db.baseSnapshot(
       bootstrapClient.headHash,
       dagWrite,
     );

--- a/src/sync/pull.test.ts
+++ b/src/sync/pull.test.ts
@@ -50,7 +50,7 @@ test('begin try pull', async () => {
   await addIndexChange(chain, store);
   const startingNumCommits = chain.length;
   const baseSnapshot = chain[1];
-  const [baseLastMutationID, baseCookie] = Commit.snapshotMetaParts(
+  const [baseLastMutationID, baseCookie] = db.snapshotMetaParts(
     baseSnapshot as Commit<SnapshotMeta>,
   );
   const baseValueMap = new Map([['foo', '"bar"']]);
@@ -460,7 +460,7 @@ test('begin try pull', async () => {
         const chunk = await read.getChunk(syncHeadHash);
         assertNotUndefined(chunk);
         const syncHead = db.fromChunk(chunk);
-        const [gotLastMutationID, gotCookie] = Commit.snapshotMetaParts(
+        const [gotLastMutationID, gotCookie] = db.snapshotMetaParts(
           syncHead as Commit<SnapshotMeta>,
         );
         expect(expSyncHead.lastMutationID).to.equal(gotLastMutationID);
@@ -765,7 +765,7 @@ test('changed keys', async () => {
     await addSnapshot(chain, store, entries);
 
     const baseSnapshot = chain[chain.length - 1];
-    const [baseLastMutationID, baseCookie] = Commit.snapshotMetaParts(
+    const [baseLastMutationID, baseCookie] = db.snapshotMetaParts(
       baseSnapshot as Commit<SnapshotMeta>,
     );
 

--- a/src/sync/push.ts
+++ b/src/sync/push.ts
@@ -57,7 +57,7 @@ export async function push(
     if (!mainHeadHash) {
       throw new Error('Internal no main head');
     }
-    return await db.Commit.localMutations(mainHeadHash, dagRead);
+    return await db.localMutations(mainHeadHash, dagRead);
     // Important! Don't hold the lock through an HTTP request!
   });
   // Commit.pending gave us commits in head-first order; the bindings


### PR DESCRIPTION
Static methods are generally an anti-pattern in JS. They are sometimes
nice from an API perspective, but tree shaking generally has problems
with them.

The only real valid use case I can think of is when you need to inherit
static methods. In other words when your statics references `this`.