### PR TITLE
feat: Move all client map updating to retrying updateClients pattern that enables using async native hashing outside of perdag transaction 

### DIFF
--- a/src/btree/mod.ts
+++ b/src/btree/mod.ts
@@ -2,5 +2,5 @@ export {BTreeRead} from './read';
 export {BTreeWrite} from './write';
 export {changedKeys} from './changed-keys';
 export {assertBTreeNode} from './node';
-export {getRefs} from './node';
+export {getRefs, emptyDataNode} from './node';
 export type {Entry, Node, InternalNode, DataNode} from './node';

--- a/src/dag/chunk.ts
+++ b/src/dag/chunk.ts
@@ -1,5 +1,5 @@
 import {assertString} from '../asserts';
-import {Hash, hashOf} from '../hash';
+import {Hash, hashOf, nativeHashOf} from '../hash';
 import type {Value} from '../kv/store';
 
 type Refs = readonly Hash[];
@@ -50,6 +50,14 @@ export function createChunkWithHash<V extends Value>(
   refs: Refs,
 ): Chunk<V> {
   return new ChunkImpl(hash, data, refs);
+}
+
+export async function createChunkWithNativeHash<V extends Value>(
+  data: V,
+  refs: Refs,
+): Promise<Chunk<V>> {
+  const hash = await nativeHashOf(data);
+  return createChunkWithHash(hash, data, refs);
 }
 
 export type CreateChunk = <V extends Value>(data: V, refs: Refs) => Chunk<V>;

--- a/src/dag/mod.ts
+++ b/src/dag/mod.ts
@@ -1,7 +1,12 @@
 export {Read, metaFromFlatbuffer, metaToFlatbuffer} from './read';
 export {Write, fromLittleEndian, toLittleEndian} from './write';
 export type {Chunk, CreateChunk} from './chunk';
-export {createChunk, defaultChunkHasher, createChunkWithHash, createChunkWithNativeHash} from './chunk';
+export {
+  createChunk,
+  defaultChunkHasher,
+  createChunkWithHash,
+  createChunkWithNativeHash,
+} from './chunk';
 export {Store} from './store';
 export {TestStore} from './test-store';
 export * from './key';

--- a/src/dag/mod.ts
+++ b/src/dag/mod.ts
@@ -1,7 +1,7 @@
 export {Read, metaFromFlatbuffer, metaToFlatbuffer} from './read';
 export {Write, fromLittleEndian, toLittleEndian} from './write';
 export type {Chunk, CreateChunk} from './chunk';
-export {createChunk, defaultChunkHasher, createChunkWithHash} from './chunk';
+export {createChunk, defaultChunkHasher, createChunkWithHash, createChunkWithNativeHash} from './chunk';
 export {Store} from './store';
 export {TestStore} from './test-store';
 export * from './key';

--- a/src/db/commit.ts
+++ b/src/db/commit.ts
@@ -300,13 +300,32 @@ export function newSnapshot(
   valueHash: Hash,
   indexes: readonly IndexRecord[],
 ): Commit<SnapshotMeta> {
+  return commitFromCommitData(
+    createChunk,
+    newSnapshotCommitData(
+      basisHash,
+      lastMutationID,
+      cookieJSON,
+      valueHash,
+      indexes,
+    ),
+  );
+}
+
+export function newSnapshotCommitData(
+  basisHash: Hash | null,
+  lastMutationID: number,
+  cookieJSON: ReadonlyJSONValue,
+  valueHash: Hash,
+  indexes: readonly IndexRecord[],
+): CommitData<SnapshotMeta> {
   const meta: SnapshotMeta = {
     type: MetaTyped.Snapshot,
     basisHash,
     lastMutationID,
     cookieJSON,
   };
-  return commitFromCommitData(createChunk, {meta, valueHash, indexes});
+  return {meta, valueHash, indexes};
 }
 
 export function newIndexChange(

--- a/src/persist/client-gc.ts
+++ b/src/persist/client-gc.ts
@@ -5,9 +5,9 @@ import {ClientMap, noUpdates, updateClients} from './clients';
 const CLIENT_MAX_INACTIVE_IN_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const GC_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
-let _latestGCUpdate: Promise<ClientMap> | undefined;
+let latestGCUpdate: Promise<ClientMap> | undefined;
 export function getLatestGCUpdate(): Promise<ClientMap> | undefined {
-  return _latestGCUpdate;
+  return latestGCUpdate;
 }
 
 export function initClientGC(
@@ -15,7 +15,7 @@ export function initClientGC(
   dagStore: dag.Store,
 ): () => void {
   const intervalID = window.setInterval(() => {
-    _latestGCUpdate = updateClients(clients => {
+    latestGCUpdate = updateClients(clients => {
       const now = Date.now();
       const clientsAfterGC = Array.from(clients).filter(
         ([id, client]) =>

--- a/src/persist/client-gc.ts
+++ b/src/persist/client-gc.ts
@@ -18,11 +18,11 @@ export function initClientGC(
           now - client.heartbeatTimestampMs <= CLIENT_MAX_INACTIVE_IN_MS,
       );
       if (clientsAfterGC.length === clients.size) {
-        return Promise.resolve(noUpdates);
+        return noUpdates;
       }
-      return Promise.resolve({
+      return {
         clients: new Map(clientsAfterGC),
-      });
+      };
     }, dagStore);
   }, GC_INTERVAL_MS);
 

--- a/src/persist/client-gc.ts
+++ b/src/persist/client-gc.ts
@@ -1,16 +1,21 @@
 import type {ClientID} from '../sync/client-id';
 import type * as dag from '../dag/mod';
-import {noUpdates, updateClients} from './clients';
+import {ClientMap, noUpdates, updateClients} from './clients';
 
 const CLIENT_MAX_INACTIVE_IN_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const GC_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+let _latestGCUpdate: Promise<ClientMap> | undefined;
+export function getLatestGCUpdate(): Promise<ClientMap> | undefined {
+  return _latestGCUpdate;
+}
 
 export function initClientGC(
   clientID: ClientID,
   dagStore: dag.Store,
 ): () => void {
-  const intervalID = window.setInterval(async () => {
-    await updateClients(clients => {
+  const intervalID = window.setInterval(() => {
+    _latestGCUpdate = updateClients(clients => {
       const now = Date.now();
       const clientsAfterGC = Array.from(clients).filter(
         ([id, client]) =>
@@ -25,7 +30,6 @@ export function initClientGC(
       };
     }, dagStore);
   }, GC_INTERVAL_MS);
-
   return () => {
     window.clearInterval(intervalID);
   };

--- a/src/persist/clients-test-helpers.ts
+++ b/src/persist/clients-test-helpers.ts
@@ -1,0 +1,13 @@
+import {ClientMap, updateClients} from './clients';
+import type * as dag from '../dag/mod';
+
+export function setClients(
+  clients: ClientMap,
+  dagStore: dag.Store,
+): Promise<ClientMap> {
+  return updateClients(_ => {
+    return Promise.resolve({
+      clients,
+    });
+  }, dagStore);
+}

--- a/src/persist/clients.ts
+++ b/src/persist/clients.ts
@@ -67,7 +67,10 @@ export async function getClients(dagRead: dag.Read): Promise<ClientMap> {
   return getClientsAtHash(hash, dagRead);
 }
 
-async function getClientsAtHash(hash: Hash | undefined, dagRead: dag.Read): Promise<ClientMap> {
+async function getClientsAtHash(
+  hash: Hash | undefined,
+  dagRead: dag.Read,
+): Promise<ClientMap> {
   if (!hash) {
     return new Map();
   }

--- a/src/persist/clients.ts
+++ b/src/persist/clients.ts
@@ -198,6 +198,7 @@ async function updateClientsInternal(
   const result = await dagStore.withWrite(async dagWrite => {
     const currClientsHash = await dagWrite.getHead(CLIENTS_HEAD);
     if (currClientsHash !== clientsHash) {
+      // Conflict!  Someone else updated the ClientsMap.  Retry update.
       return {
         updateApplied: false,
         clients: await getClientsAtHash(currClientsHash, dagWrite),

--- a/src/persist/clients.ts
+++ b/src/persist/clients.ts
@@ -8,7 +8,7 @@ import {hasOwn} from '../has-own';
 import type {ClientID} from '../sync/client-id';
 import {uuid as makeUuid} from '../sync/uuid';
 import {getRefs, newSnapshotCommitData} from '../db/commit';
-//import {BTreeWrite} from '../btree/write';
+import type { MaybePromise } from '../mod';
 
 export type ClientMap = ReadonlyMap<ClientID, Client>;
 
@@ -161,7 +161,7 @@ export type NoUpdates = typeof noUpdates;
 
 export type ClientsUpdate = (
   clients: ClientMap,
-) => Promise<
+) => MaybePromise<
   {clients: ClientMap; chunksToPut?: Iterable<dag.Chunk>} | NoUpdates
 >;
 
@@ -232,6 +232,6 @@ async function updateClientsInternal(
   if (result.updateApplied) {
     return result.clients;
   } else {
-    return _updateClients(update, result.clients, result.clientsHash, dagStore);
+    return updateClientsInternal(update, result.clients, result.clientsHash, dagStore);
   }
 }

--- a/src/persist/clients.ts
+++ b/src/persist/clients.ts
@@ -95,7 +95,7 @@ export async function initClient(
     }
 
     let newClientCommitData;
-    const chunksToPut = []; 
+    const chunksToPut = [];
     if (bootstrapClient) {
       const constBootstrapClient = bootstrapClient;
       newClientCommitData = await dagStore.withRead(async dagRead => {
@@ -114,7 +114,6 @@ export async function initClient(
           bootstrapCommit.valueHash,
           bootstrapCommit.indexes,
         );
-
       });
     } else {
       // No existing snapshot to bootstrap from. Create empty snapshot.

--- a/src/persist/clients.ts
+++ b/src/persist/clients.ts
@@ -8,7 +8,7 @@ import {hasOwn} from '../has-own';
 import type {ClientID} from '../sync/client-id';
 import {uuid as makeUuid} from '../sync/uuid';
 import {getRefs, newSnapshotCommitData} from '../db/commit';
-import type { MaybePromise } from '../mod';
+import type {MaybePromise} from '../mod';
 
 export type ClientMap = ReadonlyMap<ClientID, Client>;
 
@@ -232,6 +232,11 @@ async function updateClientsInternal(
   if (result.updateApplied) {
     return result.clients;
   } else {
-    return updateClientsInternal(update, result.clients, result.clientsHash, dagStore);
+    return updateClientsInternal(
+      update,
+      result.clients,
+      result.clientsHash,
+      dagStore,
+    );
   }
 }

--- a/src/persist/clients.ts
+++ b/src/persist/clients.ts
@@ -174,10 +174,10 @@ export async function updateClients(
     const clientsHead = await dagRead.getHead(CLIENTS_HEAD);
     return [clients, clientsHead];
   });
-  return _updateClients(update, clients, clientsHash, dagStore);
+  return updateClientsInternal(update, clients, clientsHash, dagStore);
 }
 
-export async function _updateClients(
+async function updateClientsInternal(
   update: ClientsUpdate,
   clients: ClientMap,
   clientsHash: Hash | undefined,

--- a/src/persist/heartbeat.ts
+++ b/src/persist/heartbeat.ts
@@ -4,9 +4,9 @@ import {ClientMap, noUpdates, updateClients} from './clients';
 
 const HEARTBEAT_INTERVAL_MS = 60 * 1000;
 
-let _latestHeartbeatUpdate: Promise<ClientMap> | undefined;
+let latestHeartbeatUpdate: Promise<ClientMap> | undefined;
 export function getLatestHeartbeatUpdate(): Promise<ClientMap> | undefined {
-  return _latestHeartbeatUpdate;
+  return latestHeartbeatUpdate;
 }
 
 export function startHeartbeats(
@@ -14,7 +14,7 @@ export function startHeartbeats(
   dagStore: dag.Store,
 ): () => void {
   const intervalID = window.setInterval(() => {
-    _latestHeartbeatUpdate = writeHeartbeat(clientID, dagStore);
+    latestHeartbeatUpdate = writeHeartbeat(clientID, dagStore);
   }, HEARTBEAT_INTERVAL_MS);
   return () => {
     window.clearInterval(intervalID);

--- a/src/persist/heartbeat.ts
+++ b/src/persist/heartbeat.ts
@@ -23,14 +23,14 @@ export async function writeHeartbeat(
   const updatedClients = await updateClients(clients => {
     const client = clients.get(clientID);
     if (!client) {
-      return Promise.resolve(noUpdates);
+      return noUpdates;
     }
-    return Promise.resolve({
+    return {
       clients: new Map(clients).set(clientID, {
         heartbeatTimestampMs: Date.now(),
         headHash: client.headHash,
       }),
-    });
+    };
   }, dagStore);
   if (updatedClients.get(clientID) === undefined) {
     // Should this be a more specific error so caller can detect and handle?

--- a/src/persist/persist.ts
+++ b/src/persist/persist.ts
@@ -83,12 +83,12 @@ async function writeFixedChunks(
 ) {
   const chunksToPut = fixedChunks.values();
   await updateClients(clients => {
-    return Promise.resolve({
+    return {
       clients: new Map(clients).set(clientID, {
         heartbeatTimestampMs: Date.now(),
         headHash: mainHeadHash,
       }),
       chunksToPut,
-    });
+    };
   }, perdag);
 }

--- a/src/persist/persist.ts
+++ b/src/persist/persist.ts
@@ -4,7 +4,7 @@ import * as db from '../db/mod';
 import * as sync from '../sync/mod';
 import {Hash, nativeHashOf} from '../hash';
 import type {ClientID} from '../sync/client-id';
-import {Client, setClient} from './clients';
+import {updateClients} from './clients';
 import {ComputeHashTransformer, FixedChunks} from './compute-hash-transformer';
 import {GatherVisitor} from './gather-visitor';
 import {FixupTransformer} from './fixup-transformer';
@@ -81,18 +81,14 @@ async function writeFixedChunks(
   mainHeadHash: Hash,
   clientID: string,
 ) {
-  await perdag.withWrite(async dagWrite => {
-    const ps: Promise<void>[] = [];
-    for (const chunk of fixedChunks.values()) {
-      ps.push(dagWrite.putChunk(chunk));
-    }
-    const client: Client = {
-      heartbeatTimestampMs: Date.now(),
-      headHash: mainHeadHash,
-    };
-    // We need to set a head here or the chunks will be GC'd
-    ps.push(setClient(clientID, client, dagWrite));
-    await Promise.all(ps);
-    await dagWrite.commit();
-  });
+  const chunksToPut = fixedChunks.values();
+  await updateClients(clients => {
+    return Promise.resolve({
+      clients: new Map(clients).set(clientID, {
+        heartbeatTimestampMs: Date.now(),
+        headHash: mainHeadHash,
+      }),
+      chunksToPut,
+    });
+  }, perdag);
 }


### PR DESCRIPTION
### Problem
For Simplified Dueling Dags we want to allow using an async native hash
function. That means that the hash of a chunk has to be computed
outside the DAG transaction (because of IDB's auto commit bug/feature).

This mostly works well on the perdag because it gets it's chunks from
the memdag using the persist function which allows us to precompute all
the hashes; **except for the hash of the clients map**.

### Solution
To not require a sync hash function we instead precompute the hash of
the clients map outside the DAG transaction and then write it in the tx.
However, by doing this there is a small chance that the clients map
changed since we mutated it and computed the hash for it. If it did
change we now retry the update clients function with the new up to date
clients map.

Fixes #735
Fixes #743