### PR TITLE
fix: Incorrect ref count

### DIFF
--- a/src/dag/write.test.ts
+++ b/src/dag/write.test.ts
@@ -308,7 +308,7 @@ test('that we check if the hash is good when committing', async () => {
   }
 });
 
-test('that we changeRefCount does not write stale value', async () => {
+test('that changeRefCount does not write stale value with a dimamond pattern', async () => {
   const dagStore = new TestStore();
 
   // If we have a diamond structure we update the refcount for C twice.
@@ -351,7 +351,58 @@ test('that we changeRefCount does not write stale value', async () => {
   });
 });
 
-test('that we changeRefCount does not write stale value', async () => {
+test('that changeRefCount does not write stale value with a diamond pattern and a child', async () => {
+  const dagStore = new TestStore();
+
+  // If we have a diamond structure we update the refcount for C twice.
+  //
+  //   R
+  //  / \
+  //  A  B
+  //  \ /
+  //   C
+  //   |
+  //   D
+
+  const [a, d] = await dagStore.withWrite(async dagWrite => {
+    const d = createChunkWithHash(fakeHash('d'), 'd', []);
+    const c = createChunkWithHash(fakeHash('c'), 'c', [d.hash]);
+    const a = createChunkWithHash(fakeHash('a'), 'a', [c.hash]);
+    const b = createChunkWithHash(fakeHash('b'), 'b', [c.hash]);
+    const r = createChunkWithHash(fakeHash('r'), 'r', [a.hash, b.hash]);
+    await Promise.all([
+      dagWrite.setHead('test', r.hash),
+      dagWrite.putChunk(a),
+      dagWrite.putChunk(b),
+      dagWrite.putChunk(c),
+      dagWrite.putChunk(r),
+    ]);
+    await dagWrite.commit();
+
+    return [a, d];
+  });
+
+  await dagStore.kvStore.withRead(async kvRead => {
+    expect(await kvRead.get(chunkRefCountKey(d.hash))).to.equal(1);
+  });
+
+  //  A
+  //  \
+  //   C
+  //   |
+  //   D
+  await dagStore.withWrite(async dagWrite => {
+    await dagWrite.setHead('test', a.hash);
+    await dagWrite.commit();
+  });
+
+  await dagStore.kvStore.withRead(async kvRead => {
+    expect(await kvRead.get(chunkRefCountKey(a.hash))).to.equal(1);
+    expect(await kvRead.get(chunkRefCountKey(d.hash))).to.equal(1);
+  });
+});
+
+test('that we changeRefCount does not write stale value with a 3 incoming refs', async () => {
   const dagStore = new TestStore();
 
   // If we have a diamond structure we update the refcount for D three times.
@@ -373,6 +424,49 @@ test('that we changeRefCount does not write stale value', async () => {
       dagWrite.putChunk(a),
       dagWrite.putChunk(b),
       dagWrite.putChunk(c),
+      dagWrite.putChunk(d),
+      dagWrite.putChunk(r),
+    ]);
+    await dagWrite.commit();
+
+    return d;
+  });
+
+  await dagStore.kvStore.withRead(async kvRead => {
+    expect(await kvRead.get(chunkRefCountKey(d.hash))).to.equal(3);
+  });
+
+  await dagStore.withWrite(async dagWrite => {
+    const e = createChunkWithHash(fakeHash('e'), 'e', []);
+    await Promise.all([dagWrite.setHead('test', e.hash), dagWrite.putChunk(e)]);
+    await dagWrite.commit();
+  });
+
+  await dagStore.kvStore.withRead(async kvRead => {
+    expect(await kvRead.has(chunkRefCountKey(d.hash))).to.equal(false);
+  });
+});
+
+test('that we changeRefCount does not write stale value with a 3 incoming refs bypassing one level', async () => {
+  const dagStore = new TestStore();
+
+  // If we have a diamond structure we update the refcount for D three times.
+  //
+  //    R
+  //  / | \
+  //  A B  |
+  //  \ | /
+  //    D
+
+  const d = await dagStore.withWrite(async dagWrite => {
+    const d = createChunkWithHash(fakeHash('d'), 'd', []);
+    const a = createChunkWithHash(fakeHash('a'), 'a', [d.hash]);
+    const b = createChunkWithHash(fakeHash('b'), 'b', [d.hash]);
+    const r = createChunkWithHash(fakeHash('r'), 'r', [a.hash, b.hash, d.hash]);
+    await Promise.all([
+      dagWrite.setHead('test', r.hash),
+      dagWrite.putChunk(a),
+      dagWrite.putChunk(b),
       dagWrite.putChunk(d),
       dagWrite.putChunk(r),
     ]);

--- a/src/dag/write.ts
+++ b/src/dag/write.ts
@@ -141,6 +141,7 @@ export class Write extends Read {
     }
 
     {
+      // Read again since the ref count might have changed.
       const oldCount = refCountCache.get(hash);
       assertNumber(oldCount);
       const newCount = oldCount + delta;


### PR DESCRIPTION
If there is a diamond shape (or similar) we could end up writing a stale
ref count.

This happened because we read the ref count and then we do a bunch of
async operations. Then we write the new ref count based on the old, now
possible stale ref count value.