### PR TITLE
feat: Simplified Dueling Dags - Integrate dag.LazyStore into Replicache

### DIFF
--- a/src/replicache-subscribe.test.ts
+++ b/src/replicache-subscribe.test.ts
@@ -10,7 +10,7 @@ import type {ReadTransaction, WriteTransaction} from './mod';
 import type {JSONValue, ReadonlyJSONValue} from './json';
 import {expect} from '@esm-bundle/chai';
 import {sleep} from './sleep';
-import type * as kv from './kv/mod';
+import type * as dag from './dag/mod';
 import * as sinon from 'sinon';
 
 // fetch-mock has invalid d.ts file so we removed that on npm install.
@@ -821,7 +821,7 @@ test('subscription coalescing', async () => {
   });
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const store = sinon.spy((rep as any)._memKVStore as kv.Store);
+  const store = sinon.spy((rep as any)._memdag as dag.Store);
   const resetCounters = () => {
     store.read.resetHistory();
     store.write.resetHistory();

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -1062,7 +1062,7 @@ test('pullInterval in constructor', async () => {
 });
 
 test('closeTransaction after rep.scan', async () => {
-  const readSpy = sinon.spy(dag.StoreImpl.prototype, 'read');
+  const readSpy = sinon.spy(dag.LazyStore.prototype, 'read');
   const scanSpy = sinon.spy(db.Read.prototype, 'scan');
   const closeSpy = sinon.spy(db.Read.prototype, 'close');
 
@@ -1072,7 +1072,6 @@ test('closeTransaction after rep.scan', async () => {
     'a/0': 0,
     'a/1': 1,
   });
-
   const log: ReadonlyJSONValue[] = [];
 
   function expectCalls(l: JSONValue[]) {
@@ -1087,6 +1086,10 @@ test('closeTransaction after rep.scan', async () => {
     closeSpy.resetHistory();
     log.length = 0;
   }
+
+  readSpy.resetHistory();
+  scanSpy.resetHistory();
+  closeSpy.resetHistory();
 
   const it = rep.scan();
 
@@ -1975,7 +1978,7 @@ test('experiment KV Store', async () => {
   const b = await rep.query(tx => tx.has('foo'));
   expect(b).to.be.false;
 
-  expect(store.readCount).to.equal(0, 'readCount');
+  expect(store.readCount).to.equal(1, 'readCount');
   expect(store.writeCount).to.equal(0, 'writeCount');
   expect(store.closeCount).to.equal(0, 'closeCount');
   store.resetCounters();

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -57,7 +57,7 @@ export type Poke = {
 export const httpStatusUnauthorized = 401;
 
 const REPLICACHE_FORMAT_VERSION = 3;
-const LAZY_STORE_SOURCE_CHUNK_CACHE_SIZE_LIMIT = 100 * (2 ** 20); // 100 MB
+const LAZY_STORE_SOURCE_CHUNK_CACHE_SIZE_LIMIT = 100 * 2 ** 20; // 100 MB
 
 export type MaybePromise<T> = T | Promise<T>;
 

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -57,7 +57,7 @@ export type Poke = {
 export const httpStatusUnauthorized = 401;
 
 const REPLICACHE_FORMAT_VERSION = 3;
-const LAZY_STORE_SOURCE_CHUNK_CACHE_SIZE_LIMIT = 100 * Math.pow(2, 20); // 100 MB
+const LAZY_STORE_SOURCE_CHUNK_CACHE_SIZE_LIMIT = 100 * (2 ** 20); // 100 MB
 
 export type MaybePromise<T> = T | Promise<T>;
 


### PR DESCRIPTION
Update Replicache to use new dag.LazyStore (implemented in 7bc6106) for the memdag.  
Replace use of dag.StoreImpl on top of kv.MemStore.  Lazy loading is now used instead of
slurp.

**Performance**
Outperforms dag.StoreImpl on top of kv.MemStore with slurp on all existing benchmarks.  
Also outperforms slurp on WIP benchmark for startup from persistent storage when the 
amount of data stored is > ~4MB.

In the below output lines starting with `[LazyStore]` are with LazyStore and the other lines are with dag.StoreImpl on top of kv.MemStore using slurp (this was done with a small local patch for comparing).

```
greg replicache [grgbkr/ssd-startup-benchmark-on-checked-in-code]$ npm run perf -- --format replicache

> replicache@8.0.0 perf
> node perf/runner.js "--format" "replicache"

Running 40 benchmarks on Chromium...
[LazyStore] writeSubRead 1MB total, 64 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=0.60/0.70/0.80/1.50 ms avg=0.69 ms (19 runs sampled)
[LazyStore] writeSubRead 4MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.00/1.20/1.30/1.60 ms avg=1.16 ms (11 runs sampled)
[LazyStore] writeSubRead 16MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.40/1.60/2.20/2.20 ms avg=1.76 ms (7 runs sampled)
[LazyStore] populate 1024x1000 (clean, indexes: 0) 50/75/90/95%=83.60/86.10/137.30/137.30 ms avg=110.81 ms (7 runs sampled)
[LazyStore] populate 1024x1000 (clean, indexes: 1) 50/75/90/95%=36.90/47.60/53.70/56.60 ms avg=44.20 ms (12 runs sampled)
[LazyStore] populate 1024x1000 (clean, indexes: 2) 50/75/90/95%=45.30/51.20/67.70/67.70 ms avg=57.71 ms (9 runs sampled)
[LazyStore] scan 1024x1000 50/75/90/95%=1.20/1.50/2.20/2.70 ms avg=1.43 ms (19 runs sampled)
[LazyStore] create index 1024x5000 50/75/90/95%=95.00/101.50/106.50/106.50 ms avg=124.14 ms (7 runs sampled)
[LazyStore] startup read 1024x100 from 1024x100 stored 50/75/90/95%=9.50/10.20/10.50/10.60 ms avg=10.72 ms (19 runs sampled)
[LazyStore] startup read 1024x100 from 1024x1000 stored 50/75/90/95%=25.90/26.40/26.80/27.10 ms avg=28.57 ms (18 runs sampled)
[LazyStore] startup read 1024x100 from 1024x2000 stored 50/75/90/95%=27.10/28.30/32.90/84.10 ms avg=35.00 ms (15 runs sampled)
[LazyStore] startup read 1024x100 from 1024x3000 stored 50/75/90/95%=27.90/28.50/33.00/35.60 ms avg=31.82 ms (16 runs sampled)
[LazyStore] startup read 1024x100 from 1024x4000 stored 50/75/90/95%=27.90/34.40/46.10/61.50 ms avg=36.80 ms (14 runs sampled)
[LazyStore] startup read 1024x100 from 1024x5000 stored 50/75/90/95%=27.50/29.90/30.20/40.20 ms avg=31.90 ms (16 runs sampled)
[LazyStore] startup read 1024x100 from 1024x6000 stored 50/75/90/95%=31.20/56.90/63.60/77.90 ms avg=47.06 ms (11 runs sampled)
[LazyStore] startup read 1024x100 from 1024x7000 stored 50/75/90/95%=27.70/55.00/57.40/61.10 ms avg=42.12 ms (12 runs sampled)
[LazyStore] startup read 1024x100 from 1024x8000 stored 50/75/90/95%=30.10/42.70/77.90/78.80 ms avg=43.28 ms (12 runs sampled)
[LazyStore] startup read 1024x100 from 1024x9000 stored 50/75/90/95%=28.50/29.00/32.30/43.70 ms avg=33.43 ms (15 runs sampled)
[LazyStore] startup read 1024x100 from 1024x10000 stored 50/75/90/95%=28.30/28.70/29.20/36.10 ms avg=32.13 ms (16 runs sampled)
[LazyStore] startup read 1024x100 from 1024x100000 stored 50/75/90/95%=54.60/67.10/72.20/72.20 ms avg=73.43 ms (7 runs sampled)
writeSubRead 1MB total, 64 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=0.70/0.90/1.00/1.50 ms avg=0.83 ms (19 runs sampled)
writeSubRead 4MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=1.40/2.30/2.80/4.90 ms avg=2.12 ms (11 runs sampled)
writeSubRead 16MB total, 128 subs total, 5 subs dirty, 16kb read per sub 50/75/90/95%=2.10/2.90/2.90/2.90 ms avg=2.60 ms (7 runs sampled)
populate 1024x1000 (clean, indexes: 0) 50/75/90/95%=70.60/90.90/112.40/112.40 ms avg=91.83 ms (7 runs sampled)
populate 1024x1000 (clean, indexes: 1) 50/75/90/95%=34.60/47.30/54.50/56.60 ms avg=43.95 ms (12 runs sampled)
populate 1024x1000 (clean, indexes: 2) 50/75/90/95%=47.50/48.70/67.40/67.40 ms avg=59.67 ms (9 runs sampled)
scan 1024x1000 50/75/90/95%=1.20/1.50/2.20/2.80 ms avg=1.48 ms (19 runs sampled)
create index 1024x5000 50/75/90/95%=99.60/106.30/109.60/109.60 ms avg=129.09 ms (7 runs sampled)
startup read 1024x100 from 1024x100 stored 50/75/90/95%=9.00/9.40/9.70/9.70 ms avg=9.91 ms (19 runs sampled)
startup read 1024x100 from 1024x1000 stored 50/75/90/95%=14.00/14.40/15.10/15.30 ms avg=15.51 ms (19 runs sampled)
startup read 1024x100 from 1024x2000 stored 50/75/90/95%=19.10/20.00/28.60/93.00 ms avg=25.45 ms (19 runs sampled)
startup read 1024x100 from 1024x3000 stored 50/75/90/95%=26.70/28.10/29.80/64.60 ms avg=31.74 ms (16 runs sampled)
startup read 1024x100 from 1024x4000 stored 50/75/90/95%=31.60/33.20/35.10/37.10 ms avg=36.14 ms (14 runs sampled)
startup read 1024x100 from 1024x5000 stored 50/75/90/95%=54.30/55.10/114.20/114.20 ms avg=73.50 ms (7 runs sampled)
startup read 1024x100 from 1024x6000 stored 50/75/90/95%=62.20/94.20/97.10/97.10 ms avg=82.19 ms (7 runs sampled)
startup read 1024x100 from 1024x7000 stored 50/75/90/95%=55.20/90.60/94.00/94.00 ms avg=77.96 ms (7 runs sampled)
startup read 1024x100 from 1024x8000 stored 50/75/90/95%=57.80/62.30/63.20/63.20 ms avg=69.91 ms (8 runs sampled)
startup read 1024x100 from 1024x9000 stored 50/75/90/95%=66.30/80.30/111.00/111.00 ms avg=89.51 ms (7 runs sampled)
startup read 1024x100 from 1024x10000 stored 50/75/90/95%=82.10/89.40/114.30/114.30 ms avg=101.73 ms (7 runs sampled)
startup read 1024x100 from 1024x100000 stored 50/75/90/95%=638.90/645.50/675.20/675.20 ms avg=805.41 ms (7 runs sampled)
```


Part of #671 