### PR TITLE
Testing unload/persist/pending mutations

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "build": "rm -rf out && npm run build-dts && npm run build-mjs && npm run build-cjs && npm run build-min-mjs",
     "prepack": "npm run lint && npm run test && npm run build",
     "prepare": "rm -f node_modules/fetch-mock/esm/client.d.ts",
-    "perf": "node perf/runner.js"
+    "perf": "node perf/runner.js",
+    "test-unload": "tsc --watch & web-dev-server --node-resolve"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -785,6 +785,10 @@ export class Replicache<MD extends MutatorDefs = {}> {
     }
   }
 
+  async pendingCommits() {
+    return sync.pendingCommits(this._memdag);
+  }
+
   protected async _invokePush(maxAuthTries: number): Promise<boolean> {
     if (this.pushURL === '' && this.pusher === defaultPusher) {
       return true;

--- a/src/sync/mod.ts
+++ b/src/sync/mod.ts
@@ -1,6 +1,6 @@
 export {init as initClientID, CID_KEY} from './client-id';
 export {maybeEndPull, beginPull, handlePullResponse} from './pull';
-export {push} from './push';
+export {push, pendingCommits} from './push';
 export {newRequestID} from './request-id';
 export {SYNC_HEAD_NAME} from './sync-head-name';
 export {validateRebase} from './validate-rebase';

--- a/src/test-unload.ts
+++ b/src/test-unload.ts
@@ -1,0 +1,83 @@
+import type {Commit, LocalMeta} from './db/commit';
+import type {JSONValue} from './mod';
+import {Replicache} from './mod';
+
+const rep = new Replicache({
+  name: 'test-unload',
+  mutators: {
+    addData: async (tx, data: Record<string, JSONValue>) => {
+      for (const [k, v] of Object.entries(data)) {
+        await tx.put(k, v);
+      }
+    },
+  },
+});
+
+for (let i = 0; i < 100; i++) {
+  await rep.mutate.addData({now: new Date().toISOString()});
+  await rep.mutate.addData({a: 'long'.repeat(1000)});
+  await rep.mutate.addData({b: 2});
+}
+
+const el = document.getElementById('text');
+if (el) {
+  const {pendingCommits} = localStorage;
+  delete localStorage.pendingCommits;
+  if (pendingCommits) {
+    el.textContent = `// pendingCommits.length: ${
+      JSON.parse(pendingCommits).length
+    }\n${pendingCommits}`;
+  } else {
+    el.textContent = 'No pending commits';
+  }
+}
+
+const allDataEl = document.getElementById('all-data');
+if (allDataEl) {
+  allDataEl.textContent = await rep.query(
+    async tx => `keys: ${(await tx.scan().keys().toArray()).join(',')}`,
+  );
+}
+
+let persistDone = false;
+
+let data: Commit<LocalMeta>[];
+window.onbeforeunload = e => {
+  // This block does not finish in time...
+  void (async () => {
+    // Add mutations or persist does not have to touch IDB.
+    await rep.mutate.addData({c: 3});
+
+    const start = performance.now();
+    // @ts-expect-error private
+    await rep._persist();
+    persistDone = true;
+    const end = performance.now();
+    console.log(`persist took: ${end - start}ms`);
+  })();
+
+  // Reading the pending commits from dag.LazyStore does not need to touch IDB
+  // (unless the data does not fit in which case we are screwed).
+  void (async () => {
+    const start = performance.now();
+    data = await rep.pendingCommits();
+    const end = performance.now();
+    console.log(`pendingCommits took: ${end - start}ms`);
+
+    if (data.length > 0) {
+      e.returnValue = 1;
+      const s = JSON.stringify(data, null, 2);
+      try {
+        localStorage.pendingCommits = s;
+      } catch (e) {
+        // Size limit for localStorage is about 5MB.
+        // https://arty.name/localstorage.html
+        localStorage.pendingCommits = `localStorage quota exceeded, ${s.length}\n${e}`;
+      }
+    }
+  })();
+};
+
+window.addEventListener('beforeunload', () => {
+  console.log('persistDone', persistDone);
+});

--- a/test-unload.html
+++ b/test-unload.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<script type="module">
+  import './out/src/test-unload.js';
+</script>
+<pre
+  id="all-data"
+  style="position: absolute; background: white; right: 0; top: 0"
+></pre>
+<pre id="text">Loading...</pre>


### PR DESCRIPTION
This extracts the pending mutations code and exposes them on replicache

Then it creates a simple HTML test that tests if we can run persist
during beforeunload.

Test it by running:

  npm run test-unload

and navigate to:

  http://localhost:8000/test-unload.html