### PR TITLE
chore: remove useMemstore from perf

### DIFF
--- a/perf/replicache.ts
+++ b/perf/replicache.ts
@@ -20,12 +20,11 @@ export function benchmarkPopulate(opts: {
   numKeys: number;
   clean: boolean;
   indexes?: number;
-  useMemstore: boolean;
 }): Benchmark {
   return {
-    name: `${opts.useMemstore ? '[MemStore] ' : ''}populate ${valSize}x${
-      opts.numKeys
-    } (${opts.clean ? 'clean' : 'dirty'}, ${`indexes: ${opts.indexes || 0}`})`,
+    name: `populate ${valSize}x${opts.numKeys} (${
+      opts.clean ? 'clean' : 'dirty'
+    }, ${`indexes: ${opts.indexes || 0}`})`,
     group: 'replicache',
     byteSize: opts.numKeys * valSize,
     async run(bencher: Bencher) {
@@ -226,15 +225,10 @@ export function benchmarkReadTransaction(opts: {
   };
 }
 
-export function benchmarkScan(opts: {
-  numKeys: number;
-  useMemstore: boolean;
-}): Benchmark {
+export function benchmarkScan(opts: {numKeys: number}): Benchmark {
   let rep: ReplicacheWithPopulate;
   return {
-    name: `${opts.useMemstore ? '[MemStore] ' : ''}scan ${valSize}x${
-      opts.numKeys
-    }`,
+    name: `scan ${valSize}x${opts.numKeys}`,
     group: 'replicache',
     byteSize: opts.numKeys * valSize,
 
@@ -261,14 +255,9 @@ export function benchmarkScan(opts: {
   };
 }
 
-export function benchmarkCreateIndex(opts: {
-  numKeys: number;
-  useMemstore: boolean;
-}): Benchmark {
+export function benchmarkCreateIndex(opts: {numKeys: number}): Benchmark {
   return {
-    name: `${opts.useMemstore ? '[MemStore] ' : ''}create index ${valSize}x${
-      opts.numKeys
-    }`,
+    name: `create index ${valSize}x${opts.numKeys}`,
     group: 'replicache',
 
     async run(bencher: Bencher) {
@@ -301,7 +290,6 @@ export function benchmarkWriteSubRead(opts: {
   keysPerSub: number;
   keysWatchedPerSub: number;
   numSubsDirty: number;
-  useMemstore: boolean;
 }): Benchmark {
   const {valueSize, numSubsTotal, keysPerSub, keysWatchedPerSub, numSubsDirty} =
     opts;
@@ -312,9 +300,7 @@ export function benchmarkWriteSubRead(opts: {
   const makeKey = (index: number) => `key${index}`;
 
   return {
-    name: `${
-      opts.useMemstore ? '[MemStore] ' : ''
-    }writeSubRead ${cacheSizeMB}MB total, ${numSubsTotal} subs total, ${numSubsDirty} subs dirty, ${kbReadPerSub}kb read per sub`,
+    name: `writeSubRead ${cacheSizeMB}MB total, ${numSubsTotal} subs total, ${numSubsDirty} subs dirty, ${kbReadPerSub}kb read per sub`,
     group: 'replicache',
     async run(bencher: Bencher) {
       const keys = Array.from({length: numKeys}, (_, index) => makeKey(index));
@@ -448,7 +434,7 @@ async function makeRepWithPopulate() {
 }
 
 export function benchmarks(): Benchmark[] {
-  const bs = (useMemstore: boolean) => [
+  return [
     // write/sub/read 1mb
     benchmarkWriteSubRead({
       valueSize: 1024,
@@ -456,7 +442,6 @@ export function benchmarks(): Benchmark[] {
       keysPerSub: 16,
       keysWatchedPerSub: 16,
       numSubsDirty: 5,
-      useMemstore,
     }),
     // write/sub/read 4mb
     benchmarkWriteSubRead({
@@ -465,7 +450,6 @@ export function benchmarks(): Benchmark[] {
       keysPerSub: 32,
       keysWatchedPerSub: 16,
       numSubsDirty: 5,
-      useMemstore,
     }),
     // write/sub/read 16mb
     benchmarkWriteSubRead({
@@ -474,23 +458,13 @@ export function benchmarks(): Benchmark[] {
       keysPerSub: 128,
       keysWatchedPerSub: 16,
       numSubsDirty: 5,
-      useMemstore,
     }),
     // 128 mb is unusable
-    benchmarkPopulate({numKeys: 1000, clean: true, useMemstore}),
-    benchmarkPopulate({numKeys: 1000, clean: true, indexes: 1, useMemstore}),
-    benchmarkPopulate({numKeys: 1000, clean: true, indexes: 2, useMemstore}),
-    benchmarkScan({numKeys: 1000, useMemstore}),
-    benchmarkCreateIndex({numKeys: 5000, useMemstore}),
-  ];
-  // We do not support useMemstore any more but we keep running the benchmark
-  // with the flag to preserve the benchmark name so it is easier to keep track
-  // of the results.
-  //
-  // Run with both true and false. After a few runs we can remove the flag.
-  return [
-    ...bs(true),
-    ...bs(false),
+    benchmarkPopulate({numKeys: 1000, clean: true}),
+    benchmarkPopulate({numKeys: 1000, clean: true, indexes: 1}),
+    benchmarkPopulate({numKeys: 1000, clean: true, indexes: 2}),
+    benchmarkScan({numKeys: 1000}),
+    benchmarkCreateIndex({numKeys: 5000}),
     benchmarkStartupUsingBasicReadsFromPersistedData({
       numKeysPersisted: 100000,
       numKeysToRead: 100,


### PR DESCRIPTION
I printed MemStore so we would have some overlap in the perf graphs