### PR TITLE
refactor!: Remove deprecated pushAuth/getPushAuth and pullAuth/getPullAuth

### DIFF
--- a/src/replicache-options.ts
+++ b/src/replicache-options.ts
@@ -10,14 +10,6 @@ import type * as kv from './kv/mod';
 
 export interface ReplicacheOptions<MD extends MutatorDefs> {
   /**
-   * This is the
-   * [authorization](https://doc.replicache.dev/server-push#authorization) token
-   * used when doing a [push](https://doc.replicache.dev/server-push).
-   * @deprecated Use [[auth]] instead.
-   */
-  pushAuth?: string;
-
-  /**
    * This is the URL to the server endpoint dealing with the push updates. See
    * [Push Endpoint Reference](https://doc.replicache.dev/server-push) for more
    * details.
@@ -26,14 +18,6 @@ export interface ReplicacheOptions<MD extends MutatorDefs> {
    * [[ReplicacheOptions.pusher]] is provided.
    */
   pushURL?: string;
-
-  /**
-   * This is the
-   * [authorization](https://doc.replicache.dev/server-pull#authorization) token
-   * used when doing a [pull](https://doc.replicache.dev/server-pull).
-   * @deprecated Use [[auth]] instead.
-   */
-  pullAuth?: string;
 
   /**
    * This is the authorization token used when doing a

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -860,15 +860,15 @@ test('reauth push', async () => {
   });
 
   const consoleErrorStub = sinon.stub(console, 'error');
-  const getPushAuthFake = sinon.fake.returns(null);
-  rep.getPushAuth = getPushAuthFake;
+  const getAuthFake = sinon.fake.returns(null);
+  rep.getAuth = getAuthFake;
 
   await tickAFewTimes();
 
   fetchMock.post(pushURL, {body: 'xxx', status: httpStatusUnauthorized});
 
   await rep.mutate.noop();
-  await tickUntil(() => getPushAuthFake.callCount > 0, 1);
+  await tickUntil(() => getAuthFake.callCount > 0, 1);
 
   expect(consoleErrorStub.firstCall.args[0]).to.equal(
     'Got error response from server (https://diff.com/push) doing push: 401: xxx',
@@ -878,8 +878,8 @@ test('reauth push', async () => {
     await tickAFewTimes();
 
     const consoleInfoStub = sinon.stub(console, 'info');
-    const getPushAuthFake = sinon.fake(() => 'boo');
-    rep.getPushAuth = getPushAuthFake;
+    const getAuthFake = sinon.fake(() => 'boo');
+    rep.getAuth = getAuthFake;
 
     await rep.mutate.noop();
     await tickUntil(() => consoleInfoStub.callCount > 0, 1);

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -850,7 +850,6 @@ test('reauth push', async () => {
 
   const rep = await replicacheForTesting('reauth', {
     pushURL,
-    pushAuth: 'wrong',
     pushDelay: 0,
     mutators: {
       noop() {

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -276,9 +276,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
     const {
       name,
       logLevel = 'info',
-      pullAuth,
       pullURL = '',
-      pushAuth,
       auth,
       pushDelay = 10,
       pushURL = '',
@@ -290,7 +288,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
       pusher = defaultPusher,
       experimentalKVStore,
     } = options;
-    this.auth = auth ?? pullAuth ?? pushAuth ?? '';
+    this.auth = auth ?? '';
     this.pullURL = pullURL;
     this.pushURL = pushURL;
     if (name === '') {

--- a/src/sync/push.test.ts
+++ b/src/sync/push.test.ts
@@ -19,7 +19,7 @@ type FakePusherArgs = {
   expPush: boolean;
   expPushReq?: PushRequest;
   expPushURL: string;
-  expPushAuth: string;
+  expAuth: string;
   expRequestID: string;
   err?: string;
 };
@@ -35,7 +35,7 @@ function makeFakePusher(options: FakePusherArgs): Pusher {
       expect(new URL(options.expPushURL, location.href).toString()).to.equal(
         req.url,
       );
-      expect(options.expPushAuth).to.equal(req.headers.get('Authorization'));
+      expect(options.expAuth).to.equal(req.headers.get('Authorization'));
       expect(options.expRequestID).to.equal(
         req.headers.get('X-Replicache-RequestID'),
       );
@@ -71,7 +71,7 @@ test('try push', async () => {
 
   const requestID = 'request_id';
   const clientID = 'test_client_id';
-  const pushAuth = 'push_auth';
+  const auth = 'auth';
 
   // Push
   const pushURL = 'push_url';
@@ -229,7 +229,7 @@ test('try push', async () => {
       expPush,
       expPushReq: c.expPushReq,
       expPushURL: pushURL,
-      expPushAuth: pushAuth,
+      expAuth: auth,
       expRequestID: requestID,
       err: pushErr,
     });
@@ -242,7 +242,7 @@ test('try push', async () => {
       clientID,
       pusher,
       pushURL,
-      pushAuth,
+      auth,
       pushSchemaVersion,
     );
 

--- a/src/sync/push.ts
+++ b/src/sync/push.ts
@@ -49,7 +49,7 @@ export async function push(
   clientID: string,
   pusher: Pusher,
   pushURL: string,
-  pushAuth: string,
+  auth: string,
   schemaVersion: string,
 ): Promise<HTTPRequestInfo | undefined> {
   // Find pending commits between the base snapshot and the main head and push
@@ -88,7 +88,7 @@ export async function push(
       pusher,
       pushURL,
       pushReq,
-      pushAuth,
+      auth,
       requestID,
     );
     lc.debug?.('...Push complete in ', Date.now() - pushStart, 'ms');


### PR DESCRIPTION
Removes `Replicache.getPushAuth` and `Replicache.getPullAuth` which were deprecated and replaced by `Replicache.getAuth`.
Removes `ReplicacheOptions.pushAuth` and `ReplicacheOptions.pullAuth` which were deprecated and replaced by `ReplicacheOptions.auth`. 

These fields were deprecated by 9c3a49bc4b16924a3d8e0af5bbd4208156d20174, and have been deprecated since release [v6.4.0](https://github.com/rocicorp/replicache/releases/tag/v6.4.0).  
 
This will make some work on mutation recovery cleaner.

BREAKING CHANGE: Removes `Replicache#getPushAuth` and `Replicache#getPullAuth`.  Usages should be updated to use `Replicache#getAuth`. Removes `ReplicacheOptions.pushAuth` and `ReplicacheOptions.pullAuth`.  Usages should be updated to use `ReplicacheOptions.auth`.