### PR TITLE
refactor: Extract reauth retry logic from push and pull into shared method.

### DIFF
--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -2109,7 +2109,7 @@ test('mutation timestamps are immutable', async () => {
 
   // Create a mutation and verify it has been assigned current time.
   await rep.mutate.foo(null);
-  await rep.invokePush(1);
+  await rep.invokePush();
   expect(pending).deep.equal([
     {
       id: 1,
@@ -2144,7 +2144,7 @@ test('mutation timestamps are immutable', async () => {
   expect(val).equal('dog');
 
   // Check that mutation timestamp did not change
-  await rep.invokePush(1);
+  await rep.invokePush();
   expect(pending).deep.equal([
     {
       id: 1,

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -76,7 +76,7 @@ export function makeIdbName(name: string, schemaVersion?: string): string {
  * The maximum number of time to call out to getAuth before giving up
  * and throwing an error.
  */
-export const MAX_REAUTH_TRIES = 8;
+const MAX_REAUTH_TRIES = 8;
 
 const PERSIST_TIMEOUT = 1000;
 

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -866,6 +866,8 @@ export class Replicache<MD extends MutatorDefs = {}> {
         'push',
         this.pushURL,
       );
+      // No pushResponse means we didn't do a push because there were no
+      // pending mutations.
       return pushResponse === undefined || pushResponse.httpStatusCode === 200;
     }, 'Push');
   }

--- a/src/test-util.ts
+++ b/src/test-util.ts
@@ -1,9 +1,4 @@
-import {
-  MutatorDefs,
-  Replicache,
-  BeginPullResult,
-  MAX_REAUTH_TRIES,
-} from './replicache';
+import {MutatorDefs, Replicache, BeginPullResult} from './replicache';
 import type {ReplicacheOptions} from './replicache-options';
 import * as kv from './kv/mod';
 import {SinonFakeTimers, useFakeTimers} from 'sinon';
@@ -20,17 +15,17 @@ export class ReplicacheTest<
   // eslint-disable-next-line @typescript-eslint/ban-types
   MD extends MutatorDefs = {},
 > extends Replicache<MD> {
-  beginPull(maxAuthTries = MAX_REAUTH_TRIES): Promise<BeginPullResult> {
-    return super._beginPull(maxAuthTries);
+  beginPull(): Promise<BeginPullResult> {
+    return super._beginPull();
   }
 
   maybeEndPull(beginPullResult: BeginPullResult): Promise<void> {
     return super._maybeEndPull(beginPullResult);
   }
 
-  invokePush(maxAuthTries: number): Promise<boolean> {
+  invokePush(): Promise<boolean> {
     // indirection to allow test to spy on it.
-    return super._invokePush(maxAuthTries);
+    return super._invokePush();
   }
 
   protected override _memdagHashFunction(): <V extends ReadonlyJSONValue>(
@@ -39,14 +34,12 @@ export class ReplicacheTest<
     return makeNewTempHashFunction();
   }
 
-  protected override _invokePush(maxAuthTries: number): Promise<boolean> {
-    return this.invokePush(maxAuthTries);
+  protected override _invokePush(): Promise<boolean> {
+    return this.invokePush();
   }
 
-  protected override _beginPull(
-    maxAuthTries: number,
-  ): Promise<BeginPullResult> {
-    return this.beginPull(maxAuthTries);
+  protected override _beginPull(): Promise<BeginPullResult> {
+    return this.beginPull();
   }
 
   persist() {


### PR DESCRIPTION
Extract reauth retry logic from push and pull into shared method.  This reduces duplication and also will allow for reuse of this logic for mutation recovery.