### PR TITLE
feat: Simplified Dueling Dags - Mutation Recovery - Add an optional parameter to beingPull for disabling the creation of a sync branch from the pull response

### DIFF
--- a/src/sync/pull.test.ts
+++ b/src/sync/pull.test.ts
@@ -524,8 +524,9 @@ test('begin try pull', async () => {
       } else {
         const gotHead = await read.getHead(SYNC_HEAD_NAME);
         expect(gotHead).to.be.undefined;
-        // When  nop sync we except Beginpull to succeed but sync_head will
-        // be empty.
+        // When createSyncBranch is false or sync is a noop (empty patch,
+        // same last mutation id, same cookie) we except Beginpull to succeed
+        // but sync_head will be empty.
         if (typeof c.expBeginPullResult !== 'string') {
           assertObject(result);
           expect(result.syncHead).to.be.equal(emptyHash);


### PR DESCRIPTION
For Mutation Recover we need to be able to pull to confirm mutations have been applied on the server by 
looking at the responses `lastMutationID`, but we do not want to apply the response to the DAG.  Add an 
option to beginPull to not create a sync branch from the pull response.

Also add the `PullResponse` to `BeginPullResponse`, as it will be need by Mutation Recovery to get the 
`lastMutationID`. 

Part of #671 