### PR TITLE
refactor!: Update Replicache.schemaVersion to readonly.

### DIFF
--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -175,7 +175,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
   }
 
   /** The schema version of the data understood by this application. */
-  schemaVersion: string;
+  readonly schemaVersion: string;
 
   private _closed = false;
   private _online = true;


### PR DESCRIPTION
This should always have been readonly, the schema version of a Replicache instance should be constant through out its life.   Previously modifying this had no effect.

BREAKING CHANGE:  Code modifying Replicache.schemaVersion must be removed (to resolve TypeScript errors).  