### PR TITLE
feat: Track Replicache IndexedDB databases in another IndexedDB database for mutation recovery and db gc.

### DIFF
--- a/src/persist/idb-databases-store.test.ts
+++ b/src/persist/idb-databases-store.test.ts
@@ -3,37 +3,37 @@ import {TestMemStore} from '../kv/test-mem-store';
 import {IDBDatabasesStore} from './idb-databases-store';
 
 test('getDatabases with no existing record in db', async () => {
-  const idbDatabasesStore = new IDBDatabasesStore(_ => new TestMemStore());
-  expect(await idbDatabasesStore.getDatabases()).to.deep.equal({});
+  const store = new IDBDatabasesStore(_ => new TestMemStore());
+  expect(await store.getDatabases()).to.deep.equal({});
 });
 
 test('putDatabase with no existing record in db', async () => {
-  const idbDatabasesStore = new IDBDatabasesStore(_ => new TestMemStore());
+  const store = new IDBDatabasesStore(_ => new TestMemStore());
   const testDB = {
     name: 'testName',
     replicacheFormatVersion: 1,
     schemaVersion: 'testSchemaVersion',
   };
-  expect(await idbDatabasesStore.putDatabase(testDB)).to.deep.equal({
+  expect(await store.putDatabase(testDB)).to.deep.equal({
     testName: testDB,
   });
-  expect(await idbDatabasesStore.getDatabases()).to.deep.equal({
+  expect(await store.getDatabases()).to.deep.equal({
     testName: testDB,
   });
 });
 
 test('putDatabase sequence', async () => {
-  const idbDatabasesStore = new IDBDatabasesStore(_ => new TestMemStore());
+  const store = new IDBDatabasesStore(_ => new TestMemStore());
   const testDB1 = {
     name: 'testName1',
     replicacheFormatVersion: 1,
     schemaVersion: 'testSchemaVersion1',
   };
 
-  expect(await idbDatabasesStore.putDatabase(testDB1)).to.deep.equal({
+  expect(await store.putDatabase(testDB1)).to.deep.equal({
     testName1: testDB1,
   });
-  expect(await idbDatabasesStore.getDatabases()).to.deep.equal({
+  expect(await store.getDatabases()).to.deep.equal({
     testName1: testDB1,
   });
 
@@ -43,11 +43,11 @@ test('putDatabase sequence', async () => {
     schemaVersion: 'testSchemaVersion2',
   };
 
-  expect(await idbDatabasesStore.putDatabase(testDB2)).to.deep.equal({
+  expect(await store.putDatabase(testDB2)).to.deep.equal({
     testName1: testDB1,
     testName2: testDB2,
   });
-  expect(await idbDatabasesStore.getDatabases()).to.deep.equal({
+  expect(await store.getDatabases()).to.deep.equal({
     testName1: testDB1,
     testName2: testDB2,
   });

--- a/src/persist/idb-databases-store.test.ts
+++ b/src/persist/idb-databases-store.test.ts
@@ -1,0 +1,54 @@
+import {expect} from '@esm-bundle/chai';
+import {TestMemStore} from '../kv/test-mem-store';
+import {IDBDatabasesStore} from './idb-databases-store';
+
+test('getDatabases with no existing record in db', async () => {
+  const idbDatabasesStore = new IDBDatabasesStore(_ => new TestMemStore());
+  expect(await idbDatabasesStore.getDatabases()).to.deep.equal({});
+});
+
+test('putDatabase with no existing record in db', async () => {
+  const idbDatabasesStore = new IDBDatabasesStore(_ => new TestMemStore());
+  const testDB = {
+    name: 'testName',
+    replicacheFormatVersion: 1,
+    schemaVersion: 'testSchemaVersion',
+  };
+  expect(await idbDatabasesStore.putDatabase(testDB)).to.deep.equal({
+    testName: testDB,
+  });
+  expect(await idbDatabasesStore.getDatabases()).to.deep.equal({
+    testName: testDB,
+  });
+});
+
+test('putDatabase sequence', async () => {
+  const idbDatabasesStore = new IDBDatabasesStore(_ => new TestMemStore());
+  const testDB1 = {
+    name: 'testName1',
+    replicacheFormatVersion: 1,
+    schemaVersion: 'testSchemaVersion1',
+  };
+
+  expect(await idbDatabasesStore.putDatabase(testDB1)).to.deep.equal({
+    testName1: testDB1,
+  });
+  expect(await idbDatabasesStore.getDatabases()).to.deep.equal({
+    testName1: testDB1,
+  });
+
+  const testDB2 = {
+    name: 'testName2',
+    replicacheFormatVersion: 2,
+    schemaVersion: 'testSchemaVersion2',
+  };
+
+  expect(await idbDatabasesStore.putDatabase(testDB2)).to.deep.equal({
+    testName1: testDB1,
+    testName2: testDB2,
+  });
+  expect(await idbDatabasesStore.getDatabases()).to.deep.equal({
+    testName1: testDB1,
+    testName2: testDB2,
+  });
+});

--- a/src/persist/idb-databases-store.test.ts
+++ b/src/persist/idb-databases-store.test.ts
@@ -52,3 +52,11 @@ test('putDatabase sequence', async () => {
     testName2: testDB2,
   });
 });
+
+test('close closes kv store', async () => {
+  const memstore = new TestMemStore();
+  const store = new IDBDatabasesStore(_ => memstore);
+  expect(memstore.closed).to.be.false;
+  await store.close();
+  expect(memstore.closed).to.be.true;
+});

--- a/src/persist/idb-databases-store.ts
+++ b/src/persist/idb-databases-store.ts
@@ -13,6 +13,8 @@ export type IndexedDBDatabase = {
   schemaVersion: string;
 };
 
+export type IndexedDBDatabaseRecord = Record<IndexDBName, IndexedDBDatabase>;
+
 function assertIndexedDBDatabaseRecord(
   value: unknown,
 ): asserts value is IndexedDBDatabaseRecord {
@@ -31,8 +33,6 @@ function assertIndexedDBDatabase(
   assertNumber(value.replicacheFormatVersion);
   assertString(value.schemaVersion);
 }
-
-export type IndexedDBDatabaseRecord = Record<IndexDBName, IndexedDBDatabase>;
 
 export class IDBDatabasesStore {
   private readonly _kvStore: kv.Store;

--- a/src/persist/idb-databases-store.ts
+++ b/src/persist/idb-databases-store.ts
@@ -43,11 +43,12 @@ export class IDBDatabasesStore {
     this._kvStore = createKVStore(IDB_NAME);
   }
 
-  async addDatabase(db: IndexedDBDatabase): Promise<IndexedDBDatabaseRecord> {
+  async putDatabase(db: IndexedDBDatabase): Promise<IndexedDBDatabaseRecord> {
     return this._kvStore.withWrite(async write => {
       const dbRecord = await this._getDatabases(write);
       dbRecord[db.name] = db;
       await write.put(KEY, dbRecord);
+      await write.commit();
       return dbRecord;
     });
   }

--- a/src/persist/idb-databases-store.ts
+++ b/src/persist/idb-databases-store.ts
@@ -5,15 +5,15 @@ const IDB_NAME = 'replicache-dbs';
 const KEY = 'dbs';
 
 // TODO: make an opaque type
-export type IndexDBName = string;
+export type IndexedDBName = string;
 
 export type IndexedDBDatabase = {
-  name: IndexDBName;
+  name: IndexedDBName;
   replicacheFormatVersion: number;
   schemaVersion: string;
 };
 
-export type IndexedDBDatabaseRecord = Record<IndexDBName, IndexedDBDatabase>;
+export type IndexedDBDatabaseRecord = Record<IndexedDBName, IndexedDBDatabase>;
 
 function assertIndexedDBDatabaseRecord(
   value: unknown,
@@ -54,9 +54,7 @@ export class IDBDatabasesStore {
   }
 
   getDatabases(): Promise<IndexedDBDatabaseRecord> {
-    return this._kvStore.withRead(async read => {
-      return this._getDatabases(read);
-    });
+    return this._kvStore.withRead(async read => this._getDatabases(read));
   }
 
   close(): Promise<void> {

--- a/src/persist/idb-databases-store.ts
+++ b/src/persist/idb-databases-store.ts
@@ -1,0 +1,69 @@
+import {assertNumber, assertObject, assertString} from '../asserts';
+import * as kv from '../kv/mod';
+
+const IDB_NAME = 'replicache-dbs';
+const KEY = 'dbs';
+
+// TODO: make an opaque type
+export type IndexDBName = string;
+
+export type IndexedDBDatabase = {
+  name: IndexDBName;
+  replicacheFormatVersion: number;
+  schemaVersion: string;
+};
+
+function assertIndexedDBDatabaseRecord(
+  value: unknown,
+): asserts value is IndexedDBDatabaseRecord {
+  assertObject(value);
+  for (const [name, db] of Object.entries(value)) {
+    assertString(name);
+    assertIndexedDBDatabase(db);
+  }
+}
+
+function assertIndexedDBDatabase(
+  value: unknown,
+): asserts value is IndexedDBDatabase {
+  assertObject(value);
+  assertString(value.name);
+  assertNumber(value.replicacheFormatVersion);
+  assertString(value.schemaVersion);
+}
+
+export type IndexedDBDatabaseRecord = Record<IndexDBName, IndexedDBDatabase>;
+
+export class IDBDatabasesStore {
+  private readonly _kvStore: kv.Store;
+
+  constructor(
+    createKVStore: (name: string) => kv.Store = name => new kv.IDBStore(name),
+  ) {
+    this._kvStore = createKVStore(IDB_NAME);
+  }
+
+  async addDatabase(db: IndexedDBDatabase): Promise<IndexedDBDatabaseRecord> {
+    return this._kvStore.withWrite(async write => {
+      const dbRecord = await this._getDatabases(write);
+      dbRecord[db.name] = db;
+      await write.put(KEY, dbRecord);
+      return dbRecord;
+    });
+  }
+
+  getDatabases(): Promise<IndexedDBDatabaseRecord> {
+    return this._kvStore.withRead(async read => {
+      return this._getDatabases(read);
+    });
+  }
+
+  private async _getDatabases(read: kv.Read): Promise<IndexedDBDatabaseRecord> {
+    let dbRecord = await read.get(KEY);
+    if (!dbRecord) {
+      dbRecord = {};
+    }
+    assertIndexedDBDatabaseRecord(dbRecord);
+    return dbRecord;
+  }
+}

--- a/src/persist/idb-databases-store.ts
+++ b/src/persist/idb-databases-store.ts
@@ -43,7 +43,7 @@ export class IDBDatabasesStore {
     this._kvStore = createKVStore(IDB_NAME);
   }
 
-  async putDatabase(db: IndexedDBDatabase): Promise<IndexedDBDatabaseRecord> {
+  putDatabase(db: IndexedDBDatabase): Promise<IndexedDBDatabaseRecord> {
     return this._kvStore.withWrite(async write => {
       const dbRecord = await this._getDatabases(write);
       dbRecord[db.name] = db;
@@ -57,6 +57,10 @@ export class IDBDatabasesStore {
     return this._kvStore.withRead(async read => {
       return this._getDatabases(read);
     });
+  }
+
+  close(): Promise<void> {
+    return this._kvStore.close();
   }
 
   private async _getDatabases(read: kv.Read): Promise<IndexedDBDatabaseRecord> {

--- a/src/persist/mod.ts
+++ b/src/persist/mod.ts
@@ -2,3 +2,4 @@ export {persist} from './persist';
 export {startHeartbeats} from './heartbeat';
 export {initClient} from './clients';
 export {initClientGC} from './client-gc';
+export {IDBDatabasesStore} from './idb-databases-store';

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -417,7 +417,11 @@ export class Replicache<MD extends MutatorDefs = {}> {
     this._endClientsGC();
 
     await this._ready;
-    const closingPromises = [this._memdag.close(), this._perdag.close()];
+    const closingPromises = [
+      this._memdag.close(),
+      this._perdag.close(),
+      this._idbDatabases.close(),
+    ];
 
     this._pullConnectionLoop.close();
     this._pushConnectionLoop.close();

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -209,7 +209,8 @@ export class Replicache<MD extends MutatorDefs = {}> {
 
   private readonly _memdag: dag.Store;
   private readonly _perdag: dag.Store;
-  private readonly _idbDatabases: persist.IDBDatabasesStore;
+  private readonly _idbDatabases: persist.IDBDatabasesStore =
+    new persist.IDBDatabasesStore();
   private _hasPendingSubscriptionRuns = false;
   private readonly _lc: LogContext;
 
@@ -292,7 +293,6 @@ export class Replicache<MD extends MutatorDefs = {}> {
       this._memdagHashFunction(),
       assertHash,
     );
-    this._idbDatabases = new persist.IDBDatabasesStore();
 
     // Use a promise-resolve pair so that we have a promise to use even before
     // we call the Open RPC.


### PR DESCRIPTION
### Problem
We need to be able to find old Replicache IndexedDB databases (i.e. databases with previous schema 
versions or replicache format versions), so that we can recover mutations from them and also GC them.

### Solution
Keep track of Replicache IndexedDB databases in a IndexedDB database. 

Unfortunately Firefox does not implement [IDBFactory.databases](https://developer.mozilla.org/en-US/docs/Web/API/IDBFactory/databases), or we would use that api.

IndexedDB is used over LocalStorage because LocalStorage's lack of concurrency control makes
it very difficult to avoid write clobbering when updating a list or map.