### PR TITLE
fix: fix benchmarks broken by mutation recovery change

### DIFF
--- a/perf/perf.ts
+++ b/perf/perf.ts
@@ -189,7 +189,7 @@ export async function runBenchmarkByNameAndGroup(
           : formatAsBenchmarkJS(result),
     };
   } catch (e) {
-    return {error: `${b.name} had an error: ${e}`};
+    return {error: `${b.name} had an error: ${e}:${e.stack}`};
   }
 }
 

--- a/perf/perf.ts
+++ b/perf/perf.ts
@@ -189,7 +189,7 @@ export async function runBenchmarkByNameAndGroup(
           : formatAsBenchmarkJS(result),
     };
   } catch (e) {
-    return {error: `${b.name} had an error: ${e}:${e.stack}`};
+    return {error: `${b.name} had an error: ${e}`};
   }
 }
 

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -1190,7 +1190,14 @@ export class Replicache<MD extends MutatorDefs = {}> {
           dag.throwChunkHasher,
           assertNotTempHash,
         );
-        await this._recoverMutationsFromPerdag(perdag, database.schemaVersion);
+        try {
+          await this._recoverMutationsFromPerdag(
+            perdag,
+            database.schemaVersion,
+          );
+        } finally {
+          await perdag.close();
+        }
       }
     } catch (e) {
       if (this.closed) {


### PR DESCRIPTION
These were broken by 1538c424e2369c36c5a41c7876f0dad338e59768. 

three fixes.
1. close other indexeddbs we try to recover
2. delete IDBDatabasesStore indexeddb db after each benchmark.  this way mutationRecovery is not try to recover a ton of dbs during benchmarks. 
3. make the indexeddb deletion code in perf tests more robost.  There is no way to wait for an indexeddb close to complete (the api is silently async).  If you call delete when a close is in process, it fails with a onblocked event.  Add code that will delay 100ms and then retry delete after a onblocked event (up to 10 retries).