### PR TITLE
fix: remove debugging console.log from benchmarks

### DIFF
--- a/perf/replicache.ts
+++ b/perf/replicache.ts
@@ -396,7 +396,6 @@ function deleteDatabase(name: string): Promise<unknown> {
   const retryDelayMs = 100;
   let retryBlockCount = 0;
   function delDB(resolve: (_: unknown) => void, reject: (_: unknown) => void) {
-    console.log(name);
     const req = indexedDB.deleteDatabase(name);
     req.onsuccess = resolve;
     req.onerror = req.onupgradeneeded = reject;


### PR DESCRIPTION
Remove debugging console.log from benchmarks.

Accidentally check in here ac33faf50ceb379998ad1697305c29d19f32644a.