### PR TITLE
fix: Simplified Dueling Dags - Mutation Recovery - Do not recover mutation from clients with a different Replicache name

### DIFF
--- a/src/persist/idb-databases-store.test.ts
+++ b/src/persist/idb-databases-store.test.ts
@@ -11,6 +11,7 @@ test('putDatabase with no existing record in db', async () => {
   const store = new IDBDatabasesStore(_ => new TestMemStore());
   const testDB = {
     name: 'testName',
+    replicacheName: 'testReplicacheName',
     replicacheFormatVersion: 1,
     schemaVersion: 'testSchemaVersion',
   };
@@ -26,6 +27,7 @@ test('putDatabase sequence', async () => {
   const store = new IDBDatabasesStore(_ => new TestMemStore());
   const testDB1 = {
     name: 'testName1',
+    replicacheName: 'testReplicacheName1',
     replicacheFormatVersion: 1,
     schemaVersion: 'testSchemaVersion1',
   };
@@ -39,6 +41,7 @@ test('putDatabase sequence', async () => {
 
   const testDB2 = {
     name: 'testName2',
+    replicacheName: 'testReplicacheName2',
     replicacheFormatVersion: 2,
     schemaVersion: 'testSchemaVersion2',
   };
@@ -65,6 +68,7 @@ test('clear', async () => {
   const store = new IDBDatabasesStore(_ => new TestMemStore());
   const testDB1 = {
     name: 'testName1',
+    replicacheName: 'testReplicacheName1',
     replicacheFormatVersion: 1,
     schemaVersion: 'testSchemaVersion1',
   };
@@ -82,6 +86,7 @@ test('clear', async () => {
 
   const testDB2 = {
     name: 'testName2',
+    replicacheName: 'testReplicacheName2',
     replicacheFormatVersion: 2,
     schemaVersion: 'testSchemaVersion2',
   };

--- a/src/persist/idb-databases-store.ts
+++ b/src/persist/idb-databases-store.ts
@@ -1,7 +1,8 @@
 import {assert, assertNumber, assertObject, assertString} from '../asserts';
 import * as kv from '../kv/mod';
 
-export const IDB_DATABASES_DB_NAME = 'replicache-dbs';
+export const IDB_DATABASES_VERSION = 0;
+export const IDB_DATABASES_DB_NAME = 'replicache-dbs-v' + IDB_DATABASES_VERSION;
 const KEY = 'dbs';
 
 // TODO: make an opaque type
@@ -9,6 +10,7 @@ export type IndexedDBName = string;
 
 export type IndexedDBDatabase = {
   name: IndexedDBName;
+  replicacheName: string;
   replicacheFormatVersion: number;
   schemaVersion: string;
 };
@@ -31,6 +33,7 @@ function assertIndexedDBDatabase(
 ): asserts value is IndexedDBDatabase {
   assertObject(value);
   assertString(value.name);
+  assertString(value.replicacheName);
   assertNumber(value.replicacheFormatVersion);
   assertString(value.schemaVersion);
 }

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -351,6 +351,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
     await closingInstances.get(this.name);
     await this._idbDatabases.putDatabase({
       name: this.idbName,
+      replicacheName: this.name,
       replicacheFormatVersion: REPLICACHE_FORMAT_VERSION,
       schemaVersion: this.schemaVersion,
     });
@@ -1176,12 +1177,13 @@ export class Replicache<MD extends MutatorDefs = {}> {
       for (const database of Object.values(
         await this._idbDatabases.getDatabases(),
       )) {
-        if (database.name === this.idbName) {
-          continue;
-        }
-        if (database.replicacheFormatVersion !== REPLICACHE_FORMAT_VERSION) {
-          // TODO: when REPLICACHE_FORMAT_VERSION is updated
+        if (
+          database.name === this.idbName ||
+          database.replicacheName !== this.name ||
+          // TODO: when REPLICACHE_FORMAT_VERSION is update
           // need to also handle previous REPLICACHE_FORMAT_VERSIONs
+          database.replicacheFormatVersion !== REPLICACHE_FORMAT_VERSION
+        ) {
           continue;
         }
         const perKvStore = new IDBStore(database.name);


### PR DESCRIPTION
Problem
======
A client _**MUST NOT**_ recover mutations from a client with a different Replicache name.  This is because a client uses its auth to push the mutations.  This is safe for client's with the same name as they are for the same user.  However, pushing on behalf of a client with a different name is very bad, as it will apply the mutations for a different user.

Solution
======
Add Replicache name to the IndexedDBDatabase records, and only recover mutations for clients with the same Repliache name.  Add a test for this behavior.

Also adds versioning to IDBDatabasesStore for easing handling of future format changes of  IndexedDBDatabase records.