### PR TITLE
feat: Simplified Dueling Dags - Mutation Recovery - Make recovery robust to errors and exit early on close.

### DIFF
--- a/src/persist/mod.ts
+++ b/src/persist/mod.ts
@@ -11,3 +11,7 @@ export {initClientGC} from './client-gc';
 export {IDB_DATABASES_DB_NAME, IDBDatabasesStore} from './idb-databases-store';
 
 export type {Client, ClientMap} from './clients';
+export type {
+  IndexedDBDatabase,
+  IndexedDBDatabaseRecord,
+} from './idb-databases-store';

--- a/src/replicache-mutation-recovery.test.ts
+++ b/src/replicache-mutation-recovery.test.ts
@@ -11,6 +11,7 @@ import type * as db from './db/mod';
 import * as dag from './dag/mod';
 import * as persist from './persist/mod';
 import * as kv from './kv/mod';
+import type * as sync from './sync/mod';
 import {assertHash, assertNotTempHash, makeNewTempHashFunction} from './hash';
 import {assertNotUndefined} from './asserts';
 import {expect} from '@esm-bundle/chai';
@@ -38,7 +39,7 @@ teardown(async () => {
   }
   dagsToClose.length = 0;
   await idbDatabases.close();
-  //sinon.restore();
+  sinon.restore();
 });
 
 async function createPerdag(args: {

--- a/src/replicache-mutation-recovery.test.ts
+++ b/src/replicache-mutation-recovery.test.ts
@@ -9,14 +9,14 @@ import {makeIdbName, REPLICACHE_FORMAT_VERSION} from './replicache';
 import {addGenesis, addLocal, addSnapshot, Chain} from './db/test-helpers';
 import type * as db from './db/mod';
 import * as dag from './dag/mod';
-import type * as sync from './sync/mod';
 import * as persist from './persist/mod';
 import * as kv from './kv/mod';
 import {assertHash, assertNotTempHash, makeNewTempHashFunction} from './hash';
 import {assertNotUndefined} from './asserts';
 import {expect} from '@esm-bundle/chai';
 import {uuid} from './sync/uuid';
-import {assertJSONObject, JSONObject} from './json';
+import {assertJSONObject, JSONObject, ReadonlyJSONObject} from './json';
+import sinon from 'sinon';
 
 // fetch-mock has invalid d.ts file so we removed that on npm install.
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -38,6 +38,7 @@ teardown(async () => {
   }
   dagsToClose.length = 0;
   await idbDatabases.close();
+  //sinon.restore();
 });
 
 async function createPerdag(args: {
@@ -84,6 +85,24 @@ async function createAndPersistClientWithPendingLocal(
   }
   await persist.persist(clientID, testMemdag, perdag);
   return localMetas;
+}
+
+function createPushBody(
+  client1ID: string,
+  localMetas: db.LocalMeta[],
+  schemaVersion: string,
+): ReadonlyJSONObject {
+  return {
+    clientID: client1ID,
+    mutations: localMetas.map(localMeta => ({
+      id: localMeta.mutationID,
+      name: localMeta.mutatorName,
+      args: localMeta.mutatorArgsJSON,
+      timestamp: localMeta.timestamp,
+    })),
+    pushVersion: 0,
+    schemaVersion,
+  };
 }
 
 async function testRecoveringMutationsOfClient(args: {
@@ -345,13 +364,13 @@ test('successfully recovering mutations of multiple clients with mix of schema v
           };
         case client3ID:
           return {
-            cookie: 'pull_cookie_2',
+            cookie: 'pull_cookie_3',
             lastMutationID: client3.mutationID,
             patch: [],
           };
         case client4ID:
           return {
-            cookie: 'pull_cookie_3',
+            cookie: 'pull_cookie_4',
             lastMutationID: client4.mutationID,
             patch: [],
           };
@@ -365,57 +384,23 @@ test('successfully recovering mutations of multiple clients with mix of schema v
 
   const pushCalls = fetchMock.calls(pushURL);
   expect(pushCalls.length).to.equal(3);
-  expect(await pushCalls[0].request.json()).to.deep.equal({
-    clientID: client1ID,
-    mutations: [
-      {
-        id: client1PendingLocalMetas[0].mutationID,
-        name: client1PendingLocalMetas[0].mutatorName,
-        args: client1PendingLocalMetas[0].mutatorArgsJSON,
-        timestamp: client1PendingLocalMetas[0].timestamp,
-      },
-      {
-        id: client1PendingLocalMetas[1].mutationID,
-        name: client1PendingLocalMetas[1].mutatorName,
-        args: client1PendingLocalMetas[1].mutatorArgsJSON,
-        timestamp: client1PendingLocalMetas[1].timestamp,
-      },
-    ],
-    pushVersion: 0,
-    schemaVersion: schemaVersionOfClients1Thru3AndClientRecoveringMutations,
-  });
-  expect(await pushCalls[1].request.json()).to.deep.equal({
-    clientID: client3ID,
-    mutations: [
-      {
-        id: client3PendingLocalMetas[0].mutationID,
-        name: client3PendingLocalMetas[0].mutatorName,
-        args: client3PendingLocalMetas[0].mutatorArgsJSON,
-        timestamp: client3PendingLocalMetas[0].timestamp,
-      },
-    ],
-    pushVersion: 0,
-    schemaVersion: schemaVersionOfClients1Thru3AndClientRecoveringMutations,
-  });
-  expect(await pushCalls[2].request.json()).to.deep.equal({
-    clientID: client4ID,
-    mutations: [
-      {
-        id: client4PendingLocalMetas[0].mutationID,
-        name: client4PendingLocalMetas[0].mutatorName,
-        args: client4PendingLocalMetas[0].mutatorArgsJSON,
-        timestamp: client4PendingLocalMetas[0].timestamp,
-      },
-      {
-        id: client4PendingLocalMetas[1].mutationID,
-        name: client4PendingLocalMetas[1].mutatorName,
-        args: client4PendingLocalMetas[1].mutatorArgsJSON,
-        timestamp: client4PendingLocalMetas[1].timestamp,
-      },
-    ],
-    pushVersion: 0,
-    schemaVersion: schemaVersionOfClient4,
-  });
+  expect(await pushCalls[0].request.json()).to.deep.equal(
+    createPushBody(
+      client1ID,
+      client1PendingLocalMetas,
+      schemaVersionOfClients1Thru3AndClientRecoveringMutations,
+    ),
+  );
+  expect(await pushCalls[1].request.json()).to.deep.equal(
+    createPushBody(
+      client3ID,
+      client3PendingLocalMetas,
+      schemaVersionOfClients1Thru3AndClientRecoveringMutations,
+    ),
+  );
+  expect(await pushCalls[2].request.json()).to.deep.equal(
+    createPushBody(client4ID, client4PendingLocalMetas, schemaVersionOfClient4),
+  );
 
   expect(pullRequestJsonBodies.length).to.equal(3);
   expect(pullRequestJsonBodies[0]).to.deep.equal({
@@ -480,6 +465,528 @@ test('successfully recovering mutations of multiple clients with mix of schema v
   expect(updatedClient4.headHash).to.equal(client4.headHash);
 });
 
+test('if a push error occurs, continues to try to recover other clients', async () => {
+  const schemaVersion = 'testSchema1';
+  // client1 has same schema version as recovering client and 2 mutations to recover
+  const client1ID = 'client1';
+  // client2 has same schema version as recovering client and 1 mutation to recover
+  const client2ID = 'client2';
+  // client3 has same schema version as recovering client and 1 mutation to recover
+  const client3ID = 'client3';
+  const replicacheName = 'recoverMutationsRobustToPushError';
+  const auth = '1';
+  const pushURL = 'https://test.replicache.dev/push';
+  const pullURL = 'https://test.replicache.dev/pull';
+  const rep = await replicacheForTesting(replicacheName, {
+    auth,
+    schemaVersion,
+    pushURL,
+    pullURL,
+  });
+
+  await tickAFewTimes();
+
+  const testPerdag = await createPerdag({
+    replicacheName,
+    schemaVersion,
+  });
+
+  const client1PendingLocalMetas = await createAndPersistClientWithPendingLocal(
+    client1ID,
+    testPerdag,
+    2,
+  );
+  const client2PendingLocalMetas = await createAndPersistClientWithPendingLocal(
+    client2ID,
+    testPerdag,
+    1,
+  );
+  const client3PendingLocalMetas = await createAndPersistClientWithPendingLocal(
+    client3ID,
+    testPerdag,
+    1,
+  );
+
+  const clients = await testPerdag.withRead(read => persist.getClients(read));
+  const client1 = clients.get(client1ID);
+  assertNotUndefined(client1);
+  const client2 = clients.get(client2ID);
+  assertNotUndefined(client2);
+  const client3 = clients.get(client3ID);
+  assertNotUndefined(client3);
+
+  const pushRequestJsonBodies: JSONObject[] = [];
+  const pullRequestJsonBodies: JSONObject[] = [];
+  fetchMock.reset();
+  fetchMock.post(
+    pushURL,
+    async (_url: string, _options: RequestInit, request: Request) => {
+      const requestJson = await request.json();
+      assertJSONObject(requestJson);
+      pushRequestJsonBodies.push(requestJson);
+      const {clientID} = requestJson;
+      if (clientID === client2ID) {
+        throw new Error('test error in push');
+      } else {
+        return 'ok';
+      }
+    },
+  );
+  fetchMock.post(
+    pullURL,
+    async (_url: string, _options: RequestInit, request: Request) => {
+      const requestJson = await request.json();
+      assertJSONObject(requestJson);
+      pullRequestJsonBodies.push(requestJson);
+      const {clientID} = requestJson;
+      switch (clientID) {
+        case client1ID:
+          return {
+            cookie: 'pull_cookie_1',
+            lastMutationID: client1.mutationID,
+            patch: [],
+          };
+        case client3ID:
+          return {
+            cookie: 'pull_cookie_3',
+            lastMutationID: client3.mutationID,
+            patch: [],
+          };
+        default:
+          throw new Error(`Unexpected pull ${requestJson}`);
+      }
+    },
+  );
+
+  await rep.recoverMutations();
+
+  expect(pushRequestJsonBodies.length).to.equal(3);
+  expect(await pushRequestJsonBodies[0]).to.deep.equal(
+    createPushBody(client1ID, client1PendingLocalMetas, schemaVersion),
+  );
+  expect(await pushRequestJsonBodies[1]).to.deep.equal(
+    createPushBody(client2ID, client2PendingLocalMetas, schemaVersion),
+  );
+  expect(await pushRequestJsonBodies[2]).to.deep.equal(
+    createPushBody(client3ID, client3PendingLocalMetas, schemaVersion),
+  );
+
+  expect(pullRequestJsonBodies.length).to.equal(2);
+  expect(pullRequestJsonBodies[0]).to.deep.equal({
+    clientID: client1ID,
+    schemaVersion,
+    cookie: 'cookie_1',
+    lastMutationID: client1.lastServerAckdMutationID,
+    pullVersion: 0,
+  });
+  expect(pullRequestJsonBodies[1]).to.deep.equal({
+    clientID: client3ID,
+    schemaVersion,
+    cookie: 'cookie_1',
+    lastMutationID: client3.lastServerAckdMutationID,
+    pullVersion: 0,
+  });
+
+  const updateClients = await testPerdag.withRead(read =>
+    persist.getClients(read),
+  );
+  const updatedClient1 = updateClients.get(client1ID);
+  assertNotUndefined(updatedClient1);
+  const updatedClient2 = updateClients.get(client2ID);
+  assertNotUndefined(updatedClient2);
+  const updatedClient3 = updateClients.get(client3ID);
+  assertNotUndefined(updatedClient3);
+
+  expect(updatedClient1.mutationID).to.equal(client1.mutationID);
+  // lastServerAckdMutationID is updated to high mutationID as mutations
+  // were recovered
+  expect(updatedClient1.lastServerAckdMutationID).to.equal(client1.mutationID);
+  expect(updatedClient1.headHash).to.equal(client1.headHash);
+
+  expect(updatedClient2.mutationID).to.equal(client2.mutationID);
+  // lastServerAckdMutationID is not updated due to error
+  expect(updatedClient2.lastServerAckdMutationID).to.equal(
+    client2.lastServerAckdMutationID,
+  );
+  expect(updatedClient2.headHash).to.equal(client2.headHash);
+
+  expect(updatedClient3.mutationID).to.equal(client3.mutationID);
+  // lastServerAckdMutationID is updated to high mutationID as mutations
+  // were recovered, despite error in client 2
+  expect(updatedClient3.lastServerAckdMutationID).to.equal(client3.mutationID);
+  expect(updatedClient3.headHash).to.equal(client3.headHash);
+});
+
+test('if an error occurs recovering one client, continues to try to recover other clients', async () => {
+  const schemaVersion = 'testSchema1';
+  // client1 has same schema version as recovering client and 2 mutations to recover
+  const client1ID = 'client1';
+  // client2 has same schema version as recovering client and 1 mutation to recover
+  const client2ID = 'client2';
+  // client3 has same schema version as recovering client and 1 mutation to recover
+  const client3ID = 'client3';
+  const replicacheName = 'recoverMutationsRobustToClientError';
+  const auth = '1';
+  const pushURL = 'https://test.replicache.dev/push';
+  const pullURL = 'https://test.replicache.dev/pull';
+  const rep = await replicacheForTesting(replicacheName, {
+    auth,
+    schemaVersion,
+    pushURL,
+    pullURL,
+  });
+
+  await tickAFewTimes();
+
+  const testPerdag = await createPerdag({
+    replicacheName,
+    schemaVersion,
+  });
+
+  const client1PendingLocalMetas = await createAndPersistClientWithPendingLocal(
+    client1ID,
+    testPerdag,
+    2,
+  );
+  await createAndPersistClientWithPendingLocal(client2ID, testPerdag, 1);
+  const client3PendingLocalMetas = await createAndPersistClientWithPendingLocal(
+    client3ID,
+    testPerdag,
+    1,
+  );
+
+  const clients = await testPerdag.withRead(read => persist.getClients(read));
+  const client1 = clients.get(client1ID);
+  assertNotUndefined(client1);
+  const client2 = clients.get(client2ID);
+  assertNotUndefined(client2);
+  const client3 = clients.get(client3ID);
+  assertNotUndefined(client3);
+
+  const pullRequestJsonBodies: JSONObject[] = [];
+  fetchMock.reset();
+  fetchMock.post(pushURL, 'ok');
+  fetchMock.post(
+    pullURL,
+    async (_url: string, _options: RequestInit, request: Request) => {
+      const requestJson = await request.json();
+      assertJSONObject(requestJson);
+      pullRequestJsonBodies.push(requestJson);
+      const {clientID} = requestJson;
+      switch (clientID) {
+        case client1ID:
+          return {
+            cookie: 'pull_cookie_1',
+            lastMutationID: client1.mutationID,
+            patch: [],
+          };
+        case client3ID:
+          return {
+            cookie: 'pull_cookie_3',
+            lastMutationID: client3.mutationID,
+            patch: [],
+          };
+        default:
+          throw new Error(`Unexpected pull ${requestJson}`);
+      }
+    },
+  );
+
+  const lazyDagWithWriteStub = sinon.stub(dag.LazyStore.prototype, 'withWrite');
+  const testErrorMsg = 'Test dag.LazyStore.withWrite error';
+  lazyDagWithWriteStub.onSecondCall().throws(testErrorMsg);
+  lazyDagWithWriteStub.callThrough();
+
+  const consoleErrorStub = sinon.stub(console, 'error');
+
+  await rep.recoverMutations();
+
+  expect(consoleErrorStub.callCount).to.equal(1);
+  expect(consoleErrorStub.firstCall.args.join(' ')).to.contain(testErrorMsg);
+
+  const pushCalls = fetchMock.calls(pushURL);
+  expect(pushCalls.length).to.equal(2);
+  expect(await pushCalls[0].request.json()).to.deep.equal(
+    createPushBody(client1ID, client1PendingLocalMetas, schemaVersion),
+  );
+  expect(await pushCalls[1].request.json()).to.deep.equal(
+    createPushBody(client3ID, client3PendingLocalMetas, schemaVersion),
+  );
+
+  expect(pullRequestJsonBodies.length).to.equal(2);
+  expect(pullRequestJsonBodies[0]).to.deep.equal({
+    clientID: client1ID,
+    schemaVersion,
+    cookie: 'cookie_1',
+    lastMutationID: client1.lastServerAckdMutationID,
+    pullVersion: 0,
+  });
+  expect(pullRequestJsonBodies[1]).to.deep.equal({
+    clientID: client3ID,
+    schemaVersion,
+    cookie: 'cookie_1',
+    lastMutationID: client3.lastServerAckdMutationID,
+    pullVersion: 0,
+  });
+
+  const updateClients = await testPerdag.withRead(read =>
+    persist.getClients(read),
+  );
+  const updatedClient1 = updateClients.get(client1ID);
+  assertNotUndefined(updatedClient1);
+  const updatedClient2 = updateClients.get(client2ID);
+  assertNotUndefined(updatedClient2);
+  const updatedClient3 = updateClients.get(client3ID);
+  assertNotUndefined(updatedClient3);
+
+  expect(updatedClient1.mutationID).to.equal(client1.mutationID);
+  // lastServerAckdMutationID is updated to high mutationID as mutations
+  // were recovered
+  expect(updatedClient1.lastServerAckdMutationID).to.equal(client1.mutationID);
+  expect(updatedClient1.headHash).to.equal(client1.headHash);
+
+  expect(updatedClient2.mutationID).to.equal(client2.mutationID);
+  // lastServerAckdMutationID is not updated due to error
+  expect(updatedClient2.lastServerAckdMutationID).to.equal(
+    client2.lastServerAckdMutationID,
+  );
+  expect(updatedClient2.headHash).to.equal(client2.headHash);
+
+  expect(updatedClient3.mutationID).to.equal(client3.mutationID);
+  // lastServerAckdMutationID is updated to high mutationID as mutations
+  // were recovered, despite error in client 2
+  expect(updatedClient3.lastServerAckdMutationID).to.equal(client3.mutationID);
+  expect(updatedClient3.headHash).to.equal(client3.headHash);
+});
+
+test('if an error occurs recovering one db, continues to try to recover clients from other dbs', async () => {
+  const schemaVersionOfClient1 = 'testSchema1';
+  const schemaVersionOfClient2 = 'testSchema2';
+  const schemaVersionOfRecoveringClient = 'testSchemaOfRecovering';
+  const client1ID = 'client1';
+  const client2ID = 'client2';
+  const replicacheName = 'recoverMutationsRobustToDBError';
+  const auth = '1';
+  const pushURL = 'https://test.replicache.dev/push';
+  const pullURL = 'https://test.replicache.dev/pull';
+  const rep = await replicacheForTesting(replicacheName, {
+    auth,
+    schemaVersion: schemaVersionOfRecoveringClient,
+    pushURL,
+    pullURL,
+  });
+
+  await tickAFewTimes();
+
+  const testPerdagForClient1 = await createPerdag({
+    replicacheName,
+    schemaVersion: schemaVersionOfClient1,
+  });
+  await createAndPersistClientWithPendingLocal(
+    client1ID,
+    testPerdagForClient1,
+    1,
+  );
+
+  const testPerdagForClient2 = await createPerdag({
+    replicacheName,
+    schemaVersion: schemaVersionOfClient2,
+  });
+  const client2PendingLocalMetas = await createAndPersistClientWithPendingLocal(
+    client2ID,
+    testPerdagForClient2,
+    1,
+  );
+
+  const client1 = await testPerdagForClient1.withRead(read =>
+    persist.getClient(client1ID, read),
+  );
+  assertNotUndefined(client1);
+
+  const client2 = await testPerdagForClient2.withRead(read =>
+    persist.getClient(client2ID, read),
+  );
+  assertNotUndefined(client2);
+
+  const pullRequestJsonBodies: JSONObject[] = [];
+  fetchMock.reset();
+  fetchMock.post(pushURL, 'ok');
+  fetchMock.post(
+    pullURL,
+    async (_url: string, _options: RequestInit, request: Request) => {
+      const requestJson = await request.json();
+      assertJSONObject(requestJson);
+      pullRequestJsonBodies.push(requestJson);
+      const {clientID} = requestJson;
+      switch (clientID) {
+        case client2ID:
+          return {
+            cookie: 'pull_cookie_2',
+            lastMutationID: client2.mutationID,
+            patch: [],
+          };
+        default:
+          throw new Error(`Unexpected pull ${requestJson}`);
+      }
+    },
+  );
+
+  const dagStoreWithReadStub = sinon.stub(dag.StoreImpl.prototype, 'withRead');
+  const testErrorMsg = 'Test dag.StoreImpl.withRead error';
+  dagStoreWithReadStub.onSecondCall().throws(testErrorMsg);
+  dagStoreWithReadStub.callThrough();
+
+  const consoleErrorStub = sinon.stub(console, 'error');
+
+  await rep.recoverMutations();
+
+  expect(consoleErrorStub.callCount).to.equal(1);
+  expect(consoleErrorStub.firstCall.args.join(' ')).to.contain(testErrorMsg);
+
+  const pushCalls = fetchMock.calls(pushURL);
+  expect(pushCalls.length).to.equal(1);
+  expect(await pushCalls[0].request.json()).to.deep.equal(
+    createPushBody(client2ID, client2PendingLocalMetas, schemaVersionOfClient2),
+  );
+
+  expect(pullRequestJsonBodies.length).to.equal(1);
+  expect(pullRequestJsonBodies[0]).to.deep.equal({
+    clientID: client2ID,
+    schemaVersion: schemaVersionOfClient2,
+    cookie: 'cookie_1',
+    lastMutationID: client2.lastServerAckdMutationID,
+    pullVersion: 0,
+  });
+
+  const updatedClient1 = await testPerdagForClient1.withRead(read =>
+    persist.getClient(client1ID, read),
+  );
+  assertNotUndefined(updatedClient1);
+
+  const updatedClient2 = await testPerdagForClient2.withRead(read =>
+    persist.getClient(client2ID, read),
+  );
+  assertNotUndefined(updatedClient2);
+
+  expect(updatedClient1.mutationID).to.equal(client1.mutationID);
+  // lastServerAckdMutationID not updated due to error when recovering this
+  // client's db
+  expect(updatedClient1.lastServerAckdMutationID).to.equal(
+    client1.lastServerAckdMutationID,
+  );
+  expect(updatedClient1.headHash).to.equal(client1.headHash);
+
+  expect(updatedClient2.mutationID).to.equal(client2.mutationID);
+  // lastServerAckdMutationID is updated to high mutationID as mutations
+  // were recovered despite error in other db
+  expect(updatedClient2.lastServerAckdMutationID).to.equal(client2.mutationID);
+  expect(updatedClient2.headHash).to.equal(client2.headHash);
+});
+
+test('mutation recovery exits early if Replicache is closed', async () => {
+  const schemaVersion = 'testSchema1';
+  const client1ID = 'client1';
+  const client2ID = 'client2';
+  const replicacheName = 'recoverMutationsRobustToClientError';
+  const auth = '1';
+  const pushURL = 'https://test.replicache.dev/push';
+  const pullURL = 'https://test.replicache.dev/pull';
+  const rep = await replicacheForTesting(replicacheName, {
+    auth,
+    schemaVersion,
+    pushURL,
+    pullURL,
+  });
+
+  await tickAFewTimes();
+
+  const testPerdag = await createPerdag({
+    replicacheName,
+    schemaVersion,
+  });
+
+  const client1PendingLocalMetas = await createAndPersistClientWithPendingLocal(
+    client1ID,
+    testPerdag,
+    1,
+  );
+  await createAndPersistClientWithPendingLocal(client2ID, testPerdag, 1);
+
+  const clients = await testPerdag.withRead(read => persist.getClients(read));
+  const client1 = clients.get(client1ID);
+  assertNotUndefined(client1);
+  const client2 = clients.get(client2ID);
+  assertNotUndefined(client2);
+
+  const pullRequestJsonBodies: JSONObject[] = [];
+  fetchMock.reset();
+  fetchMock.post(pushURL, 'ok');
+  fetchMock.post(
+    pullURL,
+    async (_url: string, _options: RequestInit, request: Request) => {
+      const requestJson = await request.json();
+      assertJSONObject(requestJson);
+      pullRequestJsonBodies.push(requestJson);
+      const {clientID} = requestJson;
+      switch (clientID) {
+        case client1ID:
+          return {
+            cookie: 'pull_cookie_1',
+            lastMutationID: client1.mutationID,
+            patch: [],
+          };
+        default:
+          throw new Error(`Unexpected pull ${requestJson}`);
+      }
+    },
+  );
+
+  // At the end of recovering client1 close the recovering Replicache instance
+  const lazyDagWithWriteStub = sinon.stub(dag.LazyStore.prototype, 'close');
+  lazyDagWithWriteStub.onFirstCall().callsFake(async () => {
+    await rep.close();
+  });
+  lazyDagWithWriteStub.callThrough();
+
+  await rep.recoverMutations();
+
+  const pushCalls = fetchMock.calls(pushURL);
+  expect(pushCalls.length).to.equal(1);
+  expect(await pushCalls[0].request.json()).to.deep.equal(
+    createPushBody(client1ID, client1PendingLocalMetas, schemaVersion),
+  );
+
+  expect(pullRequestJsonBodies.length).to.equal(1);
+  expect(pullRequestJsonBodies[0]).to.deep.equal({
+    clientID: client1ID,
+    schemaVersion,
+    cookie: 'cookie_1',
+    lastMutationID: client1.lastServerAckdMutationID,
+    pullVersion: 0,
+  });
+
+  const updateClients = await testPerdag.withRead(read =>
+    persist.getClients(read),
+  );
+  const updatedClient1 = updateClients.get(client1ID);
+  assertNotUndefined(updatedClient1);
+  const updatedClient2 = updateClients.get(client2ID);
+  assertNotUndefined(updatedClient2);
+
+  expect(updatedClient1.mutationID).to.equal(client1.mutationID);
+  // lastServerAckdMutationID is updated to high mutationID as mutations
+  // were recovered
+  expect(updatedClient1.lastServerAckdMutationID).to.equal(client1.mutationID);
+  expect(updatedClient1.headHash).to.equal(client1.headHash);
+
+  expect(updatedClient2.mutationID).to.equal(client2.mutationID);
+  // lastServerAckdMutationID is not updated due to close
+  expect(updatedClient2.lastServerAckdMutationID).to.equal(
+    client2.lastServerAckdMutationID,
+  );
+  expect(updatedClient2.headHash).to.equal(client2.headHash);
+});
+
 test('mutation recovery is invoked at startup', async () => {
   const rep = await replicacheForTesting('mutation-recovery-startup');
   expect(rep.recoverMutationsSpy.callCount).to.equal(1);
@@ -526,51 +1033,4 @@ test('mutation recovery is invoked on 5 minute interval', async () => {
   expect(rep.recoverMutationsSpy.callCount).to.equal(2);
   await clock.tickAsync(5 * 60 * 1000);
   expect(rep.recoverMutationsSpy.callCount).to.equal(3);
-});
-
-test('mutation recovery interrupted by close does no throw an error', async () => {
-  const schemaVersion = 'test_schema';
-  const client1ID = 'client1';
-  const replicacheName = `recoverMutations${schemaVersion}recovering${schemaVersion}`;
-  const auth = '1';
-  const pushURL = 'https://test.replicache.dev/push';
-  const pullURL = 'https://test.replicache.dev/pull';
-  const rep = await replicacheForTesting(replicacheName, {
-    auth,
-    schemaVersion,
-    pushURL,
-    pullURL,
-  });
-
-  await tickAFewTimes();
-
-  const testPerdag = await createPerdag({
-    replicacheName,
-    schemaVersion,
-  });
-
-  await createAndPersistClientWithPendingLocal(client1ID, testPerdag, 2);
-  const client1 = await testPerdag.withRead(read =>
-    persist.getClient(client1ID, read),
-  );
-  assertNotUndefined(client1);
-
-  fetchMock.reset();
-  fetchMock.post(pushURL, () => {
-    void rep.close();
-    return 'ok';
-  });
-  fetchMock.post(pullURL, {
-    cookie: 'pull_cookie_1',
-    lastMutationID: client1.mutationID,
-    patch: [],
-  });
-
-  await rep.recoverMutations();
-
-  const updatedClient1 = await testPerdag.withRead(read =>
-    persist.getClient(client1ID, read),
-  );
-  // not changed because interrupted by close
-  expect(updatedClient1).to.deep.equal(client1);
 });


### PR DESCRIPTION
**Problem**
If the Mutation Recovery process stops on the first error encountered.  This means a single problematic db or client can prevent recovery of all other clients.  

**Solution**
Updates Mutation Recovery logic to be more robust against errors.  If an error occurs recovering a particular 
client or db, the logic will now log that error, and continue trying to recover other clients/dbs. 

Adding the above robustness requires the process to handle the Replicache instance being closed more explicitly.  Previously the process would stop on the first error encountered due to the Replicache intance being closed. 
This change updates the logic to check if this Replicache instance is closed before processing each db, and 
each client inside each db, and exits early if this Replicache instance is closed.
