### PR TITLE
feat: Simplified Dueling Dags - Mutation Recovery - Optimize mutation recovery at startup by reusing client map read by client init.

### DIFF
--- a/src/persist/clients.test.ts
+++ b/src/persist/clients.test.ts
@@ -536,7 +536,15 @@ test('updateClients throws errors if chunk pointed to by clients head does not c
 test('initClient creates new empty snapshot when no existing snapshot to bootstrap from', async () => {
   const dagStore = new dag.TestStore();
   clock.tick(4000);
-  const [clientId, client] = await initClient(dagStore);
+  const [clientId, client, clients] = await initClient(dagStore);
+
+  expect(clients).to.deep.equal(
+    new Map(
+      Object.entries({
+        [clientId]: client,
+      }),
+    ),
+  );
 
   await dagStore.withRead(async (read: dag.Read) => {
     // New client was added to the client map.
@@ -589,7 +597,9 @@ test('initClient bootstraps from base snapshot of client with highest heartbeat'
   await setClients(clientMap, dagStore);
 
   clock.tick(4000);
-  const [clientId, client] = await initClient(dagStore);
+  const [clientId, client, clients] = await initClient(dagStore);
+
+  expect(clients).to.deep.equal(new Map(clientMap).set(clientId, client));
 
   await dagStore.withRead(async (read: dag.Read) => {
     // New client was added to the client map.

--- a/src/persist/clients.ts
+++ b/src/persist/clients.ts
@@ -122,7 +122,7 @@ export async function getClient(
 
 export async function initClient(
   dagStore: dag.Store,
-): Promise<[sync.ClientID, Client]> {
+): Promise<[sync.ClientID, Client, ClientMap]> {
   const newClientID = makeUuid();
   const updatedClients = await updateClients(async clients => {
     let bootstrapClient: Client | undefined;
@@ -190,7 +190,7 @@ export async function initClient(
   }, dagStore);
   const newClient = updatedClients.get(newClientID);
   assertNotUndefined(newClient);
-  return [newClientID, newClient];
+  return [newClientID, newClient, updatedClients];
 }
 
 function hashOfClients(clients: ClientMap): Promise<Hash> {


### PR DESCRIPTION
**Problem**
Mutation recovery regressed our median startup scan benchmark by ~20% (25 ms to 30 ms).

**Solution**
Try to mitigate by reusing the client map read by `persist.initClient`, rather than reading it in a new IndexedDB transaction. 