### PR TITLE
feat: Update Replicache Format Version from 3 to 4 for v9 release.

### DIFF
--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -58,7 +58,7 @@ export type Poke = {
 
 export const httpStatusUnauthorized = 401;
 
-export const REPLICACHE_FORMAT_VERSION = 3;
+export const REPLICACHE_FORMAT_VERSION = 4;
 const LAZY_STORE_SOURCE_CHUNK_CACHE_SIZE_LIMIT = 100 * 2 ** 20; // 100 MB
 const MUTATION_RECOVERY_LAZY_STORE_SOURCE_CHUNK_CACHE_SIZE_LIMIT = 10 * 2 ** 20; // 10 MB
 const RECOVER_MUTATIONS_INTERVAL_MS = 5 * 60 * 1000; // 5 mins


### PR DESCRIPTION
Major change to the persisted dag's structure.  The per dag now has a single head `clients` that contains a `ClientMap`.  
See [Simplified Dueling Dags design doc](https://www.notion.so/replicache/Simplified-DD1-1ed242a8c1094d9ca3734c46d65ffce4) for details.