### PR TITLE
refactor!: Rename ReplicacheOptions.name and Replicache.name to userID.

### DIFF
--- a/perf/replicache.ts
+++ b/perf/replicache.ts
@@ -72,7 +72,7 @@ class ReplicacheWithPersist<MD extends MutatorDefs> extends Replicache {
 }
 
 async function setupPersistedData(
-  replicacheName: string,
+  userID: string,
   numKeys: number,
 ): Promise<void> {
   const randomValues = jsonArrayTestData(numKeys, valSize);
@@ -92,7 +92,7 @@ async function setupPersistedData(
     // so that a snapshot commit is created, which new clients
     // can use to bootstrap.
     const rep = (repToClose = new ReplicacheWithPersist({
-      name: replicacheName,
+      userID,
       pullInterval: null,
       puller: async (_: Request) => {
         return {
@@ -124,14 +124,14 @@ export function benchmarkStartupUsingBasicReadsFromPersistedData(opts: {
   numKeysPersisted: number;
   numKeysToRead: number;
 }): Benchmark {
-  const repName = makeRepName();
+  const userID = makeUserID();
   let repToClose: Replicache | undefined;
   return {
     name: `startup read ${valSize}x${opts.numKeysToRead} from ${valSize}x${opts.numKeysPersisted} stored`,
     group: 'replicache',
     byteSize: opts.numKeysToRead * valSize,
     async setup() {
-      await setupPersistedData(repName, opts.numKeysPersisted);
+      await setupPersistedData(userID, opts.numKeysPersisted);
     },
     async setupEach() {
       setupIDBDatabasesStoreForTest();
@@ -150,7 +150,7 @@ export function benchmarkStartupUsingBasicReadsFromPersistedData(opts: {
       ).map(i => `key${i}`);
       bencher.reset();
       const rep = (repToClose = new Replicache({
-        name: repName,
+        userID,
         pullInterval: null,
       }));
       let getCount = 0;
@@ -172,14 +172,14 @@ export function benchmarkStartupUsingScanFromPersistedData(opts: {
   numKeysPersisted: number;
   numKeysToRead: number;
 }): Benchmark {
-  const repName = makeRepName();
+  const userID = makeUserID();
   let repToClose: Replicache | undefined;
   return {
     name: `startup scan ${valSize}x${opts.numKeysToRead} from ${valSize}x${opts.numKeysPersisted} stored`,
     group: 'replicache',
     byteSize: opts.numKeysToRead * valSize,
     async setup() {
-      await setupPersistedData(repName, opts.numKeysPersisted);
+      await setupPersistedData(userID, opts.numKeysPersisted);
     },
     async setupEach() {
       setupIDBDatabasesStoreForTest();
@@ -203,7 +203,7 @@ export function benchmarkStartupUsingScanFromPersistedData(opts: {
       const randomStartKey = sortedKeys[randomIndex];
       bencher.reset();
       const rep = (repToClose = new Replicache({
-        name: repName,
+        userID,
         pullInterval: null,
       }));
       await rep.query(async (tx: ReadTransaction) => {
@@ -441,16 +441,16 @@ export function benchmarkWriteSubRead(opts: {
   };
 }
 
-function makeRepName(): string {
-  return `bench${uuid()}`;
+function makeUserID(): string {
+  return `user-${uuid()}`;
 }
 
 function makeRep<MD extends MutatorDefs>(
-  options: Omit<ReplicacheOptions<MD>, 'name'> = {},
+  options: Omit<ReplicacheOptions<MD>, 'userID'> = {},
 ) {
-  const name = makeRepName();
+  const userID = makeUserID();
   return new Replicache<MD>({
-    name,
+    userID,
     pullInterval: null,
     ...options,
   });

--- a/src/persist/idb-databases-store.test.ts
+++ b/src/persist/idb-databases-store.test.ts
@@ -11,7 +11,7 @@ test('putDatabase with no existing record in db', async () => {
   const store = new IDBDatabasesStore(_ => new TestMemStore());
   const testDB = {
     name: 'testName',
-    replicacheName: 'testReplicacheName',
+    userID: 'testUserID',
     replicacheFormatVersion: 1,
     schemaVersion: 'testSchemaVersion',
   };
@@ -27,7 +27,7 @@ test('putDatabase sequence', async () => {
   const store = new IDBDatabasesStore(_ => new TestMemStore());
   const testDB1 = {
     name: 'testName1',
-    replicacheName: 'testReplicacheName1',
+    userID: 'testUserID1',
     replicacheFormatVersion: 1,
     schemaVersion: 'testSchemaVersion1',
   };
@@ -41,7 +41,7 @@ test('putDatabase sequence', async () => {
 
   const testDB2 = {
     name: 'testName2',
-    replicacheName: 'testReplicacheName2',
+    userID: 'testUserID2',
     replicacheFormatVersion: 2,
     schemaVersion: 'testSchemaVersion2',
   };
@@ -68,7 +68,7 @@ test('clear', async () => {
   const store = new IDBDatabasesStore(_ => new TestMemStore());
   const testDB1 = {
     name: 'testName1',
-    replicacheName: 'testReplicacheName1',
+    userID: 'testUserID1',
     replicacheFormatVersion: 1,
     schemaVersion: 'testSchemaVersion1',
   };
@@ -86,7 +86,7 @@ test('clear', async () => {
 
   const testDB2 = {
     name: 'testName2',
-    replicacheName: 'testReplicacheName2',
+    userID: 'testUserID2',
     replicacheFormatVersion: 2,
     schemaVersion: 'testSchemaVersion2',
   };

--- a/src/persist/idb-databases-store.ts
+++ b/src/persist/idb-databases-store.ts
@@ -27,7 +27,7 @@ export type IndexedDBName = string;
 
 export type IndexedDBDatabase = {
   name: IndexedDBName;
-  replicacheName: string;
+  userID: string;
   replicacheFormatVersion: number;
   schemaVersion: string;
 };
@@ -50,7 +50,7 @@ function assertIndexedDBDatabase(
 ): asserts value is IndexedDBDatabase {
   assertObject(value);
   assertString(value.name);
-  assertString(value.replicacheName);
+  assertString(value.userID);
   assertNumber(value.replicacheFormatVersion);
   assertString(value.schemaVersion);
 }

--- a/src/replicache-mutation-recovery.test.ts
+++ b/src/replicache-mutation-recovery.test.ts
@@ -4,7 +4,7 @@ import {
   tickAFewTimes,
   dbsToDrop,
   clock,
-  createReplicacheNameForTest,
+  createUserIDForTest,
 } from './test-util';
 import {makeIdbName, REPLICACHE_FORMAT_VERSION} from './replicache';
 import {addGenesis, addLocal, addSnapshot, Chain} from './db/test-helpers';
@@ -38,11 +38,11 @@ teardown(async () => {
 });
 
 async function createPerdag(args: {
-  replicacheName: string;
+  userID: string;
   schemaVersion: string;
 }): Promise<dag.Store> {
-  const {replicacheName, schemaVersion} = args;
-  const idbName = makeIdbName(replicacheName, schemaVersion);
+  const {userID, schemaVersion} = args;
+  const idbName = makeIdbName(userID, schemaVersion);
   dbsToDrop.add(idbName);
   const idb = new kv.IDBStore(idbName);
 
@@ -50,7 +50,7 @@ async function createPerdag(args: {
   try {
     await idbDatabases.putDatabase({
       name: idbName,
-      replicacheName,
+      userID,
       schemaVersion,
       replicacheFormatVersion: REPLICACHE_FORMAT_VERSION,
     });
@@ -137,7 +137,7 @@ async function testRecoveringMutationsOfClient(args: {
   await tickAFewTimes();
 
   const testPerdag = await createPerdag({
-    replicacheName: rep.name,
+    userID: rep.userID,
     schemaVersion: schemaVersionOfClientWPendingMutations,
   });
 
@@ -250,9 +250,7 @@ test('client does not attempt to recover mutations from IndexedDB with different
   await tickAFewTimes();
 
   const testPerdag = await createPerdag({
-    replicacheName: createReplicacheNameForTest(
-      replicachePartialNameOfClientWPendingMutations,
-    ),
+    userID: createUserIDForTest(replicachePartialNameOfClientWPendingMutations),
     schemaVersion,
   });
 
@@ -307,7 +305,7 @@ test('successfully recovering mutations of multiple clients with mix of schema v
   await tickAFewTimes();
 
   const testPerdagForClients1Thru3 = await createPerdag({
-    replicacheName: rep.name,
+    userID: rep.userID,
     schemaVersion: schemaVersionOfClients1Thru3AndClientRecoveringMutations,
   });
 
@@ -329,7 +327,7 @@ test('successfully recovering mutations of multiple clients with mix of schema v
   );
 
   const testPerdagForClient4 = await createPerdag({
-    replicacheName: rep.name,
+    userID: rep.userID,
     schemaVersion: schemaVersionOfClient4,
   });
   const client4PendingLocalMetas = await createAndPersistClientWithPendingLocal(
@@ -495,7 +493,7 @@ test('if a push error occurs, continues to try to recover other clients', async 
   await tickAFewTimes();
 
   const testPerdag = await createPerdag({
-    replicacheName: rep.name,
+    userID: rep.userID,
     schemaVersion,
   });
 
@@ -647,7 +645,7 @@ test('if an error occurs recovering one client, continues to try to recover othe
   await tickAFewTimes();
 
   const testPerdag = await createPerdag({
-    replicacheName: rep.name,
+    userID: rep.userID,
     schemaVersion,
   });
 
@@ -787,7 +785,7 @@ test('if an error occurs recovering one db, continues to try to recover clients 
   await tickAFewTimes();
 
   const testPerdagForClient1 = await createPerdag({
-    replicacheName: rep.name,
+    userID: rep.userID,
     schemaVersion: schemaVersionOfClient1,
   });
   await createAndPersistClientWithPendingLocal(
@@ -797,7 +795,7 @@ test('if an error occurs recovering one db, continues to try to recover clients 
   );
 
   const testPerdagForClient2 = await createPerdag({
-    replicacheName: rep.name,
+    userID: rep.userID,
     schemaVersion: schemaVersionOfClient2,
   });
   const client2PendingLocalMetas = await createAndPersistClientWithPendingLocal(
@@ -909,7 +907,7 @@ test('mutation recovery exits early if Replicache is closed', async () => {
   await tickAFewTimes();
 
   const testPerdag = await createPerdag({
-    replicacheName: rep.name,
+    userID: rep.userID,
     schemaVersion,
   });
 

--- a/src/replicache-options.ts
+++ b/src/replicache-options.ts
@@ -37,14 +37,20 @@ export interface ReplicacheOptions<MD extends MutatorDefs> {
   pullURL?: string;
 
   /**
-   * The name of the Replicache database.
+   * A unique identifier for the user authenticated by
+   * [[ReplicacheOptions.auth]]. Must be non-empty.
    *
-   * It is important to use user specific names so that if there are multiple
-   * tabs open for different distinct users the data is kept seperate.
+   * This is used to keep different user's state separate.
    *
-   * You can use multiple Replicache instances as long as the names are unique.
+   * For efficiency, a new Replicache instance will initialize its state from
+   * the persisted state of an existing Replicache instance with the same
+   * `userID`, domain and browser profile.
+   *
+   * Mutations from one Replicache instance may be pushed using the
+   * [[ReplicacheOptions.auth]] of another Replicache instance with the same
+   * `userID`, domain and browser profile.
    */
-  name: string;
+  userID: string;
 
   /**
    * The schema version of the data understood by this application. This enables

--- a/src/replicache-types.test.ts
+++ b/src/replicache-types.test.ts
@@ -4,7 +4,7 @@ import type {WriteTransaction} from './transactions';
 // Only used for type checking
 test.skip('mutator optional args [type checking only]', async () => {
   const rep = new Replicache({
-    name: 'test-types',
+    userID: 'test-types',
     mutators: {
       mut: async (tx: WriteTransaction, x: number) => {
         console.log(tx);
@@ -45,7 +45,7 @@ test.skip('mutator optional args [type checking only]', async () => {
   console.log(res4);
 
   // This should be an error!
-  // new Replicache({name: 'test-types-2', {
+  // new Replicache({userID: 'test-types-2', {
   //   mutators: {
   //     // @ts-expect-error symbol is not a JSONValue
   //     mut5: (tx: WriteTransaction, x: symbol) => {
@@ -59,7 +59,7 @@ test.skip('mutator optional args [type checking only]', async () => {
 // Only used for type checking
 test.skip('Test partial JSONObject [type checking only]', async () => {
   const rep = new Replicache({
-    name: 'test-types',
+    userID: 'test-types',
     mutators: {
       mut: async (tx: WriteTransaction, todo: Partial<Todo>) => {
         console.log(tx);
@@ -84,7 +84,7 @@ test.skip('Test partial JSONObject [type checking only]', async () => {
 // Only used for type checking
 test.skip('Test register param [type checking only]', async () => {
   const rep = new Replicache({
-    name: 'test-types',
+    userID: 'test-types',
     mutators: {
       mut: async (tx: WriteTransaction) => {
         console.log(tx);
@@ -119,7 +119,7 @@ test.skip('Test register param [type checking only]', async () => {
   /* eslint-enable prefer-destructuring */
 
   new Replicache({
-    name: 'test-types',
+    userID: 'test-types',
     mutators: {
       // @ts-expect-error Type '(tx: WriteTransaction, a: string, b: number) =>
       //   Promise<void>' is not assignable to type '(tx: WriteTransaction,
@@ -133,7 +133,7 @@ test.skip('Test register param [type checking only]', async () => {
 
 // Only used for type checking
 test.skip('Key type for scans [type checking only]', async () => {
-  const rep = new Replicache({name: 'test-types'});
+  const rep = new Replicache({userID: 'test-types'});
 
   for await (const k of rep.scan({indexName: 'n'}).keys()) {
     // @ts-expect-error Type '[secondary: string, primary?: string | undefined]' is not assignable to type 'string'.ts(2322)
@@ -183,7 +183,7 @@ test.skip('mut [type checking only]', async () => {
   type ToRecord<T> = {[P in keyof T]: T[P]};
 
   const rep = new Replicache({
-    name: 'type-checking-only',
+    userID: 'type-checking-only',
     mutators: {
       a: (tx: WriteTransaction) => {
         console.log(tx);
@@ -292,19 +292,19 @@ test.skip('mut [type checking only]', async () => {
   await rep.mutate.h(null);
 
   {
-    const rep = new Replicache({name: 'type-checking-only', mutators: {}});
+    const rep = new Replicache({userID: 'type-checking-only', mutators: {}});
     // @ts-expect-error Property 'abc' does not exist on type 'MakeMutators<{}>'.ts(2339)
     rep.mutate.abc(43);
   }
 
   {
-    const rep = new Replicache({name: 'type-checking-only'});
+    const rep = new Replicache({userID: 'type-checking-only'});
     // @ts-expect-error Property 'abc' does not exist on type 'MakeMutators<{}>'.ts(2339)
     rep.mutate.abc(1, 2, 3);
   }
 
   {
-    const rep = new Replicache({name: 'type-checking-only'});
+    const rep = new Replicache({userID: 'type-checking-only'});
     // @ts-expect-error Property 'abc' does not exist on type 'MakeMutators<{}>'.ts(2339)
     rep.mutate.abc(1, 2, 3);
   }
@@ -312,7 +312,7 @@ test.skip('mut [type checking only]', async () => {
 
 // Only used for type checking
 test.skip('scan with index [type checking only]', async () => {
-  const rep = new Replicache({name: 'scan-with-index'});
+  const rep = new Replicache({userID: 'scan-with-index'});
 
   (await rep.scan({indexName: 'a'}).keys().toArray()) as [
     secondary: string,

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -56,14 +56,16 @@ async function expectAsyncFuncToThrow(f: () => unknown, c: unknown) {
   (await expectPromiseToReject(f())).to.be.instanceof(c);
 }
 
-test('name is required', () => {
+test('userID is required', () => {
   expect(
     () => new Replicache({} as ReplicacheOptions<Record<string, never>>),
-  ).to.throw(/name.*required/);
+  ).to.throw(/userID.*required/);
 });
 
-test('name cannot be empty', () => {
-  expect(() => new Replicache({name: ''})).to.throw(/name.*must be non-empty/);
+test('userID cannot be empty', () => {
+  expect(() => new Replicache({userID: ''})).to.throw(
+    /userID.*must be non-empty/,
+  );
 });
 
 test('get, has, scan on empty db', async () => {
@@ -281,7 +283,7 @@ test('scan', async () => {
   );
 });
 
-test('name', async () => {
+test('userID', async () => {
   const repA = await replicacheForTesting('a', {mutators: {addData}});
   const repB = await replicacheForTesting('b', {mutators: {addData}});
 
@@ -1440,7 +1442,7 @@ test('logLevel', async () => {
   expect(
     debug
       .getCalls()
-      .some(call => (call.firstArg + '').startsWith(`db=${rep.name}`)),
+      .some(call => (call.firstArg + '').startsWith(`db=${rep.idbName}`)),
   ).to.equal(true);
   expect(
     debug.getCalls().some(call => call.firstArg.startsWith('PULL')),
@@ -1759,23 +1761,23 @@ test('clientID', async () => {
   const re =
     /^[0-9:A-z]{8}-[0-9:A-z]{4}-4[0-9:A-z]{3}-[0-9:A-z]{4}-[0-9:A-z]{12}$/;
 
-  let rep = await replicacheForTesting('clientID');
+  let rep = await replicacheForTesting('userID');
   const clientID = await rep.clientID;
   expect(clientID).to.match(re);
   await rep.close();
 
-  const rep2 = await replicacheForTesting('clientID2');
+  const rep2 = await replicacheForTesting('userID2');
   const clientID2 = await rep2.clientID;
   expect(clientID2).to.match(re);
   expect(clientID2).to.not.equal(clientID);
 
-  rep = await replicacheForTesting('clientID');
+  rep = await replicacheForTesting('userID3');
   const clientID3 = await rep.clientID;
   expect(clientID3).to.match(re);
   // With SDD we never reuse client IDs.
   expect(clientID3).to.not.equal(clientID);
 
-  const rep4 = new Replicache({name: 'clientID4', pullInterval: null});
+  const rep4 = new Replicache({userID: 'userID4', pullInterval: null});
   const clientID4 = await rep4.clientID;
   expect(clientID4).to.match(re);
   await rep4.close();
@@ -1962,15 +1964,15 @@ test('online', async () => {
 
 test('overlapping open/close', async () => {
   const pullInterval = 60_000;
-  const name = 'overlapping-open-close';
+  const userID = 'overlapping-open-close';
 
-  const rep = new Replicache({name, pullInterval});
+  const rep = new Replicache({userID, pullInterval});
   const p = rep.close();
 
-  const rep2 = new Replicache({name, pullInterval});
+  const rep2 = new Replicache({userID, pullInterval});
   const p2 = rep2.close();
 
-  const rep3 = new Replicache({name, pullInterval});
+  const rep3 = new Replicache({userID, pullInterval});
   const p3 = rep3.close();
 
   await p;
@@ -1978,10 +1980,10 @@ test('overlapping open/close', async () => {
   await p3;
 
   {
-    const rep = new Replicache({name, pullInterval});
+    const rep = new Replicache({userID, pullInterval});
     await rep.clientID;
     const p = rep.close();
-    const rep2 = new Replicache({name, pullInterval});
+    const rep2 = new Replicache({userID, pullInterval});
     await rep2.clientID;
     const p2 = rep2.close();
     await p;

--- a/src/test-util.ts
+++ b/src/test-util.ts
@@ -80,52 +80,49 @@ export async function deleteAllDatabases(): Promise<void> {
   dbsToDrop.clear();
 }
 
-const partialNamesToRepliacheNames: Map<string, string> = new Map();
-/** Namespace replicache names to isolate tests' indexeddb state. */
-export function createReplicacheNameForTest(partialName: string): string {
-  let replicacheName = partialNamesToRepliacheNames.get(partialName);
-  if (!replicacheName) {
+const partialUserIDsToUserIDs: Map<string, string> = new Map();
+/** Namespace userIDS with uuid to isolate tests' indexeddb state. */
+export function createUserIDForTest(partialUserID: string): string {
+  let userID = partialUserIDsToUserIDs.get(partialUserID);
+  if (!userID) {
     const namespaceForTest = uuid();
-    replicacheName = `${namespaceForTest}:${partialName}`;
-    partialNamesToRepliacheNames.set(partialName, replicacheName);
+    userID = `${namespaceForTest}:${partialUserID}`;
+    partialUserIDsToUserIDs.set(partialUserID, userID);
   }
-  return replicacheName;
+  return userID;
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export async function replicacheForTesting<MD extends MutatorDefs = {}>(
-  partialName: string,
-  options: Omit<ReplicacheOptions<MD>, 'name'> = {},
+  partialUserID: string,
+  options: Omit<ReplicacheOptions<MD>, 'userID'> = {},
 ): Promise<ReplicacheTest<MD>> {
-  const pullURL = 'https://pull.com/?name=' + partialName;
-  const pushURL = 'https://push.com/?name=' + partialName;
-  return replicacheForTestingNoDefaultURLs(
-    createReplicacheNameForTest(partialName),
-    {
-      pullURL,
-      pushURL,
-      ...options,
-    },
-  );
+  const pullURL = 'https://pull.com/?userID=' + partialUserID;
+  const pushURL = 'https://push.com/?userID=' + partialUserID;
+  return replicacheForTestingNoDefaultURLs(createUserIDForTest(partialUserID), {
+    pullURL,
+    pushURL,
+    ...options,
+  });
 }
 
 export async function replicacheForTestingNoDefaultURLs<
   // eslint-disable-next-line @typescript-eslint/ban-types
   MD extends MutatorDefs = {},
 >(
-  name: string,
+  userID: string,
   {
     pullURL,
     pushDelay = 60_000, // Large to prevent interfering
     pushURL,
     ...rest
-  }: Omit<ReplicacheOptions<MD>, 'name'> = {},
+  }: Omit<ReplicacheOptions<MD>, 'userID'> = {},
 ): Promise<ReplicacheTest<MD>> {
   const rep = new ReplicacheTest<MD>({
     pullURL,
     pushDelay,
     pushURL,
-    name,
+    userID,
     ...rest,
   });
   dbsToDrop.add(rep.idbName);
@@ -152,7 +149,7 @@ export function initReplicacheTesting(): void {
     clock.restore();
     fetchMock.restore();
     sinon.restore();
-    partialNamesToRepliacheNames.clear();
+    partialUserIDsToUserIDs.clear();
     await closeAllReps();
     await deleteAllDatabases();
     await persist.teardownIDBDatabasesStoreForTest();

--- a/src/worker-tests/worker-test.ts
+++ b/src/worker-tests/worker-test.ts
@@ -8,9 +8,9 @@ import type {JSONValue} from '../json';
 import {closeAllReps, reps} from '../test-util';
 
 onmessage = async (e: MessageEvent) => {
-  const {name} = e.data;
+  const {userID} = e.data;
   try {
-    await testGetHasScanOnEmptyDB(name);
+    await testGetHasScanOnEmptyDB(userID);
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore TypeScripts type defs are incorrect.
     postMessage(undefined);
@@ -23,10 +23,10 @@ onmessage = async (e: MessageEvent) => {
   }
 };
 
-async function testGetHasScanOnEmptyDB(name: string) {
+async function testGetHasScanOnEmptyDB(userID: string) {
   const rep = new ReplicacheTest({
     pushDelay: 60_000, // Large to prevent interferin;,
-    name,
+    userID,
     mutators: {
       testMut: async (
         tx: WriteTransaction,


### PR DESCRIPTION
**Problem**
It is important, but not obvious that `ReplicacheOptions.name` uniquely identifies the user, authenticates the same user as `ReplicacheOptions.auth`, and that `ReplicacheOptions.auth` of a Replicache instance can be used to push the mutations of other Replicache instances with the same name.

**Solution**
Rename `ReplicacheOptions.name` to `ReplicacheOptions.userID`, and document its uses. 
Deprecate `Replicache.name` in favor of `Replicache.userID`.


BREAKING CHANGE: Use of `ReplicacheOptions.name` must be replaced with `ReplicacheOptions.userID`.