### PR TITLE
bump licensing version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -615,9 +615,9 @@
       "dev": true
     },
     "node_modules/@rocicorp/licensing": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rocicorp/licensing/-/licensing-1.0.0.tgz",
-      "integrity": "sha512-tNOtfZcrbNJB/UKoZw/FJSWroAocww2Iskf7u7g4nbQBYjZcD7yiHo7XvW/VPe/larAWK6pnOY5Vop0PRS0kXA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rocicorp/licensing/-/licensing-1.0.1.tgz",
+      "integrity": "sha512-0kRq7XFj6CHYzckUBOOF72Pdeh2l2fxsXm25U2R8ET/K3EbU1hIAxxFA83E4ZLk8nbokiRyZgW8seNEKo6ahXQ==",
       "dev": true,
       "dependencies": {
         "@prisma/client": "^3.9.1",
@@ -6730,9 +6730,9 @@
       "dev": true
     },
     "@rocicorp/licensing": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rocicorp/licensing/-/licensing-1.0.0.tgz",
-      "integrity": "sha512-tNOtfZcrbNJB/UKoZw/FJSWroAocww2Iskf7u7g4nbQBYjZcD7yiHo7XvW/VPe/larAWK6pnOY5Vop0PRS0kXA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rocicorp/licensing/-/licensing-1.0.1.tgz",
+      "integrity": "sha512-0kRq7XFj6CHYzckUBOOF72Pdeh2l2fxsXm25U2R8ET/K3EbU1hIAxxFA83E4ZLk8nbokiRyZgW8seNEKo6ahXQ==",
       "dev": true,
       "requires": {
         "@prisma/client": "^3.9.1",


### PR DESCRIPTION
This undoes the bundle size regression I caused adding the licensing client.