### PR TITLE
fix: Catch errors in background interval processes and log appropriatly.

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -47,13 +47,13 @@ export class LogContext implements Logger {
   readonly info?: (...args: unknown[]) => void = undefined;
   readonly error?: (...args: unknown[]) => void = undefined;
 
-  constructor(level: LogLevel = 'info', s = '') {
+  constructor(level: LogLevel = 'info', s = '', c = console) {
     this._s = s;
 
     const impl =
       (name: LogLevel) =>
       (...args: unknown[]) =>
-        console[name](this._s, ...args);
+        c[name](this._s, ...args);
 
     /* eslint-disable no-fallthrough , @typescript-eslint/ban-ts-comment */
     switch (level) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -47,13 +47,13 @@ export class LogContext implements Logger {
   readonly info?: (...args: unknown[]) => void = undefined;
   readonly error?: (...args: unknown[]) => void = undefined;
 
-  constructor(level: LogLevel = 'info', s = '', c = console) {
+  constructor(level: LogLevel = 'info', s = '') {
     this._s = s;
 
     const impl =
       (name: LogLevel) =>
       (...args: unknown[]) =>
-        c[name](this._s, ...args);
+        console[name](this._s, ...args);
 
     /* eslint-disable no-fallthrough , @typescript-eslint/ban-ts-comment */
     switch (level) {

--- a/src/persist/bg-interval.test.ts
+++ b/src/persist/bg-interval.test.ts
@@ -54,19 +54,19 @@ test('calling function returned by initBgIntervalProcess, stops interval', async
   expect(processCallCount).to.equal(1);
 });
 
-test('logs error thrown during process before stop is called to error', async () => {
+test('error thrown during process (before stop is called) is logged to error', async () => {
   const lc = new LogContext();
   const errorStub = sinon.stub(console, 'error');
   const process = () => {
-    return Promise.reject('TestError');
+    return Promise.reject('TestErrorBeforeStop');
   };
   initBgIntervalProcess('testProcess', process, 100, lc);
   await clock.tickAsync(100);
   expect(errorStub.callCount).to.equal(1);
-  expect(errorStub.getCall(0).args.join(' ')).to.contain('TestError');
+  expect(errorStub.getCall(0).args.join(' ')).to.contain('TestErrorBeforeStop');
 });
 
-test('logs error thrown during process after stop is called to debug', async () => {
+test('error thrown during process (after stop is called) is logged to debug', async () => {
   const lc = new LogContext('debug');
   const errorStub = sinon.stub(console, 'error');
   const debugStub = sinon.stub(console, 'debug');

--- a/src/persist/bg-interval.test.ts
+++ b/src/persist/bg-interval.test.ts
@@ -1,0 +1,94 @@
+import {expect} from '@esm-bundle/chai';
+import sinon, {SinonFakeTimers, useFakeTimers} from 'sinon';
+import {LogContext} from '../logger';
+import {resolver} from '../resolver';
+import {initBgIntervalProcess} from './bg-interval';
+
+let clock: SinonFakeTimers;
+setup(() => {
+  clock = useFakeTimers();
+});
+
+teardown(() => {
+  clock.restore();
+  sinon.restore();
+});
+
+test('initBgIntervalProcess starts interval that executed process every intervalMs', async () => {
+  let processCallCount = 0;
+  const process = () => {
+    processCallCount++;
+    return Promise.resolve();
+  };
+  initBgIntervalProcess('testProcess', process, 100, new LogContext());
+
+  expect(processCallCount).to.equal(0);
+  await clock.tickAsync(100);
+  expect(processCallCount).to.equal(1);
+  await clock.tickAsync(100);
+  expect(processCallCount).to.equal(2);
+  await clock.tickAsync(400);
+  expect(processCallCount).to.equal(6);
+});
+
+test('calling function returned by initBgIntervalProcess, stops interval', async () => {
+  let processCallCount = 0;
+  const process = () => {
+    processCallCount++;
+    return Promise.resolve();
+  };
+  const stop = initBgIntervalProcess(
+    'testProcess',
+    process,
+    100,
+    new LogContext(),
+  );
+
+  expect(processCallCount).to.equal(0);
+  await clock.tickAsync(100);
+  expect(processCallCount).to.equal(1);
+  stop();
+  await clock.tickAsync(100);
+  expect(processCallCount).to.equal(1);
+  await clock.tickAsync(400);
+  expect(processCallCount).to.equal(1);
+});
+
+test('logs error thrown during process before stop is called to error', async () => {
+  const lc = new LogContext();
+  const errorStub = sinon.stub(console, 'error');
+  const process = () => {
+    return Promise.reject('TestError');
+  };
+  initBgIntervalProcess('testProcess', process, 100, lc);
+  await clock.tickAsync(100);
+  expect(errorStub.callCount).to.equal(1);
+  expect(errorStub.getCall(0).args.join(' ')).to.contain('TestError');
+});
+
+test('logs error thrown during process after stop is called to debug', async () => {
+  const lc = new LogContext('debug');
+  const errorStub = sinon.stub(console, 'error');
+  const debugStub = sinon.stub(console, 'debug');
+
+  let processCallCount = 0;
+  const processResolver = resolver();
+  const process = () => {
+    processCallCount++;
+    return processResolver.promise;
+  };
+  const stop = initBgIntervalProcess('testProcess', process, 100, lc);
+  expect(processCallCount).to.equal(0);
+  await clock.tickAsync(100);
+  expect(processCallCount).to.equal(1);
+  stop();
+  processResolver.reject('TestErrorAfterStop');
+  try {
+    await processResolver.promise;
+  } catch (e) {
+    expect(e).to.equal('TestErrorAfterStop');
+  }
+  expect(errorStub.callCount).to.equal(0);
+  expect(debugStub.callCount).to.be.greaterThan(0);
+  expect(debugStub.lastCall.args.join(' ')).to.contain('TestErrorAfterStop');
+});

--- a/src/persist/bg-interval.ts
+++ b/src/persist/bg-interval.ts
@@ -1,0 +1,31 @@
+import type {LogContext} from '../logger';
+
+export function initBgIntervalProcess(
+  processName: string,
+  process: () => Promise<unknown>,
+  intervalMs: number,
+  lc: LogContext,
+): () => void {
+  lc = lc.addContext('bgIntervalProcess', processName);
+  let closed = false;
+  const intervalID = setInterval(async () => {
+    lc.debug?.('Running');
+    try {
+      await process();
+    } catch (e) {
+      if (closed) {
+        lc.debug?.('Error running most likely due to close.', e);
+      } else {
+        lc.error?.('Error running.', e);
+      }
+    }
+  }, intervalMs);
+  lc = lc.addContext('intervalID', intervalID);
+  lc.debug?.('Starting');
+
+  return () => {
+    lc.debug?.('Stopping');
+    closed = true;
+    clearInterval(intervalID);
+  };
+}

--- a/src/persist/client-gc.test.ts
+++ b/src/persist/client-gc.test.ts
@@ -6,6 +6,7 @@ import {fakeHash} from '../hash';
 import {initClientGC, getLatestGCUpdate} from './client-gc';
 import {makeClient, setClients} from './clients-test-helpers';
 import {assertNotUndefined} from '../asserts';
+import {LogContext} from '../logger';
 
 let clock: SinonFakeTimers;
 const START_TIME = 0;
@@ -56,7 +57,7 @@ test('initClientGC starts 5 min interval that collects clients that have been in
 
   await setClients(clientMap, dagStore);
 
-  initClientGC('client1', dagStore);
+  initClientGC('client1', dagStore, new LogContext());
 
   await dagStore.withRead(async (read: dag.Read) => {
     const readClientMap = await getClients(read);
@@ -154,7 +155,7 @@ test('calling function returned by initClientGC, stops Client GCs', async () => 
 
   await setClients(clientMap, dagStore);
 
-  const stopClientGC = initClientGC('client1', dagStore);
+  const stopClientGC = initClientGC('client1', dagStore, new LogContext());
 
   await dagStore.withRead(async (read: dag.Read) => {
     const readClientMap = await getClients(read);

--- a/src/persist/client-gc.ts
+++ b/src/persist/client-gc.ts
@@ -1,6 +1,8 @@
 import type {ClientID} from '../sync/client-id';
 import type * as dag from '../dag/mod';
 import {ClientMap, noUpdates, updateClients} from './clients';
+import type {LogContext} from '../logger';
+import {initBgIntervalProcess} from './bg-interval';
 
 const CLIENT_MAX_INACTIVE_IN_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const GC_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
@@ -13,24 +15,35 @@ export function getLatestGCUpdate(): Promise<ClientMap> | undefined {
 export function initClientGC(
   clientID: ClientID,
   dagStore: dag.Store,
+  lc: LogContext,
 ): () => void {
-  const intervalID = setInterval(() => {
-    latestGCUpdate = updateClients(clients => {
-      const now = Date.now();
-      const clientsAfterGC = Array.from(clients).filter(
-        ([id, client]) =>
-          id === clientID /* never collect ourself */ ||
-          now - client.heartbeatTimestampMs <= CLIENT_MAX_INACTIVE_IN_MS,
-      );
-      if (clientsAfterGC.length === clients.size) {
-        return noUpdates;
-      }
-      return {
-        clients: new Map(clientsAfterGC),
-      };
-    }, dagStore);
-  }, GC_INTERVAL_MS);
-  return () => {
-    clearInterval(intervalID);
-  };
+  return initBgIntervalProcess(
+    'ClientGC',
+    () => {
+      latestGCUpdate = gcClients(clientID, dagStore);
+      return latestGCUpdate;
+    },
+    GC_INTERVAL_MS,
+    lc,
+  );
+}
+
+async function gcClients(
+  clientID: ClientID,
+  dagStore: dag.Store,
+): Promise<ClientMap> {
+  return updateClients(clients => {
+    const now = Date.now();
+    const clientsAfterGC = Array.from(clients).filter(
+      ([id, client]) =>
+        id === clientID /* never collect ourself */ ||
+        now - client.heartbeatTimestampMs <= CLIENT_MAX_INACTIVE_IN_MS,
+    );
+    if (clientsAfterGC.length === clients.size) {
+      return noUpdates;
+    }
+    return {
+      clients: new Map(clientsAfterGC),
+    };
+  }, dagStore);
 }

--- a/src/persist/heartbeat.test.ts
+++ b/src/persist/heartbeat.test.ts
@@ -10,6 +10,7 @@ import {ClientMap, getClients} from './clients';
 import {fakeHash} from '../hash';
 import {makeClient, setClients} from './clients-test-helpers';
 import {assertNotUndefined} from '../asserts';
+import {LogContext} from '../logger';
 
 let clock: SinonFakeTimers;
 const START_TIME = 100000;
@@ -50,7 +51,7 @@ test('startHeartbeats starts interval that writes heartbeat each minute', async 
   );
   await setClients(clientMap, dagStore);
 
-  startHeartbeats('client1', dagStore);
+  startHeartbeats('client1', dagStore, new LogContext());
 
   await dagStore.withRead(async (read: dag.Read) => {
     const readClientMap = await getClients(read);
@@ -112,7 +113,7 @@ test('calling function returned by startHeartbeats, stops heartbeats', async () 
   );
   await setClients(clientMap, dagStore);
 
-  const stopHeartbeats = startHeartbeats('client1', dagStore);
+  const stopHeartbeats = startHeartbeats('client1', dagStore, new LogContext());
 
   await dagStore.withRead(async (read: dag.Read) => {
     const readClientMap = await getClients(read);


### PR DESCRIPTION
Problem
=======
We have a report of the following exception being thrown from `heartbeat.ts` after a Replicache instance is closed and a new one created as part of a development setup using Replicache, Reach hooks, and Next with HMR.

```
DOMException: Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing.
```

We do stop the heartbeat interval when a Replicache instance is closed, however there is a race that can lead to the above exception: if the Replicache instance is closed while the hearbeat update is running.  

This is a fairly narrow race, so I'm still uncertain if this is what the issue reporter is hitting. 

Solution
=======
Catch errors in interval based background processes and log them to 'debug' if the error occurred after the Replicache instance was closed (as this is an expected error), and to 'error' otherwise.  Applied this to the "heartbeat" and "ClientGC" processes.  The "mutation recovery" process already does this.

Also added so additional debug logging to aid in further debugging if this does not fix the issue for the reporter.


Fixes #843 