### PR TITLE
chore: Add a mustGetChunk that throws if missing

### DIFF
--- a/src/btree/read.ts
+++ b/src/btree/read.ts
@@ -64,11 +64,7 @@ export class BTreeRead {
       return cached;
     }
 
-    const chunk = await this._dagRead.getChunk(hash);
-    if (chunk === undefined) {
-      throw new Error(`Missing chunk for ${hash}`);
-    }
-    const {data} = chunk;
+    const {data} = await this._dagRead.mustGetChunk(hash);
     assertBTreeNode(data);
     const impl = newNodeImpl(
       // We enforce that we do not mutate this at runtime by first checking the

--- a/src/dag/lazy-store.ts
+++ b/src/dag/lazy-store.ts
@@ -2,7 +2,7 @@ import {Hash, isTempHash} from '../hash';
 import type * as kv from '../kv/mod';
 import {RWLock} from '../rw-lock';
 import {Chunk, ChunkHasher, createChunk} from './chunk';
-import {Store, Read, Write, MissingChunkError, mustGetChunk} from './store';
+import {Store, Read, Write, mustGetChunk} from './store';
 import {getSizeOfValue as defaultGetSizeOfValue} from '../json';
 import type {ReadonlyJSONValue} from '../mod';
 import {

--- a/src/dag/lazy-store.ts
+++ b/src/dag/lazy-store.ts
@@ -2,7 +2,7 @@ import {Hash, isTempHash} from '../hash';
 import type * as kv from '../kv/mod';
 import {RWLock} from '../rw-lock';
 import {Chunk, ChunkHasher, createChunk} from './chunk';
-import {Store, Read, Write, MissingChunkError} from './store';
+import {Store, Read, Write, MissingChunkError, mustGetChunk} from './store';
 import {getSizeOfValue as defaultGetSizeOfValue} from '../json';
 import type {ReadonlyJSONValue} from '../mod';
 import {
@@ -226,11 +226,7 @@ export class LazyRead implements Read {
   }
 
   async mustGetChunk(hash: Hash): Promise<Chunk> {
-    const chunk = await this.getChunk(hash);
-    if (chunk) {
-      return chunk;
-    }
-    throw new MissingChunkError(hash);
+    return mustGetChunk(this, hash);
   }
 
   async getHead(name: string): Promise<Hash | undefined> {

--- a/src/dag/lazy-store.ts
+++ b/src/dag/lazy-store.ts
@@ -2,7 +2,7 @@ import {Hash, isTempHash} from '../hash';
 import type * as kv from '../kv/mod';
 import {RWLock} from '../rw-lock';
 import {Chunk, ChunkHasher, createChunk} from './chunk';
-import type {Store, Read, Write} from './store';
+import {Store, Read, Write, MissingChunkError} from './store';
 import {getSizeOfValue as defaultGetSizeOfValue} from '../json';
 import type {ReadonlyJSONValue} from '../mod';
 import {
@@ -223,6 +223,14 @@ export class LazyRead implements Read {
       }
     }
     return chunk;
+  }
+
+  async mustGetChunk(hash: Hash): Promise<Chunk> {
+    const chunk = await this.getChunk(hash);
+    if (chunk) {
+      return chunk;
+    }
+    throw new MissingChunkError(hash);
   }
 
   async getHead(name: string): Promise<Hash | undefined> {

--- a/src/dag/store-impl.ts
+++ b/src/dag/store-impl.ts
@@ -1,5 +1,5 @@
 import type * as kv from '../kv/mod';
-import {Store, Read, Write, MissingChunkError} from './store';
+import {Store, Read, Write, MissingChunkError, mustGetChunk} from './store';
 import {
   assertMeta,
   Chunk,
@@ -88,11 +88,7 @@ export class ReadImpl implements Read {
   }
 
   async mustGetChunk(hash: Hash): Promise<Chunk> {
-    const chunk = await this.getChunk(hash);
-    if (chunk) {
-      return chunk;
-    }
-    throw new MissingChunkError(hash);
+    return mustGetChunk(this, hash);
   }
 
   async getHead(name: string): Promise<Hash | undefined> {

--- a/src/dag/store-impl.ts
+++ b/src/dag/store-impl.ts
@@ -1,5 +1,5 @@
 import type * as kv from '../kv/mod';
-import {Store, Read, Write, MissingChunkError, mustGetChunk} from './store';
+import {Store, Read, Write, mustGetChunk} from './store';
 import {
   assertMeta,
   Chunk,

--- a/src/dag/store-impl.ts
+++ b/src/dag/store-impl.ts
@@ -1,5 +1,5 @@
 import type * as kv from '../kv/mod';
-import type {Store, Read, Write} from './store';
+import {Store, Read, Write, MissingChunkError} from './store';
 import {
   assertMeta,
   Chunk,
@@ -85,6 +85,14 @@ export class ReadImpl implements Read {
       refs = [];
     }
     return createChunkWithHash(hash, data, refs);
+  }
+
+  async mustGetChunk(hash: Hash): Promise<Chunk> {
+    const chunk = await this.getChunk(hash);
+    if (chunk) {
+      return chunk;
+    }
+    throw new MissingChunkError(hash);
   }
 
   async getHead(name: string): Promise<Hash | undefined> {

--- a/src/dag/store.ts
+++ b/src/dag/store.ts
@@ -10,9 +10,12 @@ export interface Store {
   close(): Promise<void>;
 }
 
-export interface Read {
-  hasChunk(hash: Hash): Promise<boolean>;
+interface GetChunk {
   getChunk(hash: Hash): Promise<Chunk | undefined>;
+}
+
+export interface Read extends GetChunk {
+  hasChunk(hash: Hash): Promise<boolean>;
   mustGetChunk(hash: Hash): Promise<Chunk>;
   getHead(name: string): Promise<Hash | undefined>;
   close(): void;
@@ -38,4 +41,15 @@ export class MissingChunkError extends Error {
     super(`Missing chunk ${hash}`);
     this.hash = hash;
   }
+}
+
+export async function mustGetChunk(
+  store: GetChunk,
+  hash: Hash,
+): Promise<Chunk> {
+  const chunk = await store.getChunk(hash);
+  if (chunk) {
+    return chunk;
+  }
+  throw new MissingChunkError(hash);
 }

--- a/src/dag/store.ts
+++ b/src/dag/store.ts
@@ -13,6 +13,7 @@ export interface Store {
 export interface Read {
   hasChunk(hash: Hash): Promise<boolean>;
   getChunk(hash: Hash): Promise<Chunk | undefined>;
+  mustGetChunk(hash: Hash): Promise<Chunk>;
   getHead(name: string): Promise<Hash | undefined>;
   close(): void;
   get closed(): boolean;
@@ -28,4 +29,13 @@ export interface Write extends Read {
   removeHead(name: string): Promise<void>;
   assertValidHash(hash: Hash): void;
   commit(): Promise<void>;
+}
+
+export class MissingChunkError extends Error {
+  name = 'MissingChunkError';
+  readonly hash: Hash;
+  constructor(hash: Hash) {
+    super(`Missing chunk ${hash}`);
+    this.hash = hash;
+  }
 }

--- a/src/db/commit.ts
+++ b/src/db/commit.ts
@@ -139,8 +139,7 @@ export async function fromHash(
   hash: Hash,
   dagRead: dag.Read,
 ): Promise<Commit<Meta>> {
-  const chunk = await dagRead.getChunk(hash);
-  assert(chunk, `Missing commit for ${hash}`);
+  const chunk = await dagRead.mustGetChunk(hash);
   return fromChunk(chunk);
 }
 

--- a/src/db/transformer.ts
+++ b/src/db/transformer.ts
@@ -16,7 +16,7 @@ import type * as dag from '../dag/mod';
 import type {ReadonlyJSONValue} from '../json';
 import {HashRefType} from './hash-ref-type';
 import type {Value} from '../kv/store';
-import {MissingChunkError} from '../dag/store.js';
+import {MissingChunkError, mustGetChunk} from '../dag/store.js';
 
 type OldHash = Hash;
 type NewHash = Hash;
@@ -93,14 +93,10 @@ export abstract class BaseTransformer {
     return false;
   }
 
-  protected abstract getChunk(oldHash: OldHash): Promise<dag.Chunk | undefined>;
+  abstract getChunk(oldHash: OldHash): Promise<dag.Chunk | undefined>;
 
-  protected async mustGetChunk(oldHash: OldHash): Promise<dag.Chunk> {
-    const chunk = await this.getChunk(oldHash);
-    if (chunk) {
-      return chunk;
-    }
-    throw new MissingChunkError(oldHash);
+  async mustGetChunk(oldHash: OldHash): Promise<dag.Chunk> {
+    return mustGetChunk(this, oldHash);
   }
 
   private async _maybeWriteChunk<D extends Value>(

--- a/src/db/transformer.ts
+++ b/src/db/transformer.ts
@@ -16,7 +16,7 @@ import type * as dag from '../dag/mod';
 import type {ReadonlyJSONValue} from '../json';
 import {HashRefType} from './hash-ref-type';
 import type {Value} from '../kv/store';
-import {MissingChunkError, mustGetChunk} from '../dag/store.js';
+import {mustGetChunk} from '../dag/store.js';
 
 type OldHash = Hash;
 type NewHash = Hash;
@@ -336,9 +336,7 @@ export class Transformer extends BaseTransformer {
     this.dagWrite = dagWrite;
   }
 
-  protected override getChunk(
-    oldHash: OldHash,
-  ): Promise<dag.Chunk | undefined> {
+  override getChunk(oldHash: OldHash): Promise<dag.Chunk | undefined> {
     return this.dagWrite.getChunk(oldHash);
   }
 

--- a/src/db/visitor.ts
+++ b/src/db/visitor.ts
@@ -1,4 +1,3 @@
-import {assert} from '../asserts';
 import {assertBTreeNode} from '../btree/mod';
 import {
   assertCommitData,
@@ -14,6 +13,7 @@ import type * as dag from '../dag/mod';
 import {emptyHash, Hash} from '../hash';
 import {InternalNode, isInternalNode, Node} from '../btree/node';
 import {HashRefType} from './hash-ref-type';
+import {MissingChunkError} from '../dag/store.js';
 
 export class Visitor {
   readonly dagRead: dag.Read;
@@ -37,7 +37,7 @@ export class Visitor {
       if (hashRefType === HashRefType.AllowWeak) {
         return;
       }
-      throw new Error(`Chunk ${h} not found`);
+      throw new MissingChunkError(h);
     }
 
     const {data} = chunk;
@@ -107,8 +107,7 @@ export class Visitor {
     }
     this._visitedHashes.add(h);
 
-    const chunk = await this.dagRead.getChunk(h);
-    assert(chunk);
+    const chunk = await this.dagRead.mustGetChunk(h);
     const {data} = chunk;
     assertBTreeNode(data);
 

--- a/src/persist/compute-hash-transformer.ts
+++ b/src/persist/compute-hash-transformer.ts
@@ -46,9 +46,7 @@ export class ComputeHashTransformer extends db.BaseTransformer {
     return this._gatheredChunks.has(oldHash);
   }
 
-  protected override async getChunk(
-    hash: Hash,
-  ): Promise<dag.Chunk | undefined> {
+  override async getChunk(hash: Hash): Promise<dag.Chunk | undefined> {
     const gatheredChunk = this._gatheredChunks.get(hash);
     // We cannot get here if we did not gather a chunk for this hash.
     assert(gatheredChunk !== undefined);


### PR DESCRIPTION
Now, all code paths that gets a required chunk uses `mustGetChunk`. When
the chunk is missing this throws a `MissingChunkError`.

The idea is that the caller will detect these errors and see if the
client might have been GC'd.

Towards #784