### PR TITLE
feat: Check if client exists in persist

### DIFF
--- a/src/persist/client-gc.ts
+++ b/src/persist/client-gc.ts
@@ -28,7 +28,7 @@ export function initClientGC(
   );
 }
 
-async function gcClients(
+export async function gcClients(
   clientID: ClientID,
   dagStore: dag.Store,
 ): Promise<ClientMap> {

--- a/src/persist/clients.ts
+++ b/src/persist/clients.ts
@@ -112,6 +112,31 @@ async function getClientsAtHash(
   return chunkDataToClientMap(chunk?.data);
 }
 
+/**
+ * Used to signal that a client does not exist. Maybe it was garbage collected?
+ */
+export class MissingClientError extends Error {
+  name = 'MissingClientError';
+  readonly id: string;
+  constructor(id: sync.ClientID) {
+    super(`Missing client ${id}`);
+    this.id = id;
+  }
+}
+
+/**
+ * Throws a `MissingClientError` if the client does not exist.
+ */
+export async function assertclientExists(
+  id: sync.ClientID,
+  dagRead: dag.Read,
+): Promise<void> {
+  const client = await getClient(id, dagRead);
+  if (!client) {
+    throw new MissingClientError(id);
+  }
+}
+
 export async function getClient(
   id: sync.ClientID,
   dagRead: dag.Read,

--- a/src/persist/clients.ts
+++ b/src/persist/clients.ts
@@ -127,7 +127,7 @@ export class MissingClientError extends Error {
 /**
  * Throws a `MissingClientError` if the client does not exist.
  */
-export async function assertclientExists(
+export async function assertClientExists(
   id: sync.ClientID,
   dagRead: dag.Read,
 ): Promise<void> {

--- a/src/persist/persist.ts
+++ b/src/persist/persist.ts
@@ -4,7 +4,7 @@ import * as db from '../db/mod';
 import * as sync from '../sync/mod';
 import {Hash, hashOf} from '../hash';
 import type {ClientID} from '../sync/client-id';
-import {assertclientExists, updateClients} from './clients';
+import {assertClientExists, updateClients} from './clients';
 import {ComputeHashTransformer, FixedChunks} from './compute-hash-transformer';
 import {GatherVisitor} from './gather-visitor';
 import {FixupTransformer} from './fixup-transformer';
@@ -30,7 +30,7 @@ export async function persist(
   // Start checking if client exists while we do other async work
   const clientExistsCheckP =
     !skipClientExists &&
-    perdag.withRead(read => assertclientExists(clientID, read));
+    perdag.withRead(read => assertClientExists(clientID, read));
 
   // 1. Gather all temp chunks from main head on the memdag.
   const [gatheredChunks, mainHeadTempHash, mutationID, lastMutationID] =

--- a/src/replicache-mutation-recovery.test.ts
+++ b/src/replicache-mutation-recovery.test.ts
@@ -85,7 +85,7 @@ async function createAndPersistClientWithPendingLocal(
     await addLocal(chain, testMemdag);
     localMetas.push(chain[chain.length - 1].meta as db.LocalMeta);
   }
-  await persist.persist(clientID, testMemdag, perdag);
+  await persist.persist(clientID, testMemdag, perdag, 'skip');
   return localMetas;
 }
 

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -2165,7 +2165,7 @@ test('experiment KV Store', async () => {
   store.resetCounters();
 
   await rep.persist();
-  expect(store.readCount).to.equal(1, 'readCount');
+  expect(store.readCount).to.equal(2, 'readCount');
   expect(store.writeCount).to.equal(1, 'writeCount');
   expect(store.closeCount).to.equal(0, 'closeCount');
   store.resetCounters();


### PR DESCRIPTION
We now check if the client ID exists in the client map when we do a
`persist`. If it doesn't we throw a `MissingClientError`.

For testing purpuse we can skip this check.

The intended use is to handle clients that are missing and raise an
"event" on the Replicache instance when this happens.

Towards #784