### PR TITLE
feat: Add onClientMissing

### DIFF
--- a/src/dag/mod.ts
+++ b/src/dag/mod.ts
@@ -5,6 +5,7 @@ export {
   createChunkWithNativeHash,
   throwChunkHasher,
 } from './chunk';
+export {MissingChunkError} from './store';
 export type {Store, Read, Write} from './store';
 export {StoreImpl} from './store-impl';
 export {LazyStore} from './lazy-store';

--- a/src/persist/client-gc.ts
+++ b/src/persist/client-gc.ts
@@ -47,3 +47,16 @@ export async function gcClients(
     };
   }, dagStore);
 }
+
+export async function deleteClientForTesting(
+  clientID: ClientID,
+  dagStore: dag.Store,
+): Promise<void> {
+  await updateClients(clients => {
+    const clientsAfterGC = new Map(clients);
+    clientsAfterGC.delete(clientID);
+    return {
+      clients: new Map(clientsAfterGC),
+    };
+  }, dagStore);
+}

--- a/src/persist/client-gc.ts
+++ b/src/persist/client-gc.ts
@@ -47,16 +47,3 @@ export async function gcClients(
     };
   }, dagStore);
 }
-
-export async function deleteClientForTesting(
-  clientID: ClientID,
-  dagStore: dag.Store,
-): Promise<void> {
-  await updateClients(clients => {
-    const clientsAfterGC = new Map(clients);
-    clientsAfterGC.delete(clientID);
-    return {
-      clients: new Map(clientsAfterGC),
-    };
-  }, dagStore);
-}

--- a/src/persist/clients-test-helpers.ts
+++ b/src/persist/clients-test-helpers.ts
@@ -1,5 +1,6 @@
 import {Client, ClientMap, updateClients} from './clients';
 import type * as dag from '../dag/mod';
+import type * as sync from '../sync/mod';
 import type {Hash} from '../hash';
 
 export function setClients(
@@ -24,4 +25,17 @@ export function makeClient(partialClient: {
     lastServerAckdMutationID: 0,
     ...partialClient,
   };
+}
+
+export async function deleteClientForTesting(
+  clientID: sync.ClientID,
+  dagStore: dag.Store,
+): Promise<void> {
+  await updateClients(clients => {
+    const clientsAfterGC = new Map(clients);
+    clientsAfterGC.delete(clientID);
+    return {
+      clients: new Map(clientsAfterGC),
+    };
+  }, dagStore);
 }

--- a/src/persist/clients.ts
+++ b/src/persist/clients.ts
@@ -131,10 +131,13 @@ export async function assertClientExists(
   id: sync.ClientID,
   dagRead: dag.Read,
 ): Promise<void> {
-  const client = await getClient(id, dagRead);
-  if (!client) {
+  if (await isClientMissing(id, dagRead)) {
     throw new MissingClientError(id);
   }
+}
+
+export async function isClientMissing(id: sync.ClientID, dagRead: dag.Read) {
+  return !(await getClient(id, dagRead));
 }
 
 export async function getClient(

--- a/src/persist/clients.ts
+++ b/src/persist/clients.ts
@@ -115,29 +115,32 @@ async function getClientsAtHash(
 /**
  * Used to signal that a client does not exist. Maybe it was garbage collected?
  */
-export class MissingClientError extends Error {
-  name = 'MissingClientError';
+export class ClientStateNotFoundError extends Error {
+  name = 'ClientStateNotFoundError';
   readonly id: string;
   constructor(id: sync.ClientID) {
-    super(`Missing client ${id}`);
+    super(`Client state not found, id: ${id}`);
     this.id = id;
   }
 }
 
 /**
- * Throws a `MissingClientError` if the client does not exist.
+ * Throws a `ClientStateNotFoundError` if the client does not exist.
  */
-export async function assertClientExists(
+export async function assertHasClientState(
   id: sync.ClientID,
   dagRead: dag.Read,
 ): Promise<void> {
-  if (await isClientMissing(id, dagRead)) {
-    throw new MissingClientError(id);
+  if (!(await hasClientState(id, dagRead))) {
+    throw new ClientStateNotFoundError(id);
   }
 }
 
-export async function isClientMissing(id: sync.ClientID, dagRead: dag.Read) {
-  return !(await getClient(id, dagRead));
+export async function hasClientState(
+  id: sync.ClientID,
+  dagRead: dag.Read,
+): Promise<boolean> {
+  return !!(await getClient(id, dagRead));
 }
 
 export async function getClient(

--- a/src/persist/heartbeat.test.ts
+++ b/src/persist/heartbeat.test.ts
@@ -1,4 +1,5 @@
 import {expect} from '@esm-bundle/chai';
+import * as sinon from 'sinon';
 import {SinonFakeTimers, useFakeTimers} from 'sinon';
 import * as dag from '../dag/mod';
 import {
@@ -6,7 +7,7 @@ import {
   startHeartbeats,
   writeHeartbeat,
 } from './heartbeat';
-import {ClientMap, getClients} from './clients';
+import {ClientMap, ClientStateNotFoundError, getClients} from './clients';
 import {fakeHash} from '../hash';
 import {makeClient, setClients} from './clients-test-helpers';
 import {assertNotUndefined} from '../asserts';
@@ -51,14 +52,14 @@ test('startHeartbeats starts interval that writes heartbeat each minute', async 
   );
   await setClients(clientMap, dagStore);
 
-  startHeartbeats('client1', dagStore, new LogContext());
+  startHeartbeats('client1', dagStore, () => undefined, new LogContext());
 
   await dagStore.withRead(async (read: dag.Read) => {
     const readClientMap = await getClients(read);
     expect(readClientMap).to.deep.equal(clientMap);
   });
 
-  clock.tick(ONE_MIN_IN_MS);
+  await clock.tickAsync(ONE_MIN_IN_MS);
   await awaitLatestHeartbeatUpdate();
 
   await dagStore.withRead(async (read: dag.Read) => {
@@ -113,29 +114,30 @@ test('calling function returned by startHeartbeats, stops heartbeats', async () 
   );
   await setClients(clientMap, dagStore);
 
-  const stopHeartbeats = startHeartbeats('client1', dagStore, new LogContext());
+  const stopHeartbeats = startHeartbeats(
+    'client1',
+    dagStore,
+    () => undefined,
+    new LogContext(),
+  );
 
   await dagStore.withRead(async (read: dag.Read) => {
     const readClientMap = await getClients(read);
     expect(readClientMap).to.deep.equal(clientMap);
   });
 
-  clock.tick(ONE_MIN_IN_MS);
+  await clock.tickAsync(ONE_MIN_IN_MS);
   await awaitLatestHeartbeatUpdate();
 
   await dagStore.withRead(async (read: dag.Read) => {
     const readClientMap = await getClients(read);
-    expect(readClientMap).to.deep.equal(
-      new Map(
-        Object.entries({
-          client1: {
-            ...client1,
-            heartbeatTimestampMs: START_TIME + ONE_MIN_IN_MS,
-          },
-          client2,
-        }),
-      ),
-    );
+    expect(Object.fromEntries(readClientMap)).to.deep.equal({
+      client1: {
+        ...client1,
+        heartbeatTimestampMs: START_TIME + ONE_MIN_IN_MS,
+      },
+      client2,
+    });
   });
 
   stopHeartbeats();
@@ -210,5 +212,21 @@ test('writeHeartbeat throws Error if no Client is found for clientID', async () 
   } catch (ex) {
     e = ex;
   }
-  expect(e).to.be.instanceOf(Error);
+  expect(e)
+    .to.be.instanceOf(ClientStateNotFoundError)
+    .property('id', 'client1');
+});
+
+test('heartbeat with missing client calls callback', async () => {
+  const dagStore = new dag.TestStore();
+  const onClientStateNotFound = sinon.fake();
+  const stop = startHeartbeats(
+    'client1',
+    dagStore,
+    onClientStateNotFound,
+    new LogContext(),
+  );
+  await clock.tickAsync(ONE_MIN_IN_MS);
+  expect(onClientStateNotFound.callCount).to.equal(1);
+  stop();
 });

--- a/src/persist/heartbeat.test.ts
+++ b/src/persist/heartbeat.test.ts
@@ -3,7 +3,7 @@ import * as sinon from 'sinon';
 import {SinonFakeTimers, useFakeTimers} from 'sinon';
 import * as dag from '../dag/mod';
 import {
-  getLatestHeartbeatUpdate,
+  latestHeartbeatUpdate,
   startHeartbeats,
   writeHeartbeat,
 } from './heartbeat';
@@ -25,7 +25,7 @@ teardown(() => {
 });
 
 function awaitLatestHeartbeatUpdate(): Promise<ClientMap> {
-  const latest = getLatestHeartbeatUpdate();
+  const latest = latestHeartbeatUpdate;
   assertNotUndefined(latest);
   return latest;
 }

--- a/src/persist/heartbeat.ts
+++ b/src/persist/heartbeat.ts
@@ -11,11 +11,7 @@ import {initBgIntervalProcess} from './bg-interval';
 
 const HEARTBEAT_INTERVAL_MS = 60 * 1000;
 
-let latestHeartbeatUpdate: Promise<ClientMap> | undefined;
-
-export function getLatestHeartbeatUpdate(): Promise<ClientMap> | undefined {
-  return latestHeartbeatUpdate;
-}
+export let latestHeartbeatUpdate: Promise<ClientMap> | undefined;
 
 export function startHeartbeats(
   clientID: ClientID,

--- a/src/persist/mod.ts
+++ b/src/persist/mod.ts
@@ -10,7 +10,7 @@ export {
   assertClientExists,
   MissingClientError,
 } from './clients';
-export {initClientGC} from './client-gc';
+export {initClientGC, deleteClientForTesting} from './client-gc';
 export {
   IDBDatabasesStore,
   setupForTest as setupIDBDatabasesStoreForTest,

--- a/src/persist/mod.ts
+++ b/src/persist/mod.ts
@@ -6,6 +6,9 @@ export {
   getClients,
   updateClients,
   noUpdates as noClientUpdates,
+  isClientMissing,
+  assertClientExists,
+  MissingClientError,
 } from './clients';
 export {initClientGC} from './client-gc';
 export {

--- a/src/persist/mod.ts
+++ b/src/persist/mod.ts
@@ -6,11 +6,11 @@ export {
   getClients,
   updateClients,
   noUpdates as noClientUpdates,
-  isClientMissing,
-  assertClientExists,
-  MissingClientError,
+  hasClientState,
+  assertHasClientState,
+  ClientStateNotFoundError,
 } from './clients';
-export {initClientGC, deleteClientForTesting} from './client-gc';
+export {initClientGC} from './client-gc';
 export {
   IDBDatabasesStore,
   setupForTest as setupIDBDatabasesStoreForTest,

--- a/src/persist/persist.test.ts
+++ b/src/persist/persist.test.ts
@@ -21,7 +21,7 @@ import {
 } from '../hash';
 import type {Value} from '../kv/store';
 import type {ClientID} from '../sync/client-id';
-import {getClient, MissingClientError} from './clients';
+import {getClient, ClientStateNotFoundError} from './clients';
 import {addSyncSnapshot} from '../sync/test-helpers';
 import {persist} from './persist';
 import {gcClients} from './client-gc.js';
@@ -228,7 +228,9 @@ test('We get a MissingClientException during persist if client is missing', asyn
   } catch (e) {
     err = e;
   }
-  expect(err).to.be.an.instanceof(MissingClientError).property('id', clientID);
+  expect(err)
+    .to.be.an.instanceof(ClientStateNotFoundError)
+    .property('id', clientID);
 });
 
 function setupPersistTest() {

--- a/src/persist/persist.ts
+++ b/src/persist/persist.ts
@@ -4,7 +4,7 @@ import * as db from '../db/mod';
 import * as sync from '../sync/mod';
 import {Hash, hashOf} from '../hash';
 import type {ClientID} from '../sync/client-id';
-import {assertClientExists, updateClients} from './clients';
+import {assertHasClientState, updateClients} from './clients';
 import {ComputeHashTransformer, FixedChunks} from './compute-hash-transformer';
 import {GatherVisitor} from './gather-visitor';
 import {FixupTransformer} from './fixup-transformer';
@@ -30,7 +30,7 @@ export async function persist(
   // Start checking if client exists while we do other async work
   const clientExistsCheckP =
     !skipClientExists &&
-    perdag.withRead(read => assertClientExists(clientID, read));
+    perdag.withRead(read => assertHasClientState(clientID, read));
 
   // 1. Gather all temp chunks from main head on the memdag.
   const [gatheredChunks, mainHeadTempHash, mutationID, lastMutationID] =

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -1,5 +1,6 @@
 import {httpStatusUnauthorized} from './replicache';
 import {
+  addData,
   clock,
   initReplicacheTesting,
   MemStoreWithCounters,
@@ -39,12 +40,6 @@ import type {ReplicacheOptions} from './replicache-options';
 const {fail} = assert;
 
 initReplicacheTesting();
-
-async function addData(tx: WriteTransaction, data: {[key: string]: JSONValue}) {
-  for (const [key, value] of Object.entries(data)) {
-    await tx.put(key, value);
-  }
-}
 
 async function expectPromiseToReject(p: unknown): Promise<Chai.Assertion> {
   let e;

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -279,8 +279,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
 
   /**
    * `onClientMissing` is called when the persistent client has been garbage
-   * collected. This can  happen if the client has not been used for over a
-   * week.
+   * collected. This can happen if the client has not been used for over a week.
    *
    * The default behavior is to reload the page (using `location.reload()`). Set
    * this to `null` or provide your own function to prevent the page from
@@ -1373,6 +1372,10 @@ export class Replicache<MD extends MutatorDefs = {}> {
     });
   }
 
+  /**
+   * In the case we get a MissingChunkError we check if the client got garbage
+   * collected and if so change the error to a MissingClientError instead
+   */
   private async _convertToMissingClientError(ex: unknown): Promise<unknown> {
     if (
       ex instanceof dag.MissingChunkError &&

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -448,6 +448,10 @@ export class Replicache<MD extends MutatorDefs = {}> {
   }
 
   private _onVisibilityChange = async () => {
+    if (this._closed) {
+      return;
+    }
+
     // In case of running in a worker, we don't have a document.
     if (getDocument()?.visibilityState !== 'visible') {
       return;
@@ -594,6 +598,11 @@ export class Replicache<MD extends MutatorDefs = {}> {
       clearInterval(this._recoverMutationsIntervalID);
     }
 
+    getDocument()?.removeEventListener(
+      'visibilitychange',
+      this._onVisibilityChange,
+    );
+
     await this._ready;
     const closingPromises = [
       this._memdag.close(),
@@ -609,11 +618,6 @@ export class Replicache<MD extends MutatorDefs = {}> {
       subscription.onDone?.();
     }
     this._subscriptions.clear();
-
-    getDocument()?.removeEventListener(
-      'visibilitychange',
-      this._onVisibilityChange,
-    );
 
     await Promise.all(closingPromises);
     closingInstances.delete(this.name);

--- a/src/test-util.ts
+++ b/src/test-util.ts
@@ -4,7 +4,7 @@ import * as kv from './kv/mod';
 import * as persist from './persist/mod';
 import {SinonFakeTimers, useFakeTimers} from 'sinon';
 import * as sinon from 'sinon';
-import type {ReadonlyJSONValue} from './json';
+import type {JSONValue, ReadonlyJSONValue} from './json';
 import {Hash, makeNewTempHashFunction} from './hash';
 
 // fetch-mock has invalid d.ts file so we removed that on npm install.
@@ -12,6 +12,7 @@ import {Hash, makeNewTempHashFunction} from './hash';
 // @ts-expect-error
 import fetchMock from 'fetch-mock/esm/client';
 import {uuid} from './uuid';
+import type {WriteTransaction} from './transactions.js';
 
 export class ReplicacheTest<
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -61,6 +62,11 @@ export class ReplicacheTest<
 
   licenseActive(): Promise<boolean> {
     return this._licenseActivePromise;
+  }
+
+  get perdag() {
+    // @ts-expect-error Property '_perdag' is private
+    return this._perdag;
   }
 }
 
@@ -214,5 +220,14 @@ export class MemStoreWithCounters implements kv.Store {
 
   get closed(): boolean {
     return this.store.closed;
+  }
+}
+
+export async function addData(
+  tx: WriteTransaction,
+  data: {[key: string]: JSONValue},
+) {
+  for (const [key, value] of Object.entries(data)) {
+    await tx.put(key, value);
   }
 }


### PR DESCRIPTION
This hooks up the test if the client exists. If the client does not
exist we call `onClientMissing`.

The test for the client missing is done in persist, query, mutate as well as in
visibilitychange and the visibilityState is visible.

Fixes #784