### PR TITLE
chore: Rename MissingChunkError

### DIFF
--- a/src/dag/mod.ts
+++ b/src/dag/mod.ts
@@ -5,7 +5,7 @@ export {
   createChunkWithNativeHash,
   throwChunkHasher,
 } from './chunk';
-export {MissingChunkError} from './store';
+export {ChunkNotFoundError} from './store';
 export type {Store, Read, Write} from './store';
 export {StoreImpl} from './store-impl';
 export {LazyStore} from './lazy-store';

--- a/src/dag/store-impl.test.ts
+++ b/src/dag/store-impl.test.ts
@@ -15,7 +15,7 @@ import {
 } from '../hash';
 import {assert} from '../asserts';
 import {TestStore} from './test-store';
-import {MissingChunkError} from './store.js';
+import {ChunkNotFoundError} from './store.js';
 
 suite('read', () => {
   test('has chunk', async () => {
@@ -75,7 +75,7 @@ suite('read', () => {
   });
 
   test('must get chunk missing chunks', async () => {
-    await testMissingChunkError('withRead');
+    await testChunkNotFoundError('withRead');
   });
 });
 
@@ -440,11 +440,11 @@ suite('write', () => {
   });
 
   test('must get chunk missing chunks', async () => {
-    await testMissingChunkError('withWrite');
+    await testChunkNotFoundError('withWrite');
   });
 });
 
-async function testMissingChunkError(methodName: 'withRead' | 'withWrite') {
+async function testChunkNotFoundError(methodName: 'withRead' | 'withWrite') {
   const chunkHasher = makeTestChunkHasher('fake');
   const store = new StoreImpl(new MemStore(), chunkHasher, assertHash);
 
@@ -469,7 +469,7 @@ async function testMissingChunkError(methodName: 'withRead' | 'withWrite') {
       err = e;
     }
     expect(err)
-      .to.be.instanceof(MissingChunkError)
+      .to.be.instanceof(ChunkNotFoundError)
       .with.property('hash', fakeHash('nosuchhash'));
   });
 }

--- a/src/dag/store.ts
+++ b/src/dag/store.ts
@@ -34,11 +34,11 @@ export interface Write extends Read {
   commit(): Promise<void>;
 }
 
-export class MissingChunkError extends Error {
-  name = 'MissingChunkError';
+export class ChunkNotFoundError extends Error {
+  name = 'ChunkNotFoundError';
   readonly hash: Hash;
   constructor(hash: Hash) {
-    super(`Missing chunk ${hash}`);
+    super(`Chunk not found ${hash}`);
     this.hash = hash;
   }
 }
@@ -51,5 +51,5 @@ export async function mustGetChunk(
   if (chunk) {
     return chunk;
   }
-  throw new MissingChunkError(hash);
+  throw new ChunkNotFoundError(hash);
 }

--- a/src/db/visitor.ts
+++ b/src/db/visitor.ts
@@ -13,7 +13,7 @@ import type * as dag from '../dag/mod';
 import {emptyHash, Hash} from '../hash';
 import {InternalNode, isInternalNode, Node} from '../btree/node';
 import {HashRefType} from './hash-ref-type';
-import {MissingChunkError} from '../dag/store.js';
+import {ChunkNotFoundError} from '../dag/store.js';
 
 export class Visitor {
   readonly dagRead: dag.Read;
@@ -37,7 +37,7 @@ export class Visitor {
       if (hashRefType === HashRefType.AllowWeak) {
         return;
       }
-      throw new MissingChunkError(h);
+      throw new ChunkNotFoundError(h);
     }
 
     const {data} = chunk;

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -1377,14 +1377,14 @@ export class Replicache<MD extends MutatorDefs = {}> {
   }
 
   /**
-   * In the case we get a MissingChunkError we check if the client got garbage
+   * In the case we get a ChunkNotFoundError we check if the client got garbage
    * collected and if so change the error to a ClientNotFoundError instead
    */
   private async _convertToClientStateNotFoundError(
     ex: unknown,
   ): Promise<unknown> {
     if (
-      ex instanceof dag.MissingChunkError &&
+      ex instanceof dag.ChunkNotFoundError &&
       (await this._checkForClientStateNotFoundAndCallHandler())
     ) {
       return new persist.ClientStateNotFoundError(await this._clientIDPromise);


### PR DESCRIPTION
To ChunkNotFoundError

To be consistent with ClientStateNotFound