### PR TITLE
chore: Remove flag to persist

### DIFF
--- a/src/persist/clients-test-helpers.ts
+++ b/src/persist/clients-test-helpers.ts
@@ -1,4 +1,4 @@
-import {Client, ClientMap, updateClients} from './clients';
+import {Client, ClientMap, initClient, updateClients} from './clients';
 import type * as dag from '../dag/mod';
 import type * as sync from '../sync/mod';
 import type {Hash} from '../hash';
@@ -38,4 +38,15 @@ export async function deleteClientForTesting(
       clients: new Map(clientsAfterGC),
     };
   }, dagStore);
+}
+
+export async function initClientWithClientID(
+  clientID: sync.ClientID,
+  dagStore: dag.Store,
+): Promise<void> {
+  const [generatedClientID, client, clientMap] = await initClient(dagStore);
+  const newMap = new Map(clientMap);
+  newMap.delete(generatedClientID);
+  newMap.set(clientID, client);
+  await setClients(newMap, dagStore);
 }

--- a/src/persist/persist.test.ts
+++ b/src/persist/persist.test.ts
@@ -25,6 +25,7 @@ import {getClient, ClientStateNotFoundError} from './clients';
 import {addSyncSnapshot} from '../sync/test-helpers';
 import {persist} from './persist';
 import {gcClients} from './client-gc.js';
+import {initClientWithClientID} from './clients-test-helpers.js';
 
 let clock: SinonFakeTimers;
 setup(() => {
@@ -102,12 +103,13 @@ async function getChunkSnapshot(
 }
 
 suite('persist on top of different kinds of commits', () => {
-  const {memdag, perdag, chain, testPersist} = setupPersistTest();
+  const {memdag, perdag, chain, testPersist, clientID} = setupPersistTest();
 
   setup(async () => {
     memdag.clear();
     perdag.clear();
     chain.length = 0;
+    await initClientWithClientID(clientID, perdag);
     await addGenesis(chain, memdag);
   });
 
@@ -210,6 +212,7 @@ suite('persist on top of different kinds of commits', () => {
 
 test('We get a MissingClientException during persist if client is missing', async () => {
   const {memdag, perdag, chain, testPersist, clientID} = setupPersistTest();
+  await initClientWithClientID(clientID, perdag);
 
   await addGenesis(chain, memdag);
   await addLocal(chain, memdag);
@@ -249,7 +252,7 @@ function setupPersistTest() {
   const chain: Chain = [];
 
   const testPersist = async () => {
-    await persist(clientID, memdag, perdag, 'skip');
+    await persist(clientID, memdag, perdag);
     await assertSameDagData(clientID, memdag, perdag);
     await assertClientMutationIDsCorrect(clientID, perdag);
   };

--- a/src/persist/persist.ts
+++ b/src/persist/persist.ts
@@ -25,12 +25,11 @@ export async function persist(
   clientID: ClientID,
   memdag: dag.Store,
   perdag: dag.Store,
-  skipClientExists?: 'skip',
 ): Promise<void> {
   // Start checking if client exists while we do other async work
-  const clientExistsCheckP =
-    !skipClientExists &&
-    perdag.withRead(read => assertHasClientState(clientID, read));
+  const clientExistsCheckP = perdag.withRead(read =>
+    assertHasClientState(clientID, read),
+  );
 
   // 1. Gather all temp chunks from main head on the memdag.
   const [gatheredChunks, mainHeadTempHash, mutationID, lastMutationID] =

--- a/src/replicache-mutation-recovery.test.ts
+++ b/src/replicache-mutation-recovery.test.ts
@@ -24,6 +24,7 @@ import sinon from 'sinon';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error
 import fetchMock from 'fetch-mock/esm/client';
+import {initClientWithClientID} from './persist/clients-test-helpers.js';
 
 initReplicacheTesting();
 
@@ -80,12 +81,14 @@ async function createAndPersistClientWithPendingLocal(
   await addGenesis(chain, testMemdag);
   await addSnapshot(chain, testMemdag, [['unique', uuid()]]);
 
+  await initClientWithClientID(clientID, perdag);
+
   const localMetas: db.LocalMeta[] = [];
   for (let i = 0; i < numLocal; i++) {
     await addLocal(chain, testMemdag);
     localMetas.push(chain[chain.length - 1].meta as db.LocalMeta);
   }
-  await persist.persist(clientID, testMemdag, perdag, 'skip');
+  await persist.persist(clientID, testMemdag, perdag);
   return localMetas;
 }
 


### PR DESCRIPTION
Fix tests to not need to skip the checking of missing clients

Followup to #867