### PR TITLE
feat: New Phone, Who Dis?

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -6,6 +6,7 @@ export type {
   MutatorDefs,
   Poke,
   RequestOptions,
+  ClientStateNotFoundReason,
 } from './replicache';
 export type {ReplicacheOptions} from './replicache-options';
 export type {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -36,6 +36,8 @@ export type {
   PatchOperation,
   Puller,
   PullResponse,
+  PullResponseOK,
+  ClientStateNotFoundResponse,
   PullerResult,
   PullError,
 } from './puller';

--- a/src/new-phone-who-dis.test.ts
+++ b/src/new-phone-who-dis.test.ts
@@ -1,0 +1,80 @@
+import {expect} from '@esm-bundle/chai';
+import * as sinon from 'sinon';
+import type {Puller} from './puller.js';
+import type {Pusher} from './pusher.js';
+import type {Poke} from './replicache.js';
+import {
+  initReplicacheTesting,
+  replicacheForTesting,
+  tickAFewTimes,
+} from './test-util.js';
+
+initReplicacheTesting();
+
+test('pull returning ClientStateNotFoundResponse should call onClientStateNotFound', async () => {
+  const puller: Puller = async _req => {
+    return {
+      httpRequestInfo: {httpStatusCode: 200, errorMessage: ''},
+      response: {
+        error: 'ClientStateNotFound',
+      },
+    };
+  };
+  const pusher: Pusher = async _req => {
+    return {httpStatusCode: 200, errorMessage: ''};
+  };
+
+  const consoleErrorStub = sinon.stub(console, 'error');
+  const onClientStateNotFound = sinon.fake();
+
+  const rep = await replicacheForTesting('new-phone', {
+    puller,
+    pusher,
+    onClientStateNotFound,
+  });
+
+  // One pull from open
+
+  expect(onClientStateNotFound.callCount).to.equal(1);
+  expect(consoleErrorStub.callCount).to.equal(1);
+  expect(consoleErrorStub.lastCall.args).to.deep.equal([
+    `Client state not found, clientID: ${await rep.clientID}`,
+  ]);
+
+  rep.pull();
+  await tickAFewTimes();
+
+  expect(onClientStateNotFound.callCount).to.equal(2);
+  expect(consoleErrorStub.callCount).to.equal(2);
+  expect(consoleErrorStub.lastCall.args).to.deep.equal([
+    `Client state not found, clientID: ${await rep.clientID}`,
+  ]);
+});
+
+test('poke with ClientStateNotFoundResponse should call onClientStateNotFound', async () => {
+  const puller: Puller = async _req => {
+    return {
+      httpRequestInfo: {httpStatusCode: 200, errorMessage: ''},
+    };
+  };
+
+  const consoleErrorStub = sinon.stub(console, 'error');
+  const onClientStateNotFound = sinon.fake();
+
+  const rep = await replicacheForTesting('new-phone', {
+    puller,
+    onClientStateNotFound,
+  });
+
+  const pokeBody: Poke = {
+    baseCookie: null,
+    pullResponse: {error: 'ClientStateNotFound'},
+  };
+  await rep.poke(pokeBody);
+
+  expect(onClientStateNotFound.callCount).to.equal(1);
+  expect(consoleErrorStub.callCount).to.equal(1);
+  expect(consoleErrorStub.lastCall.args).to.deep.equal([
+    `Client state not found, clientID: ${await rep.clientID}`,
+  ]);
+});

--- a/src/new-phone-who-dis.test.ts
+++ b/src/new-phone-who-dis.test.ts
@@ -4,6 +4,7 @@ import type {Puller} from './puller.js';
 import type {Pusher} from './pusher.js';
 import type {Poke} from './replicache.js';
 import {
+  expectLogContext,
   initReplicacheTesting,
   replicacheForTesting,
   tickAFewTimes,
@@ -36,19 +37,30 @@ test('pull returning ClientStateNotFoundResponse should call onClientStateNotFou
   // One pull from open
 
   expect(onClientStateNotFound.callCount).to.equal(1);
-  expect(consoleErrorStub.callCount).to.equal(1);
-  expect(consoleErrorStub.lastCall.args).to.deep.equal([
-    `Client state not found, clientID: ${await rep.clientID}`,
+  expect(onClientStateNotFound.lastCall.args).to.deep.equal([
+    {type: 'ClientStateNotFoundOnServer'},
   ]);
+
+  expectLogContext(
+    consoleErrorStub,
+    0,
+    rep,
+    `Client state not found, clientID: ${await rep.clientID}`,
+  );
 
   rep.pull();
   await tickAFewTimes();
 
   expect(onClientStateNotFound.callCount).to.equal(2);
-  expect(consoleErrorStub.callCount).to.equal(2);
-  expect(consoleErrorStub.lastCall.args).to.deep.equal([
-    `Client state not found, clientID: ${await rep.clientID}`,
+  expect(onClientStateNotFound.lastCall.args).to.deep.equal([
+    {type: 'ClientStateNotFoundOnServer'},
   ]);
+  expectLogContext(
+    consoleErrorStub,
+    1,
+    rep,
+    `Client state not found, clientID: ${await rep.clientID}`,
+  );
 });
 
 test('poke with ClientStateNotFoundResponse should call onClientStateNotFound', async () => {
@@ -73,8 +85,14 @@ test('poke with ClientStateNotFoundResponse should call onClientStateNotFound', 
   await rep.poke(pokeBody);
 
   expect(onClientStateNotFound.callCount).to.equal(1);
-  expect(consoleErrorStub.callCount).to.equal(1);
-  expect(consoleErrorStub.lastCall.args).to.deep.equal([
-    `Client state not found, clientID: ${await rep.clientID}`,
+  expect(onClientStateNotFound.lastCall.args).to.deep.equal([
+    {type: 'ClientStateNotFoundOnServer'},
   ]);
+  expect(consoleErrorStub.callCount).to.equal(1);
+  expectLogContext(
+    consoleErrorStub,
+    0,
+    rep,
+    `Client state not found, clientID: ${await rep.clientID}`,
+  );
 });

--- a/src/new-phone-who-dis.test.ts
+++ b/src/new-phone-who-dis.test.ts
@@ -38,7 +38,7 @@ test('pull returning ClientStateNotFoundResponse should call onClientStateNotFou
 
   expect(onClientStateNotFound.callCount).to.equal(1);
   expect(onClientStateNotFound.lastCall.args).to.deep.equal([
-    {type: 'ClientStateNotFoundOnServer'},
+    {type: 'NotFoundOnServer'},
   ]);
 
   expectLogContext(
@@ -53,7 +53,7 @@ test('pull returning ClientStateNotFoundResponse should call onClientStateNotFou
 
   expect(onClientStateNotFound.callCount).to.equal(2);
   expect(onClientStateNotFound.lastCall.args).to.deep.equal([
-    {type: 'ClientStateNotFoundOnServer'},
+    {type: 'NotFoundOnServer'},
   ]);
   expectLogContext(
     consoleErrorStub,
@@ -86,7 +86,7 @@ test('poke with ClientStateNotFoundResponse should call onClientStateNotFound', 
 
   expect(onClientStateNotFound.callCount).to.equal(1);
   expect(onClientStateNotFound.lastCall.args).to.deep.equal([
-    {type: 'ClientStateNotFoundOnServer'},
+    {type: 'NotFoundOnServer'},
   ]);
   expect(consoleErrorStub.callCount).to.equal(1);
   expectLogContext(

--- a/src/replicache-persist.test.ts
+++ b/src/replicache-persist.test.ts
@@ -123,7 +123,7 @@ suite('onClientStateNotFound', () => {
 
     expect(onClientStateNotFound.callCount).to.equal(1);
     expect(onClientStateNotFound.lastCall.args).to.deep.equal([
-      {type: 'ClientStateNotFoundOnClient'},
+      {type: 'NotFoundOnClient'},
     ]);
     expectLogContext(
       consoleErrorStub,
@@ -172,7 +172,7 @@ suite('onClientStateNotFound', () => {
       `Client state not found, clientID: ${clientID2}`,
     );
     expect(onClientStateNotFound.lastCall.args).to.deep.equal([
-      {type: 'ClientStateNotFoundOnClient'},
+      {type: 'NotFoundOnClient'},
     ]);
   });
 
@@ -224,7 +224,7 @@ suite('onClientStateNotFound', () => {
       `Client state not found, clientID: ${clientID2}`,
     );
     expect(onClientStateNotFound.lastCall.args).to.deep.equal([
-      {type: 'ClientStateNotFoundOnClient'},
+      {type: 'NotFoundOnClient'},
     ]);
   });
 });

--- a/src/replicache-persist.test.ts
+++ b/src/replicache-persist.test.ts
@@ -1,5 +1,6 @@
 import {
   addData,
+  expectLogContext,
   initReplicacheTesting,
   replicacheForTesting,
   tickAFewTimes,
@@ -17,7 +18,6 @@ import * as persist from './persist/mod';
 import {assertNotTempHash} from './hash';
 import {assertNotUndefined} from './asserts';
 import {deleteClientForTesting} from './persist/clients-test-helpers.js';
-import type {ClientID} from './sync/client-id.js';
 
 initReplicacheTesting();
 
@@ -104,18 +104,6 @@ test('basic persist & load', async () => {
 });
 
 suite('onClientStateNotFound', () => {
-  function checkConsoleErrorStub(
-    name: string,
-    consoleErrorStub: sinon.SinonStub,
-    clientID: ClientID,
-  ) {
-    expect(consoleErrorStub.callCount).to.equal(1);
-    const {args} = consoleErrorStub.lastCall;
-    expect(args).to.have.length(2);
-    expect(args[0]).to.equal(`name=${name}`);
-    expect(args[1]).to.equal(`Client state not found, clientID: ${clientID}`);
-  }
-
   test('Called in persist if collected', async () => {
     const consoleErrorStub = sinon.stub(console, 'error');
 
@@ -134,7 +122,15 @@ suite('onClientStateNotFound', () => {
     await rep.persist();
 
     expect(onClientStateNotFound.callCount).to.equal(1);
-    checkConsoleErrorStub(rep.name, consoleErrorStub, clientID);
+    expect(onClientStateNotFound.lastCall.args).to.deep.equal([
+      {type: 'ClientStateNotFoundOnClient'},
+    ]);
+    expectLogContext(
+      consoleErrorStub,
+      0,
+      rep,
+      `Client state not found, clientID: ${clientID}`,
+    );
   });
 
   test('Called in query if collected', async () => {
@@ -169,7 +165,15 @@ suite('onClientStateNotFound', () => {
       e = err;
     }
     expect(e).to.be.instanceOf(persist.ClientStateNotFoundError);
-    checkConsoleErrorStub(rep2.name, consoleErrorStub, clientID2);
+    expectLogContext(
+      consoleErrorStub,
+      0,
+      rep2,
+      `Client state not found, clientID: ${clientID2}`,
+    );
+    expect(onClientStateNotFound.lastCall.args).to.deep.equal([
+      {type: 'ClientStateNotFoundOnClient'},
+    ]);
   });
 
   test('Called in mutate if collected', async () => {
@@ -213,6 +217,14 @@ suite('onClientStateNotFound', () => {
     }
 
     expect(e).to.be.instanceOf(persist.ClientStateNotFoundError);
-    checkConsoleErrorStub(rep2.name, consoleErrorStub, clientID2);
+    expectLogContext(
+      consoleErrorStub,
+      0,
+      rep2,
+      `Client state not found, clientID: ${clientID2}`,
+    );
+    expect(onClientStateNotFound.lastCall.args).to.deep.equal([
+      {type: 'ClientStateNotFoundOnClient'},
+    ]);
   });
 });

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -153,16 +153,19 @@ const emptySet: ReadonlySet<string> = new Set();
 type UnknownSubscription = Subscription<JSONValue | undefined, unknown>;
 type SubscriptionSet = Set<UnknownSubscription>;
 
-type ErrorReason =
-  | {type: 'ClientStateNotFoundOnServer'}
-  | {type: 'ClientStateNotFoundOnClient'};
+/**
+ * The reason [[onClientStateNotFound]] was called.
+ */
+export type ClientStateNotFoundReason =
+  | {type: 'NotFoundOnServer'}
+  | {type: 'NotFoundOnClient'};
 
 const reasonServer = {
-  type: 'ClientStateNotFoundOnServer',
+  type: 'NotFoundOnServer',
 } as const;
 
 const reasonClient = {
-  type: 'ClientStateNotFoundOnClient',
+  type: 'NotFoundOnClient',
 } as const;
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -303,11 +306,14 @@ export class Replicache<MD extends MutatorDefs = {}> {
    * garbage collected. This can happen if the client has not been used for over
    * a week.
    *
+   * It can also happen if the server no longer knows about this client.
+   *
    * The default behavior is to reload the page (using `location.reload()`). Set
    * this to `null` or provide your own function to prevent the page from
    * reloading automatically.
    */
-  onClientStateNotFound: ((reason: ErrorReason) => void) | null = reload;
+  onClientStateNotFound: ((reason: ClientStateNotFoundReason) => void) | null =
+    reload;
 
   /**
    * This gets called when we get an HTTP unauthorized (401) response from the
@@ -1099,7 +1105,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
   }
   private _fireOnClientStateNotFound(
     clientID: sync.ClientID,
-    reason: ErrorReason,
+    reason: ClientStateNotFoundReason,
   ) {
     this._lc.error?.(`Client state not found, clientID: ${clientID}`);
     this.onClientStateNotFound?.(reason);

--- a/src/sync/pull.ts
+++ b/src/sync/pull.ts
@@ -4,10 +4,12 @@ import * as db from '../db/mod';
 import {deepClone, deepEqual, JSONValue, ReadonlyJSONValue} from '../json';
 import {
   assertPullResponse,
+  isClientStateNotFoundResponse,
   Puller,
   PullerResult,
   PullError,
   PullResponse,
+  PullResponseOK,
 } from '../puller';
 import {assertHTTPRequestInfo, HTTPRequestInfo} from '../http-request-info';
 import {callJSRequest} from './js-request';
@@ -106,7 +108,7 @@ export async function beginPull(
     };
   }
 
-  if (!createSyncBranch) {
+  if (!createSyncBranch || isClientStateNotFoundResponse(response)) {
     return {
       httpRequestInfo,
       pullResponse: response,
@@ -130,7 +132,7 @@ export async function handlePullResponse(
   lc: LogContext,
   store: dag.Store,
   expectedBaseCookie: ReadonlyJSONValue,
-  response: PullResponse,
+  response: PullResponseOK,
 ): Promise<Hash | null> {
   // It is possible that another sync completed while we were pulling. Ensure
   // that is not the case by re-checking the base snapshot.

--- a/src/test-util.ts
+++ b/src/test-util.ts
@@ -1,3 +1,4 @@
+import {expect} from '@esm-bundle/chai';
 import {MutatorDefs, Replicache, BeginPullResult} from './replicache';
 import type {ReplicacheOptions} from './replicache-options';
 import * as kv from './kv/mod';
@@ -95,14 +96,14 @@ export async function deleteAllDatabases(): Promise<void> {
   dbsToDrop.clear();
 }
 
-const partialNamesToRepliacheNames: Map<string, string> = new Map();
-/** Namespace replicache names to isolate tests' indexeddb state. */
+const partialNamesToReplicacheNames: Map<string, string> = new Map();
+/** Namespace replicache names to isolate tests' IndexedDB state. */
 export function createReplicacheNameForTest(partialName: string): string {
-  let replicacheName = partialNamesToRepliacheNames.get(partialName);
+  let replicacheName = partialNamesToReplicacheNames.get(partialName);
   if (!replicacheName) {
     const namespaceForTest = uuid();
     replicacheName = `${namespaceForTest}:${partialName}`;
-    partialNamesToRepliacheNames.set(partialName, replicacheName);
+    partialNamesToReplicacheNames.set(partialName, replicacheName);
   }
   return replicacheName;
 }
@@ -180,7 +181,7 @@ export function initReplicacheTesting(): void {
     clock.restore();
     fetchMock.restore();
     sinon.restore();
-    partialNamesToRepliacheNames.clear();
+    partialNamesToReplicacheNames.clear();
     await closeAllReps();
     await deleteAllDatabases();
     await persist.teardownIDBDatabasesStoreForTest();
@@ -248,4 +249,17 @@ export async function addData(
   for (const [key, value] of Object.entries(data)) {
     await tx.put(key, value);
   }
+}
+
+export function expectLogContext(
+  consoleLogStub: sinon.SinonStub,
+  index: number,
+  rep: Replicache,
+  expectedContext: string,
+) {
+  expect(consoleLogStub.callCount).to.greaterThan(index);
+  const {args} = consoleLogStub.getCall(index);
+  expect(args).to.have.length(2);
+  expect(args[0]).to.equal(`name=${rep.name}`);
+  expect(args[1]).to.equal(expectedContext);
 }


### PR DESCRIPTION
The server can now tell the client that it does not know about a client.
When this happens the client calls `onClientStateNotFound`.

The server can return:

```json
{"error": "ClientStateNotFound"}
```

Fixes #335