### PR TITLE
fix: Use json deepEqual in splice computation

### DIFF
--- a/src/btree/splice.test.ts
+++ b/src/btree/splice.test.ts
@@ -223,6 +223,24 @@ test('splice', () => {
     ],
     [[0, 3, 2, 0]],
   );
+
+  // Test with objects to ensure deep equality is used.
+  t(
+    [
+      ['a', {x: 0}],
+      ['b', {x: 1}],
+      ['c', {x: 2}],
+    ],
+    [
+      ['b', {x: 1}],
+      ['d', {x: 3}],
+      ['e', {x: 4}],
+    ],
+    [
+      [0, 1, 0, 0],
+      [2, 1, 2, 1],
+    ],
+  );
 });
 
 test('splice roundtrip', () => {

--- a/src/btree/splice.ts
+++ b/src/btree/splice.ts
@@ -1,3 +1,4 @@
+import {deepEqual} from '../json.js';
 import type {ReadonlyEntry} from './node';
 
 export type Splice = [at: number, removed: number, added: number, from: number];
@@ -31,7 +32,9 @@ export function* computeSplices<T>(
 
   while (previousIndex < previous.length && currentIndex < current.length) {
     if (previous[previousIndex][KEY] === current[currentIndex][KEY]) {
-      if (previous[previousIndex][VALUE] === current[currentIndex][VALUE]) {
+      if (
+        deepEqual(previous[previousIndex][VALUE], current[currentIndex][VALUE])
+      ) {
         if (splice) {
           ensureAssigned(splice, 0);
           yield splice;


### PR DESCRIPTION
This could potentionally lead to a subscription firing when the value
didn't change.

Fixes #841