### PR TITLE
chore!: Removal of deprecated Replicache methods.

### DIFF
--- a/src/replicache-types.test.ts
+++ b/src/replicache-types.test.ts
@@ -135,37 +135,39 @@ test.skip('Test register param [type checking only]', async () => {
 test.skip('Key type for scans [type checking only]', async () => {
   const rep = new Replicache({name: 'test-types'});
 
-  for await (const k of rep.scan({indexName: 'n'}).keys()) {
-    // @ts-expect-error Type '[secondary: string, primary?: string | undefined]' is not assignable to type 'string'.ts(2322)
-    const k2: string = k;
-    console.log(k2);
-  }
+  await rep.query(async tx => {
+    for await (const k of tx.scan({indexName: 'n'}).keys()) {
+      // @ts-expect-error Type '[secondary: string, primary?: string | undefined]' is not assignable to type 'string'.ts(2322)
+      const k2: string = k;
+      console.log(k2);
+    }
 
-  for await (const k of rep.scan({indexName: 'n', start: {key: 's'}}).keys()) {
-    // @ts-expect-error Type '[secondary: string, primary?: string | undefined]' is not assignable to type 'string'.ts(2322)
-    const k2: string = k;
-    console.log(k2);
-  }
+    for await (const k of tx.scan({indexName: 'n', start: {key: 's'}}).keys()) {
+      // @ts-expect-error Type '[secondary: string, primary?: string | undefined]' is not assignable to type 'string'.ts(2322)
+      const k2: string = k;
+      console.log(k2);
+    }
 
-  for await (const k of rep
-    .scan({indexName: 'n', start: {key: ['s']}})
-    .keys()) {
-    // @ts-expect-error Type '[secondary: string, primary?: string | undefined]' is not assignable to type 'string'.ts(2322)
-    const k2: string = k;
-    console.log(k2);
-  }
+    for await (const k of tx
+      .scan({indexName: 'n', start: {key: ['s']}})
+      .keys()) {
+      // @ts-expect-error Type '[secondary: string, primary?: string | undefined]' is not assignable to type 'string'.ts(2322)
+      const k2: string = k;
+      console.log(k2);
+    }
 
-  for await (const k of rep.scan({start: {key: 'p'}}).keys()) {
-    // @ts-expect-error Type 'string' is not assignable to type '[string]'.ts(2322)
-    const k2: [string] = k;
-    console.log(k2);
-  }
+    for await (const k of tx.scan({start: {key: 'p'}}).keys()) {
+      // @ts-expect-error Type 'string' is not assignable to type '[string]'.ts(2322)
+      const k2: [string] = k;
+      console.log(k2);
+    }
 
-  // @ts-expect-error Type 'number' is not assignable to type 'string | undefined'.ts(2322)
-  rep.scan({indexName: 'n', start: {key: ['s', 42]}});
+    // @ts-expect-error Type 'number' is not assignable to type 'string | undefined'.ts(2322)
+    tx.scan({indexName: 'n', start: {key: ['s', 42]}});
 
-  // @ts-expect-error Type '[string]' is not assignable to type 'string'.ts(2322)
-  rep.scan({start: {key: ['s']}});
+    // @ts-expect-error Type '[string]' is not assignable to type 'string'.ts(2322)
+    tx.scan({start: {key: ['s']}});
+  });
 });
 
 // Only used for type checking
@@ -313,14 +315,6 @@ test.skip('mut [type checking only]', async () => {
 // Only used for type checking
 test.skip('scan with index [type checking only]', async () => {
   const rep = new Replicache({name: 'scan-with-index'});
-
-  (await rep.scan({indexName: 'a'}).keys().toArray()) as [
-    secondary: string,
-    primary: string,
-  ][];
-
-  (await rep.scan({}).keys().toArray()) as string[];
-  (await rep.scan().keys().toArray()) as string[];
 
   await rep.query(async tx => {
     (await tx.scan({indexName: 'a'}).keys().toArray()) as [

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -2,7 +2,6 @@ import {LogContext, OptionalLogger} from '@rocicorp/logger';
 import {resolver, Lock} from './deps';
 import {deepClone, deepEqual, ReadonlyJSONValue} from './json';
 import type {JSONValue} from './json';
-import type {KeyTypeForScanOptions, ScanOptions} from './scan-options';
 import {Pusher, PushError} from './pusher';
 import {Puller, PullError, PullResponse} from './puller';
 import {
@@ -16,7 +15,6 @@ import type {
   ReadTransaction,
   WriteTransaction,
 } from './transactions';
-import {ScanResult} from './scan-iterator';
 import {ConnectionLoop, MAX_DELAY_MS, MIN_DELAY_MS} from './connection-loop';
 import {defaultPuller} from './puller';
 import {defaultPusher} from './pusher';
@@ -651,55 +649,6 @@ export class Replicache<MD extends MutatorDefs = {}> {
       this._root = Promise.resolve(root);
       await this._fireOnChange(changedKeys);
     }
-  }
-
-  /**
-   * Get a single value from the database.
-   * @deprecated Use [[query]] instead.
-   */
-  get(key: string): Promise<ReadonlyJSONValue | undefined> {
-    return this.query(tx => tx.get(key));
-  }
-
-  /**
-   * Determines if a single `key` is present in the database.
-   * @deprecated Use [[query]] instead.
-   */
-  has(key: string): Promise<boolean> {
-    return this.query(tx => tx.has(key));
-  }
-
-  /**
-   * Whether the database is empty.
-   * @deprecated Use [[query]] instead.
-   */
-  isEmpty(): Promise<boolean> {
-    return this.query(tx => tx.isEmpty());
-  }
-
-  /**
-   * Gets many values from the database. This returns a `ScanResult` which
-   * implements `AsyncIterable`. It also has methods to iterate over the `keys`
-   * and `entries`.
-   *
-   * If `options` has an `indexName`, then this does a scan over an index with
-   * that name. A scan over an index uses a tuple for the key consisting of
-   * `[secondary: string, primary: string]`.
-   * @deprecated Use [[query]] instead.
-   */
-  scan<Options extends ScanOptions, Key extends KeyTypeForScanOptions<Options>>(
-    options?: Options,
-  ): ScanResult<Key, ReadonlyJSONValue> {
-    return new ScanResult<Key>(
-      options,
-      async () => {
-        await this._ready;
-        const dagRead = await this._memdag.read();
-        return db.readFromDefaultHead(dagRead);
-      },
-      true, // shouldCloseTransaction
-      false, // shouldClone
-    );
   }
 
   /**


### PR DESCRIPTION
This removes the following deprecated methods from the Replicache
instance:
- scan
- has
- isEmpty
- get

These have been deprecated since 8.0