### PR TITLE
feat: Disable a bunch of assertions in prod

### DIFF
--- a/perf/runner.js
+++ b/perf/runner.js
@@ -134,7 +134,16 @@ async function main() {
       rootDir: process.cwd(),
       port,
       watch: false,
-      plugins: [esbuildPlugin({ts: true, target: 'esnext'})],
+      plugins: [
+        esbuildPlugin({
+          ts: true,
+          target: 'esnext',
+          define: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            'process.env.NODE_ENV': '"production"',
+          },
+        }),
+      ],
     },
     readCliArgs: false,
     readFileConfig: false,

--- a/src/btree/node.ts
+++ b/src/btree/node.ts
@@ -3,6 +3,7 @@ import {assert, assertArray, assertNumber, assertString} from '../asserts';
 import {Hash, emptyHash, newTempHash} from '../hash';
 import type {BTreeRead} from './read';
 import type {BTreeWrite} from './write';
+import {skipBTreeNodeAsserts} from '../config.js';
 
 export type Entry<V> = [key: string, value: V];
 export type ReadonlyEntry<V> = readonly [key: string, value: V];
@@ -119,6 +120,9 @@ export function binarySearch<V>(
 export function assertBTreeNode(
   v: unknown,
 ): asserts v is InternalNode | DataNode {
+  if (skipBTreeNodeAsserts) {
+    return;
+  }
   assertArray(v);
 
   function assertEntry(

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,7 @@
+const isProd = process.env.NODE_ENV === 'production';
+
+export const skipCommitDataAsserts = isProd;
+
+export const skipAssertJSONValue = isProd;
+
+export const skipBTreeNodeAsserts = isProd;

--- a/src/db/commit.ts
+++ b/src/db/commit.ts
@@ -10,6 +10,7 @@ import {
 } from '../asserts';
 import type {Value} from '../kv/store';
 import {assertHash, Hash} from '../hash';
+import {skipCommitDataAsserts} from '../config.js';
 
 export const DEFAULT_HEAD_NAME = 'main';
 
@@ -204,7 +205,9 @@ export type SnapshotMeta = BasisHash & {
   readonly cookieJSON: ReadonlyJSONValue;
 };
 
-function assertSnapshot(v: Record<string, unknown>): asserts v is SnapshotMeta {
+function assertSnapshotMeta(
+  v: Record<string, unknown>,
+): asserts v is SnapshotMeta {
   // type already asserted
   assertNumber(v.lastMutationID);
   assertJSONValue(v.cookieJSON);
@@ -227,7 +230,7 @@ function assertMeta(v: unknown): asserts v is Meta {
       assertLocalMeta(v);
       break;
     case MetaTyped.Snapshot:
-      assertSnapshot(v);
+      assertSnapshotMeta(v);
       break;
     default:
       throw new Error(`Invalid enum value ${v.type}`);
@@ -376,6 +379,10 @@ export type CommitData<M extends Meta> = {
 };
 
 export function assertCommitData(v: unknown): asserts v is CommitData<Meta> {
+  if (skipCommitDataAsserts) {
+    return;
+  }
+
   assertObject(v);
   assertMeta(v.meta);
   assertString(v.valueHash);

--- a/src/json.ts
+++ b/src/json.ts
@@ -1,4 +1,5 @@
 import {assertObject, throwInvalidType} from './asserts';
+import {skipAssertJSONValue} from './config.js';
 import {hasOwn} from './has-own';
 
 /** The values that can be represented in JSON */
@@ -238,6 +239,9 @@ function isSmi(value: number): boolean {
 }
 
 export function assertJSONValue(v: unknown): asserts v is JSONValue {
+  if (skipAssertJSONValue) {
+    return;
+  }
   switch (typeof v) {
     case 'boolean':
     case 'number':

--- a/src/process-env.test.ts
+++ b/src/process-env.test.ts
@@ -1,0 +1,5 @@
+import {expect} from '@esm-bundle/chai';
+
+test('process', () => {
+  expect(process.env.NODE_ENV).to.equal('development');
+});

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -8,7 +8,13 @@ const firefox = playwrightLauncher({product: 'firefox'});
 export default {
   concurrentBrowsers: 3,
   nodeResolve: true,
-  plugins: [esbuildPlugin({ts: true, target: 'esnext'})],
+  plugins: [
+    esbuildPlugin({
+      ts: true,
+      target: 'esnext',
+      define: {'process.env.NODE_ENV': '"development"'},
+    }),
+  ],
   staticLogging: !!process.env.CI,
   testFramework: {
     config: {


### PR DESCRIPTION
When `process.env.NODE_ENV === 'production'` we skip validating the
shape of the chunks (is it a Commit? is it a B+Tree?) as well as
skipping validating that the JSONValue is really a JSONValue.

Fixes #876