### PR TITLE
refactor: Remove unused ScanResult parameters

### DIFF
--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -110,13 +110,7 @@ export class ReadTransactionImpl<
     onLimitKey?: (inclusiveLimitKey: string) => void,
   ): ScanResult<Key, Value> {
     const dbRead = this._dbtx;
-    return new ScanResult(
-      options,
-      () => dbRead,
-      false, // shouldCloseTransaction
-      dbRead instanceof db.Write, // shouldClone,
-      onLimitKey,
-    );
+    return new ScanResult(options, dbRead, onLimitKey);
   }
 }
 


### PR DESCRIPTION
Now that the deprecated scan has been removed we can remov some of the
parameters to ScanResult etc.