### PR TITLE
feature: Enable custom log handling by adding logSink to ReplicacheOptions

### DIFF
--- a/doc/docusaurus.config.js
+++ b/doc/docusaurus.config.js
@@ -20,7 +20,7 @@ module.exports = {
         exclude: ['node_modules', 'src/*.test.ts'],
         excludePrivate: true,
         excludeProtected: true,
-        excludeExternals: true,
+        excludeExternals: false,
         disableSources: true,
         name: 'Replicache',
         readme: 'none',

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@esm-bundle/chai": "^4.3.4",
         "@rocicorp/licensing": "^4.0.0-beta.3",
         "@rocicorp/lock": "^1.0.1",
-        "@rocicorp/logger": "^2.1.1",
+        "@rocicorp/logger": "^2.2.0",
         "@rocicorp/resolver": "^1.0.0",
         "@types/lodash-es": "^4.17.5",
         "@types/mocha": "^9.0.0",
@@ -649,9 +649,9 @@
       }
     },
     "node_modules/@rocicorp/logger": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@rocicorp/logger/-/logger-2.1.1.tgz",
-      "integrity": "sha512-JrwEvp9lRV2mQ7pwSdoNmtYvBGrBRUP7tIDObHsOkVYMDAgsqpQToZx3AUIaV2aDpoE+UFCqG7+kwatBWLdsVA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@rocicorp/logger/-/logger-2.2.0.tgz",
+      "integrity": "sha512-6HNBFIpUahpNUuF51XFFgwMHvmpOrsyzxVfs0A65uKZrohpHwpCHhj84R/wcZAsvpenILXNR2wpReIMqzPJsuQ==",
       "dev": true,
       "engines": {
         "node": "^14.13.1 || >=16.0.0"
@@ -6880,9 +6880,9 @@
       }
     },
     "@rocicorp/logger": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@rocicorp/logger/-/logger-2.1.1.tgz",
-      "integrity": "sha512-JrwEvp9lRV2mQ7pwSdoNmtYvBGrBRUP7tIDObHsOkVYMDAgsqpQToZx3AUIaV2aDpoE+UFCqG7+kwatBWLdsVA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@rocicorp/logger/-/logger-2.2.0.tgz",
+      "integrity": "sha512-6HNBFIpUahpNUuF51XFFgwMHvmpOrsyzxVfs0A65uKZrohpHwpCHhj84R/wcZAsvpenILXNR2wpReIMqzPJsuQ==",
       "dev": true
     },
     "@rocicorp/resolver": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@esm-bundle/chai": "^4.3.4",
     "@rocicorp/licensing": "^4.0.0-beta.3",
     "@rocicorp/lock": "^1.0.1",
-    "@rocicorp/logger": "^2.1.1",
+    "@rocicorp/logger": "^2.2.0",
     "@rocicorp/resolver": "^1.0.0",
     "@types/lodash-es": "^4.17.5",
     "@types/mocha": "^9.0.0",

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,5 +1,6 @@
 export {Replicache, makeIDBName} from './replicache';
 export {TransactionClosedError} from './transaction-closed-error';
+export {consoleLogSink} from '@rocicorp/logger';
 
 export type {
   MaybePromise,
@@ -18,7 +19,7 @@ export type {
   ScanResult,
   AsyncIterableIteratorToArrayWrapper,
 } from './scan-iterator';
-export type {LogLevel} from '@rocicorp/logger';
+export type {LogSink, LogLevel} from '@rocicorp/logger';
 export type {
   JSONObject,
   JSONValue,

--- a/src/replicache-options.ts
+++ b/src/replicache-options.ts
@@ -92,8 +92,8 @@ export interface ReplicacheOptions<MD extends MutatorDefs> {
    * sent elsewhere (e.g. to a cloud logging service like DataDog) you can
    * provide an array of `LogSink`s.  Logs at or above
    * [[ReplicacheOptions.logLevel]] are sent to each of these `LogSink`s.
-   * If you would still like logs to go to the console, include
-   * [[consoleLogSink]] in the array.
+   * If you would still like logs to go to the console, include `consoleLogSink`
+   * in the array.
    *
    * ```ts
    * logSinks: [consoleLogSink, myCloudLogSink],

--- a/src/replicache-options.ts
+++ b/src/replicache-options.ts
@@ -92,8 +92,8 @@ export interface ReplicacheOptions<MD extends MutatorDefs> {
    * sent elsewhere (e.g. to a cloud logging service like DataDog) you can
    * provide an array of `LogSink`s.  Logs at or above
    * [[ReplicacheOptions.logLevel]] are sent to each of these `LogSink`s.
-   * If you would still like to logs to go to the console, include
-   * [[consoleLogSink]] in your array.
+   * If you would still like logs to go to the console, include
+   * [[consoleLogSink]] in the array.
    *
    * ```ts
    * logSinks: [consoleLogSink, myCloudLogSink],

--- a/src/replicache-options.ts
+++ b/src/replicache-options.ts
@@ -1,4 +1,4 @@
-import type {LogLevel} from '@rocicorp/logger';
+import type {LogLevel, LogSink} from '@rocicorp/logger';
 import type {Pusher} from './pusher';
 import type {Puller} from './puller';
 import type {MutatorDefs, RequestOptions} from './replicache';
@@ -81,8 +81,17 @@ export interface ReplicacheOptions<MD extends MutatorDefs> {
    * Replicache will also log `'info'` and `'error'` messages. When set to
    * `'info'` we log `'info'` and `'error'` but not `'debug'`. When set to
    * `'error'` we only log `'error'` messages.
+   * Default is `'info'`.
    */
   logLevel?: LogLevel;
+
+  /**
+   * Enables custom handling of logs. By default logs are logged to the console.
+   * If you would like logs to be sent somewhere else (e.g. to a cloud logging
+   * service like DataDog) you can provide a custom `LogSink`.  Logs above
+   * [[logLevel]] are sent to this `LogSink`.
+   */
+  logSink?: LogSink;
 
   /**
    * An object used as a map to define the *mutators*. These gets registered at

--- a/src/replicache-options.ts
+++ b/src/replicache-options.ts
@@ -90,10 +90,10 @@ export interface ReplicacheOptions<MD extends MutatorDefs> {
    *
    * By default logs are logged to the console.  If you would like logs to be
    * sent elsewhere (e.g. to a cloud logging service like DataDog) you can
-   * provide an array of `LogSink`s.  Logs at or above
-   * [[ReplicacheOptions.logLevel]] are sent to each of these `LogSink`s.
-   * If you would still like logs to go to the console, include `consoleLogSink`
-   * in the array.
+   * provide an array of [[LogSink]]s.  Logs at or above
+   * [[ReplicacheOptions.logLevel]] are sent to each of these [[LogSink]]s.
+   * If you would still like logs to go to the console, include
+   * [[consoleLogSink]] in the array.
    *
    * ```ts
    * logSinks: [consoleLogSink, myCloudLogSink],

--- a/src/replicache-options.ts
+++ b/src/replicache-options.ts
@@ -88,8 +88,8 @@ export interface ReplicacheOptions<MD extends MutatorDefs> {
   /**
    * Enables custom handling of logs. By default logs are logged to the console.
    * If you would like logs to be sent somewhere else (e.g. to a cloud logging
-   * service like DataDog) you can provide a custom `LogSink`.  Logs above
-   * [[logLevel]] are sent to this `LogSink`.
+   * service like DataDog) you can provide a custom `LogSink`.  Logs at or above
+   * [[ReplicacheOptions.logLevel]] are sent to this `LogSink`.
    */
   logSink?: LogSink;
 

--- a/src/replicache-options.ts
+++ b/src/replicache-options.ts
@@ -86,12 +86,20 @@ export interface ReplicacheOptions<MD extends MutatorDefs> {
   logLevel?: LogLevel;
 
   /**
-   * Enables custom handling of logs. By default logs are logged to the console.
-   * If you would like logs to be sent somewhere else (e.g. to a cloud logging
-   * service like DataDog) you can provide a custom `LogSink`.  Logs at or above
-   * [[ReplicacheOptions.logLevel]] are sent to this `LogSink`.
+   * Enables custom handling of logs.
+   *
+   * By default logs are logged to the console.  If you would like logs to be
+   * sent elsewhere (e.g. to a cloud logging service like DataDog) you can
+   * provide an array of `LogSink`s.  Logs at or above
+   * [[ReplicacheOptions.logLevel]] are sent to each of these `LogSink`s.
+   * If you would still like to logs to go to the console, include
+   * [[consoleLogSink]] in your array.
+   *
+   * ```ts
+   * logSinks: [consoleLogSink, myCloudLogSink],
+   * ```
    */
-  logSink?: LogSink;
+  logSinks?: LogSink[];
 
   /**
    * An object used as a map to define the *mutators*. These gets registered at

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -1409,7 +1409,37 @@ test('logLevel', async () => {
   await rep.close();
 });
 
-test('logSink', async () => {
+test('logSinks length 0', async () => {
+  const infoStub = sinon.stub(console, 'info');
+  const debugStub = sinon.stub(console, 'debug');
+  const expectNoLogsToConsole = () => {
+    expect(infoStub.callCount).to.equal(0);
+    expect(debugStub.callCount).to.equal(0);
+  };
+
+  const resetLogCounts = () => {
+    infoStub.reset();
+    debugStub.reset();
+  };
+
+  resetLogCounts();
+  let rep = await replicacheForTesting('logSinks-0', {
+    logLevel: 'info',
+    logSinks: [],
+  });
+  await rep.query(() => 42);
+  expectNoLogsToConsole();
+  await rep.close();
+  rep = await replicacheForTesting('logSinks-0', {
+    logLevel: 'debug',
+    logSinks: [],
+  });
+  await rep.query(() => 42);
+  expectNoLogsToConsole();
+  await rep.close();
+});
+
+test('logSinks length 1', async () => {
   const infoStub = sinon.stub(console, 'info');
   const debugStub = sinon.stub(console, 'debug');
   const expectNoLogsToConsole = () => {
@@ -1431,13 +1461,13 @@ test('logSink', async () => {
 
   const logSink = {
     log: (level: LogLevel, ..._args: unknown[]) => {
-      logCounts[level] = logCounts[level] + 1;
+      logCounts[level]++;
     },
   };
   resetLogCounts();
-  let rep = await replicacheForTesting('log-level', {
+  let rep = await replicacheForTesting('logSinks-1', {
     logLevel: 'info',
-    logSink,
+    logSinks: [logSink],
   });
   await rep.query(() => 42);
   expect(logCounts.info).to.be.greaterThan(0);
@@ -1446,13 +1476,66 @@ test('logSink', async () => {
   await rep.close();
 
   logCounts = initLogCounts();
-  rep = await replicacheForTesting('log-level', {
+  rep = await replicacheForTesting('logSinks-1', {
     logLevel: 'debug',
-    logSink,
+    logSinks: [logSink],
   });
   await rep.query(() => 42);
   expect(logCounts.info).to.be.greaterThan(0);
   expect(logCounts.debug).to.be.greaterThan(0);
+  expectNoLogsToConsole();
+  await rep.close();
+});
+
+test('logSinks length 3', async () => {
+  const infoStub = sinon.stub(console, 'info');
+  const debugStub = sinon.stub(console, 'debug');
+  const expectNoLogsToConsole = () => {
+    expect(infoStub.callCount).to.equal(0);
+    expect(debugStub.callCount).to.equal(0);
+  };
+
+  const initLogCounts = () =>
+    Array.from({length: 3}, () => ({
+      info: 0,
+      debug: 0,
+      error: 0,
+    }));
+  let logCounts: Record<LogLevel, number>[] = initLogCounts();
+  const resetLogCounts = () => {
+    logCounts = initLogCounts();
+    infoStub.reset();
+    debugStub.reset();
+  };
+
+  const logSinks = Array.from({length: 3}, (_, i) => ({
+    log: (level: LogLevel, ..._args: unknown[]) => {
+      logCounts[i][level]++;
+    },
+  }));
+  resetLogCounts();
+  let rep = await replicacheForTesting('log-level', {
+    logLevel: 'info',
+    logSinks,
+  });
+  await rep.query(() => 42);
+  for (const counts of logCounts) {
+    expect(counts.info).to.be.greaterThan(0);
+    expect(counts.debug).to.equal(0);
+  }
+  expectNoLogsToConsole();
+  await rep.close();
+
+  logCounts = initLogCounts();
+  rep = await replicacheForTesting('log-level', {
+    logLevel: 'debug',
+    logSinks,
+  });
+  await rep.query(() => 42);
+  for (const counts of logCounts) {
+    expect(counts.info).to.be.greaterThan(0);
+    expect(counts.info).to.be.greaterThan(0);
+  }
   expectNoLogsToConsole();
   await rep.close();
 });

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -37,7 +37,7 @@ import fetchMock from 'fetch-mock/esm/client';
 import type {Mutation} from './sync/push';
 import type {ReplicacheOptions} from './replicache-options';
 import {deleteClientForTesting} from './persist/clients-test-helpers.js';
-import {LogLevel} from '@rocicorp/logger';
+import type {LogLevel} from '@rocicorp/logger';
 
 const {fail} = assert;
 

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -1,4 +1,4 @@
-import {LogContext} from '@rocicorp/logger';
+import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import {Lock} from '@rocicorp/lock';
 import {deepClone, deepEqual, ReadonlyJSONValue} from './json';
@@ -329,6 +329,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
     const {
       name,
       logLevel = 'info',
+      logSink = consoleLogSink,
       pullURL = '',
       auth,
       pushDelay = 10,
@@ -355,7 +356,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
     this.puller = puller;
     this.pusher = pusher;
 
-    this._lc = new LogContext(logLevel).addContext('name', name);
+    this._lc = new LogContext(logLevel, logSink).addContext('name', name);
 
     const perKvStore = experimentalKVStore || new IDBStore(this.idbName);
     this._perdag = new dag.StoreImpl(

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -1,4 +1,4 @@
-import {consoleLogSink, LogContext} from '@rocicorp/logger';
+import {consoleLogSink, LogContext, TeeLogSink} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import {Lock} from '@rocicorp/lock';
 import {deepClone, deepEqual, ReadonlyJSONValue} from './json';
@@ -329,7 +329,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
     const {
       name,
       logLevel = 'info',
-      logSink = consoleLogSink,
+      logSinks = [consoleLogSink],
       pullURL = '',
       auth,
       pushDelay = 10,
@@ -356,6 +356,8 @@ export class Replicache<MD extends MutatorDefs = {}> {
     this.puller = puller;
     this.pusher = pusher;
 
+    const logSink =
+      logSinks.length === 1 ? logSinks[0] : new TeeLogSink(logSinks);
     this._lc = new LogContext(logLevel, logSink).addContext('name', name);
 
     const perKvStore = experimentalKVStore || new IDBStore(this.idbName);


### PR DESCRIPTION
This will enable customers to send logs to their own servers or to a cloud logging service (e.g. DataDog).