### PR TITLE
add licensing to docs

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -5,6 +5,7 @@ This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern 
 ## Installation
 
 ```console
+cd doc/
 yarn install
 ```
 

--- a/doc/docs/getting-started.md
+++ b/doc/docs/getting-started.md
@@ -3,15 +3,22 @@ title: Getting Started
 slug: /
 ---
 
-The easiest way to get started is with our Todo starter app.
+The easiest way to get started is with our Todo starter app. For information about
+the license key step, see [Licensing](/licensing).
 
 ```bash
+# Get a Replicache license key
+npx replicache get-license
+
+# Clone the repo and start supabase
 git clone https://github.com/rocicorp/replicache-todo
 cd replicache-todo
 npm install
 supabase init
 supabase start
 
+# Use license key printed out by `npx replicache get-license`
+REPLICACHE_LICENSE_KEY="<license key>" \
 # Use URLs and keys printed out by `supabase start`
 DATABASE_URL="<DB URL>" \
 NEXT_PUBLIC_SUPABASE_URL="<API URL>" \

--- a/doc/docs/licensing.md
+++ b/doc/docs/licensing.md
@@ -1,0 +1,74 @@
+---
+title: Licensing
+slug: /licensing
+---
+
+## Getting a License Key
+
+The [Replicache Terms of Service](https://roci.dev/terms.html) require that anyone using
+Replicache acquire and use their own license key. A license key is required for _any_ use
+of Replicache, commercial or non-commercial, including tire-kicking, evaluation, and
+just playing around. But don't worry: getting a key is fast, low commitment (no credit card),
+and there is no charge for many uses of Replicache (see [Replicache Pricing](https://replicache.dev/#price)).
+
+To get a key run:
+
+```
+npx replicache get-license
+```
+
+It will ask you a few questions and then print your license key, eg:
+
+```
+l123d3baa14984beca21bc42aee593064
+```
+
+Pass this key as a string to the Replicache constructor, e.g.:
+
+```
+new Replicache({
+	licenseKey: "l123d3baa14984beca21bc42aee593064",
+	...
+});
+```
+
+## Unit testing
+
+For reasons explained below, Replicache by default pings our server with your license key
+when Replicache is instantiated. This behavior is almost certainly undesirable in automated
+tests for a variety of reasons (hermeticity, inflated Replicache usage charges, etc.). For automated tests, pass
+`TEST_LICENSE_KEY` instead of your key. For example:
+
+```
+import {Replicache, TEST_LICENSE_KEY} from 'replicache';
+...
+
+test('my test', () => {
+	const r = new Replicache({
+		licenseKey: TEST_LICENSE_KEY,
+		...
+	});
+  ...
+});
+```
+
+Using the `TEST_LICENSE_KEY` skips the server ping, but a Replicache instance
+instantiated with it will shut itself down after a few minutes.
+
+## License pings
+
+Per [Replicache Pricing](https://replicache.dev/#price), we charge post-funding/revnue
+commercial customers based on _Monthly Active Browser Profiles_, meaning unique browser
+instances that instantiate Replicache in a calendar month. The way we accomplish this
+is to send a ping to our servers containing your license key and a unique browser
+identifier when Replicache is instantiated, and every 24 hours that it is running.
+We also check at instantiation time that your license key is valid, and complain loudly
+to the console if is not. If it is not valid, Replicache may not
+function.
+
+The licensing pings explain why you want to pass `TEST_LICENSE_KEY` to Replicache in
+automated tests: so that you're not potentially charged for large numbers of Replicache
+instances used when running tests. (Not to mention network calls are typically undesirable
+in unit tests).
+
+Disabling Replicache's pings is against our [Terms of Service](https://roci.dev/terms.html). If the pings are a problem for your environment, please get in touch with us at [hello@replicache.dev](mailto:hello@replicache.dev).

--- a/doc/sidebars.js
+++ b/doc/sidebars.js
@@ -36,6 +36,7 @@ module.exports = {
     {
       Samples: ['sample-todo', 'sample-replidraw'],
     },
+    'licensing',
     'launch-checklist',
     'design',
     'faq',


### PR DESCRIPTION
In adding licensing to the getting started page it seems like we might eventually want to make the process of getting started easier, like provide a script that runs the steps and handles capturing output to the appropriate env vars.

Note @cesara @aboodman @grgbkr @arv that this change assumes that our sample apps will get the license key out of a REPLICACHE_LICENSE_KEY env var. (Don't think we want it in the source code because we expect people to form our samples and use them as a base for their own apps.) 