### PR TITLE
address licensing feedback

### DIFF
--- a/doc/docs/guide-render-ui.md
+++ b/doc/docs/guide-render-ui.md
@@ -25,6 +25,7 @@ export default function Home() {
   useEffect(async () => {
     const rep = new Replicache({
       name: 'chat-user-id',
+      licenseKey: '...';
       pushURL: '/api/replicache-push',
       pullURL: '/api/replicache-pull',
     });

--- a/doc/docs/launch-checklist.md
+++ b/doc/docs/launch-checklist.md
@@ -7,6 +7,7 @@ Before you launch with Replicache in your product, it's a good idea to double-ch
 
 ## JS SDK
 
+- Ensure that you are passing in your own [Replipcache license key](/licensing)
 - If you wish to change the signature of a mutator (eg, the number or type of
   its arguments) you must choose a new name; Replicache does not handle mutator
   versioning.

--- a/doc/docs/licensing.md
+++ b/doc/docs/licensing.md
@@ -60,15 +60,14 @@ instantiated with it will shut itself down after a few minutes.
 Per [Replicache Pricing](https://replicache.dev/#price), we charge post-funding/revenue
 commercial customers based on _Monthly Active Browser Profiles_, meaning unique browser
 instances that instantiate Replicache in a calendar month. The way we accomplish this
-is to send a ping to our servers containing your license key and a unique browser
+is to send a ping to our servers containing your license key and a unique browser profile
 identifier when Replicache is instantiated, and every 24 hours that it is running.
 We also check at instantiation time that your license key is valid, and complain loudly
-to the console if is not. If it is not valid, Replicache may not
-function.
+to the console if it is not. We may in the future add a feature to disable Replicache in the event that the license key is not valid.
 
 The licensing pings explain why you want to pass `TEST_LICENSE_KEY` to Replicache in
 automated tests: so that you're not potentially charged for large numbers of Replicache
 instances used when running tests. (Not to mention network calls are typically undesirable
 in unit tests).
 
-Disabling Replicache's pings is against our [Terms of Service](https://roci.dev/terms.html). If the pings are a problem for your environment, please get in touch with us at [hello@replicache.dev](mailto:hello@replicache.dev).
+Disabling Replicache's pings other than via the `TEST_LICENSE_KEY` is against our [Terms of Service](https://roci.dev/terms.html). If the pings are a problem for your environment, please get in touch with us at [hello@replicache.dev](mailto:hello@replicache.dev).

--- a/doc/docs/recipe-blobs.md
+++ b/doc/docs/recipe-blobs.md
@@ -38,6 +38,7 @@ type RepUser = {
 
 const rep = new Replicache({
   name: 'user-id',
+  licenseKey: '...',
   mutators: {
     async setUserData(tx: WriteTransaction, user: RepUser) {
       await tx.put(`user/${user.id}`, user);
@@ -131,6 +132,7 @@ async function computeHash(data: Uint8Array): Promise<string> {
 
 const rep = new Replicache({
   name: 'user-id',
+  licenseKey: '...',
   mutators: {
     async setUserData(tx: WriteTransaction, user: RepUser) {
       const {id, name, picture, pictureHash} = user;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "9.0.0",
       "license": "BSL-1.1",
       "bin": {
-        "get-replicache-license": "out/get-license.cjs"
+        "replicache": "out/cli.cjs"
       },
       "devDependencies": {
         "@esm-bundle/chai": "^4.3.4",
@@ -615,9 +615,9 @@
       "dev": true
     },
     "node_modules/@rocicorp/licensing": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@rocicorp/licensing/-/licensing-4.0.0-beta.3.tgz",
-      "integrity": "sha512-7YgU7s6AHDAHsIzjY1bORwJ52+UUXuache6xs5cTID5AV5xXRxte2S0tuy5WJHBkz26WeAIlYx3d6T/9vT/Zqg==",
+      "version": "4.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@rocicorp/licensing/-/licensing-4.0.0-beta.7.tgz",
+      "integrity": "sha512-K/gx43EYXfH0I0vkqt0IsSEMx7e3pzpCa28MhngCD3wKlEVq7zrxWH1GuRA/UicEZn8mYRLJ23QtMQL7lngm0w==",
       "dev": true,
       "dependencies": {
         "@prisma/client": "^3.9.1",
@@ -6852,9 +6852,9 @@
       "dev": true
     },
     "@rocicorp/licensing": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@rocicorp/licensing/-/licensing-4.0.0-beta.3.tgz",
-      "integrity": "sha512-7YgU7s6AHDAHsIzjY1bORwJ52+UUXuache6xs5cTID5AV5xXRxte2S0tuy5WJHBkz26WeAIlYx3d6T/9vT/Zqg==",
+      "version": "4.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@rocicorp/licensing/-/licensing-4.0.0-beta.7.tgz",
+      "integrity": "sha512-K/gx43EYXfH0I0vkqt0IsSEMx7e3pzpCa28MhngCD3wKlEVq7zrxWH1GuRA/UicEZn8mYRLJ23QtMQL7lngm0w==",
       "dev": true,
       "requires": {
         "@prisma/client": "^3.9.1",

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -1977,7 +1977,9 @@ async function licenseKeyCheckTest(tc: LicenseKeyCheckTestCase) {
     expect(rep.closed).to.be.false;
   }
   if (!tc.expectValid) {
-    expect(consoleErrorStub.getCall(0).args[1]).to.match(/REPLICACHE LICENSE NOT VALID/);
+    expect(consoleErrorStub.getCall(0).args[1]).to.match(
+      /REPLICACHE LICENSE NOT VALID/,
+    );
   }
   expect(fetchMock.called(statusUrlMatcher)).to.equal(tc.expectFetchCalled);
 

--- a/src/replicache.ts
+++ b/src/replicache.ts
@@ -564,7 +564,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
   ): Promise<void> {
     lc.error?.(
       `** REPLICACHE LICENSE NOT VALID ** Replicache license key '${this._licenseKey}' is not valid (${reason}). ` +
-        `Please run 'npx get-replicache-license' to get a license key or contact hello@replicache.dev for help.`,
+        `Please run 'npx replicache get-license' to get a license key or contact hello@replicache.dev for help.`,
     );
     if (disable) {
       await this.close();


### PR DESCRIPTION
Docs changes as well as only disabling if the license status check response explicitly signals it or if they pass the empty string.

Closes #909 