### PR TITLE
fix: d.ts output to include necessary @rocicorp/lock and @rocicorp/logger declarations.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,5 +10,9 @@ export default {
   output: {
     file: `./out/replicache.d.ts`,
   },
-  plugins: [dts()],
+  plugins: [
+    dts({
+      respectExternal: true,
+    }),
+  ],
 };


### PR DESCRIPTION
Use option respectExternal: true to rollup-plugin-dts.  

Without this the following error occur when trying to build a project depending on replicache (unless @rocicorp/lock and @rocicorp/logger are also installed)

```
> tsc --noEmit

node_modules/replicache/out/replicache.d.ts:1:24 - error TS2307: Cannot find module '@rocicorp/lock' or its corresponding type declarations.

1 import { RWLock } from '@rocicorp/lock';
                         ~~~~~~~~~~~~~~~~

node_modules/replicache/out/replicache.d.ts:2:35 - error TS2307: Cannot find module '@rocicorp/logger' or its corresponding type declarations.

2 import { LogLevel, LogSink } from '@rocicorp/logger';
                                    ~~~~~~~~~~~~~~~~~~

node_modules/replicache/out/replicache.d.ts:3:51 - error TS2307: Cannot find module '@rocicorp/logger' or its corresponding type declarations.

3 export { LogLevel, LogSink, consoleLogSink } from '@rocicorp/logger';
                                                    ~~~~~~~~~~~~~~~~~~


Found 3 errors.
```

Alternatively we could make @rocicorp/lock and @rocicorp/logger `dependencies` rather than `devDependencies`.  However the code does not need to be installed as it is all bundled in our package output, all that is missing are the TS declarations.