### PR TITLE
feat!: Expose a way to reuse ScanResult

### DIFF
--- a/src/btree/node.test.ts
+++ b/src/btree/node.test.ts
@@ -1,6 +1,5 @@
 import {expect, assert} from '@esm-bundle/chai';
 import * as dag from '../dag/mod';
-import type {ScanOptionsInternal} from '../db/scan';
 import {emptyHash, Hash} from '../hash';
 import {getSizeOfValue, ReadonlyJSONValue} from '../json';
 import {
@@ -15,6 +14,7 @@ import {
   NODE_LEVEL,
   NODE_ENTRIES,
   emptyDataNode,
+  ReadonlyEntry,
 } from './node';
 import {BTreeWrite} from './write';
 import {makeTestChunkHasher} from '../dag/chunk';
@@ -263,7 +263,7 @@ test('empty read tree', async () => {
     const r = new BTreeRead(dagRead);
     expect(await r.get('a')).to.be.undefined;
     expect(await r.has('b')).to.be.false;
-    expect(await asyncIterToArray(r.scan({}, x => x))).to.deep.equal([]);
+    expect(await asyncIterToArray(r.scan(''))).to.deep.equal([]);
   });
 });
 
@@ -284,7 +284,7 @@ test('empty write tree', async () => {
     );
     expect(await w.get('a')).to.be.undefined;
     expect(await w.has('b')).to.be.false;
-    expect(await asyncIterToArray(w.scan({}, x => x))).to.deep.equal([]);
+    expect(await asyncIterToArray(w.scan(''))).to.deep.equal([]);
 
     const h = await w.flush();
     expect(h).to.equal(emptyTreeHash);
@@ -1197,7 +1197,7 @@ test('put/del - getSize', async () => {
 test('scan', async () => {
   const t = async (
     entries: Entry<ReadonlyJSONValue>[],
-    options: ScanOptionsInternal = {},
+    fromKey = '',
     expectedEntries = entries,
   ) => {
     const dagStore = new dag.TestStore();
@@ -1215,29 +1215,12 @@ test('scan', async () => {
     });
 
     await doRead(rootHash, dagStore, async r => {
-      const res: Entry<ReadonlyJSONValue>[] = [];
-      const onLimitKeyCalls: string[] = [];
-      const scanResult = r.scan(
-        options,
-        x => x,
-        inclusiveLimitKey => {
-          onLimitKeyCalls.push(inclusiveLimitKey);
-        },
-      );
+      const res: ReadonlyEntry<ReadonlyJSONValue>[] = [];
+      const scanResult = r.scan(fromKey);
       for await (const e of scanResult) {
         res.push(e);
       }
       expect(res).to.deep.equal(expectedEntries);
-      if (options.limit !== undefined) {
-        if (options.limit > 0 && res.length === options.limit) {
-          expect(onLimitKeyCalls.length).to.equal(1);
-          expect(onLimitKeyCalls[0]).to.equal(res[res.length - 1][0]);
-        } else {
-          expect(onLimitKeyCalls.length).to.equal(0);
-        }
-      } else {
-        expect(onLimitKeyCalls.length).to.equal(0);
-      }
     });
   };
 
@@ -1268,54 +1251,6 @@ test('scan', async () => {
 
   await t(
     [
-      ['a', 1],
-      ['b', 2],
-      ['c', 3],
-      ['d', 4],
-      ['e', 5],
-    ],
-    {limit: 0},
-    [],
-  );
-  await t(
-    [
-      ['a', 1],
-      ['b', 2],
-      ['c', 3],
-      ['d', 4],
-      ['e', 5],
-    ],
-    {limit: 1},
-    [['a', 1]],
-  );
-  await t(
-    [
-      ['a', 1],
-      ['b', 2],
-      ['c', 3],
-      ['d', 4],
-      ['e', 5],
-    ],
-    {limit: 2},
-    [
-      ['a', 1],
-      ['b', 2],
-    ],
-  );
-
-  await t(
-    [
-      ['a', 1],
-      ['b', 2],
-      ['c', 3],
-      ['d', 4],
-      ['e', 5],
-    ],
-    {limit: 8},
-  );
-
-  await t(
-    [
       ['a', 0],
       ['aa', 1],
       ['aaa', 2],
@@ -1323,50 +1258,15 @@ test('scan', async () => {
       ['ab', 4],
       ['b', 5],
     ],
-    {prefix: 'aa'},
+    'aa',
     [
       ['aa', 1],
       ['aaa', 2],
       ['aab', 3],
+      ['ab', 4],
+      ['b', 5],
     ],
   );
-
-  for (let limit = 4; limit >= 0; limit--) {
-    await t(
-      [
-        ['a', 0],
-        ['aa', 1],
-        ['aaa', 2],
-        ['aab', 3],
-        ['ab', 4],
-        ['b', 5],
-      ],
-      {prefix: 'aa', limit},
-      [
-        ['aa', 1],
-        ['aaa', 2],
-        ['aab', 3],
-      ].slice(0, limit) as Entry<number>[],
-    );
-  }
-
-  for (let limit = 3; limit >= 0; limit--) {
-    await t(
-      [
-        ['a', 0],
-        ['aa', 1],
-        ['aaa', 2],
-        ['aab', 3],
-        ['ab', 4],
-        ['b', 5],
-      ],
-      {prefix: 'aa', startKey: 'aaa', limit},
-      [
-        ['aaa', 2],
-        ['aab', 3],
-      ].slice(0, limit) as Entry<number>[],
-    );
-  }
 
   await t(
     [
@@ -1376,7 +1276,7 @@ test('scan', async () => {
       ['d', 4],
       ['e', 5],
     ],
-    {limit: -1},
+    'f',
     [],
   );
 
@@ -1388,31 +1288,7 @@ test('scan', async () => {
       ['d', 4],
       ['e', 5],
     ],
-    {prefix: 'f'},
-    [],
-  );
-
-  await t(
-    [
-      ['a', 1],
-      ['b', 2],
-      ['c', 3],
-      ['d', 4],
-      ['e', 5],
-    ],
-    {startKey: 'f'},
-    [],
-  );
-
-  await t(
-    [
-      ['a', 1],
-      ['b', 2],
-      ['c', 3],
-      ['d', 4],
-      ['e', 5],
-    ],
-    {startKey: 'e'},
+    'e',
     [['e', 5]],
   );
 });

--- a/src/btree/write.ts
+++ b/src/btree/write.ts
@@ -12,8 +12,8 @@ import {
   ReadonlyEntry,
   DiffResult,
   emptyDataNode,
+  isDataNodeImpl,
 } from './node';
-import type {ScanOptionsInternal} from '../db/scan';
 import type {CreateChunk} from '../dag/chunk';
 import {assert} from '../asserts';
 
@@ -127,11 +127,10 @@ export class BTreeWrite extends BTreeRead {
     return this._rwLock.withRead(() => super.isEmpty());
   }
 
-  override async *scan<R>(
-    options: ScanOptionsInternal,
-    convertEntry: (entry: Entry<ReadonlyJSONValue>) => R,
-  ): AsyncIterableIterator<R> {
-    yield* runRead(this._rwLock, super.scan(options, convertEntry));
+  override async *scan(
+    fromKey: string,
+  ): AsyncIterableIterator<ReadonlyEntry<ReadonlyJSONValue>> {
+    yield* runRead(this._rwLock, super.scan(fromKey));
   }
 
   override async *keys(): AsyncIterableIterator<string> {
@@ -219,16 +218,14 @@ export class BTreeWrite extends BTreeRead {
         // Not modified, use the original.
         return hash;
       }
-      if (node.level === 0) {
+      if (isDataNodeImpl(node)) {
         const chunk = createChunk(node.toChunkData(), []);
         newChunks.push(chunk);
         return chunk.hash;
       }
       const refs: Hash[] = [];
 
-      const internalNode = node as InternalNodeImpl;
-
-      for (const entry of internalNode.entries) {
+      for (const entry of node.entries) {
         const childHash = entry[1];
         const newChildHash = walk(childHash, newChunks, createChunk);
         if (newChildHash !== childHash) {
@@ -237,7 +234,7 @@ export class BTreeWrite extends BTreeRead {
         }
         refs.push(newChildHash);
       }
-      const chunk = createChunk(internalNode.toChunkData(), refs);
+      const chunk = createChunk(node.toChunkData(), refs);
       newChunks.push(chunk);
       return chunk.hash;
     };

--- a/src/db/index.test.ts
+++ b/src/db/index.test.ts
@@ -71,16 +71,11 @@ test('test index key', () => {
 test('encode scan key', () => {
   const t = (secondary: string, primary: string) => {
     const encodedIndexKey = encodeIndexKey([secondary, primary]);
-    // With exclusive == false
-    let scanKey = encodeIndexScanKey(secondary, primary, false);
+    const scanKey = encodeIndexScanKey(secondary, primary);
 
     expect(scanKey.startsWith(encodedIndexKey)).to.be.true;
 
     expect(stringCompare(encodedIndexKey, scanKey)).to.greaterThanOrEqual(0);
-
-    // With exclusive == true
-    scanKey = encodeIndexScanKey(secondary, primary, true);
-    expect(stringCompare(encodedIndexKey, scanKey)).to.equal(-1);
   };
 
   t('', '');

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -129,7 +129,7 @@ export function getIndexKeys(
 export const KEY_VERSION_0 = '\u0000';
 export const KEY_SEPARATOR = '\u0000';
 
-export type IndexKey = [secondary: string, primary: string];
+export type IndexKey = readonly [secondary: string, primary: string];
 
 // An index key is encoded to vec of bytes in the following order:
 //   - key version byte(s), followed by
@@ -179,17 +179,10 @@ export function encodeIndexKey(indexKey: IndexKey): string {
 export function encodeIndexScanKey(
   secondary: string,
   primary: string | undefined,
-  exclusive: boolean,
 ): string {
-  let k = encodeIndexKey([secondary, primary || '']);
-
-  let smallestLegalValue = '\u0000';
+  const k = encodeIndexKey([secondary, primary || '']);
   if (primary === undefined) {
-    k = k.slice(0, k.length - 1);
-    smallestLegalValue = '\u0001';
-  }
-  if (exclusive) {
-    k += smallestLegalValue;
+    return k.slice(0, k.length - 1);
   }
   return k;
 }

--- a/src/db/read.ts
+++ b/src/db/read.ts
@@ -1,6 +1,5 @@
 import {IndexRead} from './index';
 import type * as dag from '../dag/mod';
-import {convert, ScanOptions, ScanOptionsInternal} from './scan';
 import {
   Commit,
   DEFAULT_HEAD_NAME,
@@ -8,13 +7,14 @@ import {
   Meta,
 } from './commit';
 import type {ReadonlyJSONValue} from '../json';
-import {BTreeRead, BTreeWrite, Entry} from '../btree/mod';
+import {BTreeRead, BTreeWrite} from '../btree/mod';
 import type {Hash} from '../hash';
 
 export class Read {
   private readonly _dagRead: dag.Read;
   map: BTreeRead;
   readonly indexes: Map<string, IndexRead>;
+  shouldDeepClone = false;
 
   constructor(
     dagRead: dag.Read,
@@ -38,28 +38,12 @@ export class Read {
     return this.map.isEmpty();
   }
 
-  scan<R>(
-    opts: ScanOptions,
-    convertEntry: (entry: Entry<ReadonlyJSONValue>) => R,
-    onLimitKey?: (inclusiveLimitKey: string) => void,
-  ): AsyncIterableIterator<R> {
-    const optsInternal: ScanOptionsInternal = convert(opts);
-    if (optsInternal.indexName !== undefined) {
-      const name = optsInternal.indexName;
-      const idx = this.indexes.get(name);
-      if (idx === undefined) {
-        throw new Error(`Unknown index name: ${name}`);
-      }
-
-      return scanIndexMap(
-        idx,
-        this._dagRead,
-        optsInternal,
-        convertEntry,
-        onLimitKey,
-      );
+  async getMapForIndex(indexName: string): Promise<BTreeRead> {
+    const idx = this.indexes.get(indexName);
+    if (idx === undefined) {
+      throw new Error(`Unknown index name: ${indexName}`);
     }
-    return this.map.scan(optsInternal, convertEntry, onLimitKey);
+    return idx.withMap(this._dagRead, map => map);
   }
 
   get closed(): boolean {
@@ -69,18 +53,6 @@ export class Read {
   close(): void {
     this._dagRead.close();
   }
-}
-
-async function* scanIndexMap<R>(
-  idx: IndexRead,
-  dagRead: dag.Read,
-  optsInternal: ScanOptionsInternal,
-  convertEntry: (entry: Entry<ReadonlyJSONValue>) => R,
-  onLimitKey?: (inclusiveLimitKey: string) => void,
-): AsyncIterableIterator<R> {
-  yield* await idx.withMap(dagRead, map =>
-    map.scan(optsInternal, convertEntry, onLimitKey),
-  );
 }
 
 const enum WhenceType {
@@ -121,8 +93,8 @@ export async function fromWhence(
   dagRead: dag.Read,
 ): Promise<Read> {
   const [, basis, map] = await readCommitForBTreeRead(whence, dagRead);
-  const indexex = readIndexesForRead(basis);
-  return new Read(dagRead, map, indexex);
+  const indexes = readIndexesForRead(basis);
+  return new Read(dagRead, map, indexes);
 }
 
 export async function readCommit(

--- a/src/db/scan.test.ts
+++ b/src/db/scan.test.ts
@@ -1,19 +1,12 @@
 import {expect} from '@esm-bundle/chai';
-import {convert, ScanItem, ScanOptions} from './scan';
+import type {ScanItem} from './scan';
 import * as dag from '../dag/mod';
-import {decodeIndexKey, encodeIndexKey} from './index';
 import {BTreeWrite} from '../btree/mod';
-import type {Entry} from '../btree/node';
-import type {ReadonlyJSONValue} from '../json';
+import {fromKeyForIndexScanInternal} from '../transactions.js';
+import {decodeIndexKey} from './index.js';
 
 test('scan', async () => {
-  const t = async (opts: ScanOptions, expected: string[]) => {
-    const testDesc = `opts: ${JSON.stringify(
-      opts,
-      null,
-      2,
-    )}, expected: ${expected}`;
-
+  const t = async (fromKey: string, expected: string[]) => {
     const dagStore = new dag.TestStore();
 
     await dagStore.withWrite(async dagWrite => {
@@ -21,562 +14,24 @@ test('scan', async () => {
       await map.put('foo', 'foo');
       await map.put('bar', 'bar');
       await map.put('baz', 'baz');
-      const optsInternal = convert(opts);
+      await map.flush();
+
       const actual = [];
-      for await (const key of map.scan(optsInternal, entry => entry[0])) {
-        actual.push(key);
+      for await (const entry of map.scan(fromKey)) {
+        actual.push(entry[0]);
       }
       const expected2 = expected;
-      expect(actual).to.deep.equal(expected2, testDesc);
+      expect(actual).to.deep.equal(expected2);
     });
   };
 
-  // Empty
-  await t(
-    {
-      prefix: undefined,
-      startSecondaryKey: undefined,
-      startKey: undefined,
-      startExclusive: undefined,
-      limit: undefined,
-      indexName: undefined,
-    },
-    ['bar', 'baz', 'foo'],
-  );
-
-  // Prefix alone
-  await t(
-    {
-      prefix: '',
-      startSecondaryKey: undefined,
-      startKey: undefined,
-      startExclusive: undefined,
-      limit: undefined,
-      indexName: undefined,
-    },
-    ['bar', 'baz', 'foo'],
-  );
-  await t(
-    {
-      prefix: 'ba',
-      startSecondaryKey: undefined,
-      startKey: undefined,
-      startExclusive: undefined,
-      limit: undefined,
-      indexName: undefined,
-    },
-    ['bar', 'baz'],
-  );
-  await t(
-    {
-      prefix: 'bar',
-      startSecondaryKey: undefined,
-      startKey: undefined,
-      startExclusive: undefined,
-      limit: undefined,
-      indexName: undefined,
-    },
-    ['bar'],
-  );
-  await t(
-    {
-      prefix: 'bas',
-      startSecondaryKey: undefined,
-      startKey: undefined,
-      startExclusive: undefined,
-      limit: undefined,
-      indexName: undefined,
-    },
-    [],
-  );
-  // start key alone
-  await t(
-    {
-      prefix: undefined,
-      startSecondaryKey: undefined,
-      startKey: '',
-      startExclusive: undefined,
-      limit: undefined,
-      indexName: undefined,
-    },
-    ['bar', 'baz', 'foo'],
-  );
-  await t(
-    {
-      prefix: undefined,
-      startSecondaryKey: undefined,
-      startKey: 'a',
-      startExclusive: undefined,
-      limit: undefined,
-      indexName: undefined,
-    },
-    ['bar', 'baz', 'foo'],
-  );
-  await t(
-    {
-      prefix: undefined,
-      startSecondaryKey: undefined,
-      startKey: 'b',
-      startExclusive: undefined,
-      limit: undefined,
-      indexName: undefined,
-    },
-    ['bar', 'baz', 'foo'],
-  );
-  await t(
-    {
-      prefix: undefined,
-      startSecondaryKey: undefined,
-      startKey: 'bas',
-      startExclusive: undefined,
-      limit: undefined,
-      indexName: undefined,
-    },
-    ['baz', 'foo'],
-  );
-  await t(
-    {
-      prefix: undefined,
-      startSecondaryKey: undefined,
-      startKey: 'baz',
-      startExclusive: undefined,
-      limit: undefined,
-      indexName: undefined,
-    },
-    ['baz', 'foo'],
-  );
-  await t(
-    {
-      prefix: undefined,
-      startSecondaryKey: undefined,
-      startKey: 'baza',
-      startExclusive: undefined,
-      limit: undefined,
-      indexName: undefined,
-    },
-    ['foo'],
-  );
-  await t(
-    {
-      prefix: undefined,
-      startSecondaryKey: undefined,
-      startKey: 'fop',
-      startExclusive: undefined,
-      limit: undefined,
-      indexName: undefined,
-    },
-    [],
-  );
-
-  // exclusive
-  await t(
-    {
-      prefix: undefined,
-      startSecondaryKey: undefined,
-      startKey: '',
-      startExclusive: true,
-      limit: undefined,
-      indexName: undefined,
-    },
-    ['bar', 'baz', 'foo'],
-  );
-  await t(
-    {
-      prefix: undefined,
-      startSecondaryKey: undefined,
-      startKey: 'bar',
-      startExclusive: true,
-      limit: undefined,
-      indexName: undefined,
-    },
-    ['baz', 'foo'],
-  );
-
-  // limit alone
-  await t(
-    {
-      prefix: undefined,
-      startSecondaryKey: undefined,
-      startKey: undefined,
-      startExclusive: undefined,
-      limit: 0,
-      indexName: undefined,
-    },
-    [],
-  );
-  await t(
-    {
-      prefix: undefined,
-      startSecondaryKey: undefined,
-      startKey: undefined,
-      startExclusive: undefined,
-      limit: 1,
-      indexName: undefined,
-    },
-    ['bar'],
-  );
-  await t(
-    {
-      prefix: undefined,
-      startSecondaryKey: undefined,
-      startKey: undefined,
-      startExclusive: undefined,
-      limit: 2,
-      indexName: undefined,
-    },
-    ['bar', 'baz'],
-  );
-  await t(
-    {
-      prefix: undefined,
-      startSecondaryKey: undefined,
-      startKey: undefined,
-      startExclusive: undefined,
-      limit: 3,
-      indexName: undefined,
-    },
-    ['bar', 'baz', 'foo'],
-  );
-  await t(
-    {
-      prefix: undefined,
-      startSecondaryKey: undefined,
-      startKey: undefined,
-      startExclusive: undefined,
-      limit: 7,
-      indexName: undefined,
-    },
-    ['bar', 'baz', 'foo'],
-  );
-
-  // combos
-  await t(
-    {
-      prefix: 'f',
-      startSecondaryKey: undefined,
-      startKey: undefined,
-      startExclusive: undefined,
-      limit: 0,
-      indexName: undefined,
-    },
-    [],
-  );
-  await t(
-    {
-      prefix: 'f',
-      startSecondaryKey: undefined,
-      startKey: undefined,
-      startExclusive: undefined,
-      limit: 7,
-      indexName: undefined,
-    },
-    ['foo'],
-  );
-  await t(
-    {
-      prefix: 'ba',
-      startSecondaryKey: undefined,
-      startKey: 'a',
-      startExclusive: undefined,
-      limit: 2,
-      indexName: undefined,
-    },
-    ['bar', 'baz'],
-  );
-  await t(
-    {
-      prefix: 'ba',
-      startSecondaryKey: undefined,
-      startKey: 'a',
-      startExclusive: false,
-      limit: 1,
-      indexName: undefined,
-    },
-    ['bar'],
-  );
-  await t(
-    {
-      prefix: 'ba',
-      startSecondaryKey: undefined,
-      startKey: 'a',
-      startExclusive: false,
-      limit: 1,
-      indexName: undefined,
-    },
-    ['bar'],
-  );
-  await t(
-    {
-      prefix: 'ba',
-      startSecondaryKey: undefined,
-      startKey: 'bar',
-      startExclusive: true,
-      limit: 1,
-      indexName: undefined,
-    },
-    ['baz'],
-  );
-});
-
-test('exclusive regular map', async () => {
-  const t = async (keys: string[], startKey: string, expected: string[]) => {
-    const testDesc = `keys: ${keys}, startKey: ${startKey}, expected: ${expected}`;
-
-    const dagStore = new dag.TestStore();
-
-    await dagStore.withWrite(async dagWrite => {
-      const map = new BTreeWrite(dagWrite);
-      for (const key of keys) {
-        await map.put(key, 'value');
-      }
-      const opts = {
-        prefix: undefined,
-        startSecondaryKey: undefined,
-        startKey,
-        startExclusive: true,
-        limit: undefined,
-        indexName: undefined,
-      };
-      const convertedOpts = convert(opts);
-      const got = [];
-
-      for await (const key of map.scan(convertedOpts, entry => entry[0])) {
-        got.push(key);
-      }
-      expect(got).to.deep.equal(expected, testDesc);
-    });
-  };
-
-  await t(['', 'a', 'aa', 'ab', 'b'], '', ['a', 'aa', 'ab', 'b']);
-  await t(['', 'a', 'aa', 'ab', 'b'], 'a', ['aa', 'ab', 'b']);
-  await t(['', 'a', 'aa', 'ab', 'b'], 'aa', ['ab', 'b']);
-  await t(['', 'a', 'aa', 'ab', 'b'], 'ab', ['b']);
-});
-
-test('exclusive index map', async () => {
-  const t = async (
-    entries: [string, string][],
-    startSecondaryKey: string,
-    startKey: string | undefined,
-    expected: [string, string][],
-  ) => {
-    const testDesc = `entries: ${entries}, startSecondaryKey ${startSecondaryKey}, startKey: ${startKey}, expected: ${expected}`;
-
-    const dagStore = new dag.TestStore();
-
-    await dagStore.withWrite(async dagWrite => {
-      const map = new BTreeWrite(dagWrite);
-      for (const entry of entries) {
-        const encoded = encodeIndexKey(entry);
-        await map.put(encoded, 'value');
-      }
-      const opts = {
-        prefix: undefined,
-        startSecondaryKey,
-        startKey,
-        startExclusive: true,
-        limit: undefined,
-        indexName: 'index',
-      };
-      const got = [];
-      for await (const key of map.scan(convert(opts), entry => entry[0])) {
-        const [secondary, primary] = decodeIndexKey(key);
-        got.push([secondary, primary]);
-      }
-      expect(got).to.deep.equal(expected, testDesc);
-    });
-  };
-
-  // Test exclusive scanning with startSecondaryKey.
-  const v: string[] = ['', '\u0000', '\u0001', '\u0001\u0002'];
-  for (const pk of v) {
-    await t(
-      [
-        ['', pk],
-        ['a', pk],
-        ['aa', pk],
-        ['ab', pk],
-        ['b', pk],
-      ],
-      '',
-      undefined,
-      [
-        ['a', pk],
-        ['aa', pk],
-        ['ab', pk],
-        ['b', pk],
-      ],
-    );
-    await t(
-      [
-        ['', pk],
-        ['a', pk],
-        ['aa', pk],
-        ['ab', pk],
-        ['b', pk],
-      ],
-      'a',
-      undefined,
-      [
-        ['aa', pk],
-        ['ab', pk],
-        ['b', pk],
-      ],
-    );
-    await t(
-      [
-        ['', pk],
-        ['a', pk],
-        ['aa', pk],
-        ['ab', pk],
-        ['b', pk],
-      ],
-      'aa',
-      undefined,
-      [
-        ['ab', pk],
-        ['b', pk],
-      ],
-    );
-    await t(
-      [
-        ['', pk],
-        ['a', pk],
-        ['aa', pk],
-        ['ab', pk],
-        ['b', pk],
-      ],
-      'ab',
-      undefined,
-      [['b', pk]],
-    );
-  }
-
-  // t exclusive scanning with startSecondaryKey and startKey,
-  // with the same secondary value.
-  await t(
-    [
-      ['a', ''],
-      ['a', '\u0000'],
-      ['a', '\u0000\u0000'],
-      ['a', '\u0000\u0001'],
-      ['a', '\u0001'],
-    ],
-    'a',
-    '',
-    [
-      ['a', '\u0000'],
-      ['a', '\u0000\u0000'],
-      ['a', '\u0000\u0001'],
-      ['a', '\u0001'],
-    ],
-  );
-  await t(
-    [
-      ['a', ''],
-      ['a', '\u0000'],
-      ['a', '\u0000\u0000'],
-      ['a', '\u0000\u0001'],
-      ['a', '\u0001'],
-    ],
-    'a',
-    '\u{0000}',
-    [
-      ['a', '\u0000\u0000'],
-      ['a', '\u0000\u0001'],
-      ['a', '\u0001'],
-    ],
-  );
-  await t(
-    [
-      ['a', ''],
-      ['a', '\u0000'],
-      ['a', '\u0000\u0000'],
-      ['a', '\u0000\u0001'],
-      ['a', '\u0001'],
-    ],
-    'a',
-    '\u{0000}\u{0000}',
-    [
-      ['a', '\u0000\u0001'],
-      ['a', '\u0001'],
-    ],
-  );
-  await t(
-    [
-      ['a', ''],
-      ['a', '\u0000'],
-      ['a', '\u0000\u0000'],
-      ['a', '\u0000\u0001'],
-      ['a', '\u0001'],
-    ],
-    'a',
-    '\u{0000}\u{0001}',
-    [['a', '\u0001']],
-  );
-
-  // t exclusive scanning with startSecondaryKey and startKey,
-  // with different secondary values.
-  await t(
-    [
-      ['', ''],
-      ['a', '\u0000'],
-      ['aa', '\u0000\u0000'],
-      ['ab', '\u0000\u0001'],
-      ['b', '\u0001'],
-    ],
-    '',
-    '',
-    [
-      ['a', '\u0000'],
-      ['aa', '\u0000\u0000'],
-      ['ab', '\u0000\u0001'],
-      ['b', '\u0001'],
-    ],
-  );
-  await t(
-    [
-      ['', ''],
-      ['a', '\u0000'],
-      ['aa', '\u0000\u0000'],
-      ['ab', '\u0000\u0001'],
-      ['b', '\u0001'],
-    ],
-    'a',
-    '\u{0000}',
-    [
-      ['aa', '\u0000\u0000'],
-      ['ab', '\u0000\u0001'],
-      ['b', '\u0001'],
-    ],
-  );
-  await t(
-    [
-      ['', ''],
-      ['a', '\u0000'],
-      ['aa', '\u0000\u0000'],
-      ['ab', '\u0000\u0001'],
-      ['b', '\u0001'],
-    ],
-    'aa',
-    '\u{0000}\u{0000}',
-    [
-      ['ab', '\u0000\u0001'],
-      ['b', '\u0001'],
-    ],
-  );
-  await t(
-    [
-      ['', ''],
-      ['a', '\u0000'],
-      ['aa', '\u0000\u0000'],
-      ['ab', '\u0000\u0001'],
-      ['b', '\u0001'],
-    ],
-    'ab',
-    '\u{0000}\u{0001}',
-    [['b', '\u0001']],
-  );
+  await t('', ['bar', 'baz', 'foo']);
+  await t('ba', ['bar', 'baz', 'foo']);
+  await t('bar', ['bar', 'baz', 'foo']);
+  await t('bas', ['baz', 'foo']);
+  await t('baz', ['baz', 'foo']);
+  await t('baza', ['foo']);
+  await t('fop', []);
 });
 
 async function makeBTreeWrite(
@@ -590,99 +45,37 @@ async function makeBTreeWrite(
   return map;
 }
 
-function convertEntry(entry: Entry<ReadonlyJSONValue>): ScanItem {
-  return {
-    primaryKey: entry[0],
-    secondaryKey: '',
-    val: entry[1],
-  };
-}
-
-function convertEntryIndexScan(entry: Entry<ReadonlyJSONValue>): ScanItem {
-  const decoded = decodeIndexKey(entry[0]);
-  const secondary = decoded[0];
-  const primary = decoded[1];
-  return {
-    primaryKey: primary,
-    secondaryKey: secondary,
-    val: entry[1],
-  };
-}
-
 test('scan index startKey', async () => {
   const t = async (
     entries: Iterable<[string, string]>,
-    opts: ScanOptions,
+    {
+      startSecondaryKey,
+      startPrimaryKey,
+    }: {
+      startSecondaryKey: string;
+      startPrimaryKey?: string;
+    },
     expected: ScanItem[],
   ) => {
     const dagStore = new dag.TestStore();
 
     await dagStore.withWrite(async dagWrite => {
       const map = await makeBTreeWrite(dagWrite, entries);
-      const testDesc = `opts: ${opts}, expected: ${expected}`;
+      await map.flush();
 
+      const fromKey = fromKeyForIndexScanInternal({
+        start: {key: [startSecondaryKey, startPrimaryKey]},
+        indexName: 'dummy',
+      });
       const actual: ScanItem[] = [];
-      for await (const item of map.scan(
-        convert(opts),
-        opts.indexName ? convertEntryIndexScan : convertEntry,
-      )) {
-        actual.push(item);
+      for await (const entry of map.scan(fromKey)) {
+        const [secondaryKey, primaryKey] = decodeIndexKey(entry[0]);
+        actual.push({primaryKey, secondaryKey, val: entry[1]});
       }
 
-      expect(actual).to.deep.equal(expected, testDesc);
+      expect(actual).to.deep.equal(expected);
     });
   };
-
-  await t(
-    [
-      ['a', '1'],
-      ['b', '2'],
-      ['c', '3'],
-    ],
-    {
-      prefix: undefined,
-      startSecondaryKey: undefined,
-      startKey: 'b',
-      startExclusive: false,
-      limit: undefined,
-      indexName: undefined,
-    },
-    [
-      {
-        primaryKey: 'b',
-        secondaryKey: '',
-        val: '2',
-      },
-      {
-        primaryKey: 'c',
-        secondaryKey: '',
-        val: '3',
-      },
-    ],
-  );
-
-  await t(
-    [
-      ['a', '1'],
-      ['b', '2'],
-      ['c', '3'],
-    ],
-    {
-      prefix: undefined,
-      startSecondaryKey: undefined,
-      startKey: 'b',
-      startExclusive: true,
-      limit: undefined,
-      indexName: undefined,
-    },
-    [
-      {
-        primaryKey: 'c',
-        secondaryKey: '',
-        val: '3',
-      },
-    ],
-  );
 
   await t(
     [
@@ -691,12 +84,8 @@ test('scan index startKey', async () => {
       ['\u{0000}cs\u{0000}cp', '3'],
     ],
     {
-      prefix: undefined,
       startSecondaryKey: 'bs',
-      startKey: undefined,
-      startExclusive: false,
-      limit: undefined,
-      indexName: 'index',
+      startPrimaryKey: undefined,
     },
     [
       {
@@ -719,14 +108,15 @@ test('scan index startKey', async () => {
       ['\u{0000}cs\u{0000}cp', '3'],
     ],
     {
-      prefix: undefined,
       startSecondaryKey: 'bs',
-      startKey: undefined,
-      startExclusive: true,
-      limit: undefined,
-      indexName: 'index',
+      startPrimaryKey: undefined,
     },
     [
+      {
+        primaryKey: 'bp',
+        secondaryKey: 'bs',
+        val: '2',
+      },
       {
         primaryKey: 'cp',
         secondaryKey: 'cs',
@@ -743,12 +133,8 @@ test('scan index startKey', async () => {
       ['\u{0000}cs\u{0000}cp', '4'],
     ],
     {
-      prefix: undefined,
       startSecondaryKey: 'bs',
-      startKey: 'bp2',
-      startExclusive: false,
-      limit: undefined,
-      indexName: 'index',
+      startPrimaryKey: 'bp2',
     },
     [
       {
@@ -772,14 +158,15 @@ test('scan index startKey', async () => {
       ['\u{0000}cs\u{0000}cp', '4'],
     ],
     {
-      prefix: undefined,
       startSecondaryKey: 'bs',
-      startKey: 'bp2',
-      startExclusive: true,
-      limit: undefined,
-      indexName: 'index',
+      startPrimaryKey: 'bp2',
     },
     [
+      {
+        primaryKey: 'bp2',
+        secondaryKey: 'bs',
+        val: '3',
+      },
       {
         primaryKey: 'cp',
         secondaryKey: 'cs',

--- a/src/db/scan.ts
+++ b/src/db/scan.ts
@@ -1,4 +1,3 @@
-import {encodeIndexScanKey} from '.';
 import type {ReadonlyJSONValue} from '../json';
 
 // TODO(arv): Unify with src/scan-options.ts
@@ -61,36 +60,3 @@ export type ScanItem = {
   secondaryKey: string;
   val: ReadonlyJSONValue;
 };
-
-export function convert(source: ScanOptions): ScanOptionsInternal {
-  // If the scan is using an index then we need to generate the scan keys.
-  let prefix: string | undefined;
-  if (source.prefix !== undefined) {
-    if (source.indexName !== undefined) {
-      prefix = encodeIndexScanKey(source.prefix, undefined, false);
-    } else {
-      prefix = source.prefix;
-    }
-  }
-
-  let startKey: string | undefined;
-  if (source.indexName !== undefined) {
-    startKey = encodeIndexScanKey(
-      source.startSecondaryKey ?? '',
-      source.startKey === undefined ? undefined : source.startKey,
-      source.startExclusive ?? false,
-    );
-  } else {
-    let sk = source.startKey ?? '';
-    if (source.startExclusive ?? false) {
-      sk += '\u0000';
-    }
-    startKey = sk;
-  }
-  return {
-    prefix,
-    startKey,
-    limit: source.limit,
-    indexName: source.indexName,
-  };
-}

--- a/src/db/write.ts
+++ b/src/db/write.ts
@@ -55,6 +55,8 @@ export class Write extends Read {
   private readonly _basis: Commit<CommitMeta> | undefined;
   private readonly _meta: Meta;
 
+  shouldDeepClone = true;
+
   declare map: BTreeWrite;
 
   declare readonly indexes: Map<string, IndexWrite>;
@@ -214,11 +216,11 @@ export class Write extends Read {
     // Check to see if the index already exists.
     const index = this.indexes.get(name);
     if (index) {
-      const oldDefintion = index.meta.definition;
+      const oldDefinition = index.meta.definition;
       if (
-        oldDefintion.name === name &&
-        oldDefintion.keyPrefix === keyPrefix &&
-        oldDefintion.jsonPointer === jsonPointer
+        oldDefinition.name === name &&
+        oldDefinition.keyPrefix === keyPrefix &&
+        oldDefinition.jsonPointer === jsonPointer
       ) {
         return;
       } else {
@@ -227,7 +229,7 @@ export class Write extends Read {
     }
 
     const indexMap = new BTreeWrite(this._dagWrite);
-    for await (const entry of this.map.scan({prefix: keyPrefix}, x => x)) {
+    for await (const entry of this.map.scan(keyPrefix)) {
       await indexValue(
         lc,
         indexMap,

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -16,9 +16,12 @@ export type {
   WriteTransaction,
 } from './transactions';
 export type {
+  GetScanIterator,
+  GetIndexScanIterator,
   ScanResult,
   AsyncIterableIteratorToArrayWrapper,
 } from './scan-iterator';
+export {makeScanResult} from './scan-iterator';
 export type {LogSink, LogLevel} from '@rocicorp/logger';
 export type {
   JSONObject,

--- a/src/replicache-subscribe.test.ts
+++ b/src/replicache-subscribe.test.ts
@@ -27,7 +27,7 @@ async function addData(tx: WriteTransaction, data: {[key: string]: JSONValue}) {
 }
 
 test('subscribe', async () => {
-  const log: [string, ReadonlyJSONValue][] = [];
+  const log: (readonly [string, ReadonlyJSONValue])[] = [];
 
   const rep = await replicacheForTesting('subscribe', {
     mutators: {
@@ -41,7 +41,7 @@ test('subscribe', async () => {
       return await tx.scan({prefix: 'a/'}).entries().toArray();
     },
     {
-      onData: (values: Iterable<[string, ReadonlyJSONValue]>) => {
+      onData: (values: Iterable<readonly [string, ReadonlyJSONValue]>) => {
         for (const entry of values) {
           log.push(entry);
         }
@@ -90,7 +90,7 @@ test('subscribe', async () => {
 });
 
 test('subscribe with index', async () => {
-  const log: [[string, string], ReadonlyJSONValue][] = [];
+  const log: (readonly [readonly [string, string], ReadonlyJSONValue])[] = [];
 
   const rep = await replicacheForTesting('subscribe-with-index', {
     mutators: {
@@ -115,7 +115,11 @@ test('subscribe with index', async () => {
       return await tx.scan({indexName: 'i1'}).entries().toArray();
     },
     {
-      onData: (values: Iterable<[[string, string], ReadonlyJSONValue]>) => {
+      onData: (
+        values: Iterable<
+          readonly [readonly [string, string], ReadonlyJSONValue]
+        >,
+      ) => {
         onDataCallCount++;
         for (const entry of values) {
           log.push(entry);
@@ -238,7 +242,7 @@ test('subscribe with index', async () => {
 });
 
 test('subscribe with index and start', async () => {
-  const log: [[string, string], ReadonlyJSONValue][] = [];
+  const log: (readonly [readonly [string, string], ReadonlyJSONValue])[] = [];
 
   const rep = await replicacheForTesting('subscribe-with-index-and-start', {
     mutators: {
@@ -262,7 +266,11 @@ test('subscribe with index and start', async () => {
         .toArray();
     },
     {
-      onData: (values: Iterable<[[string, string], ReadonlyJSONValue]>) => {
+      onData: (
+        values: Iterable<
+          readonly [readonly [string, string], ReadonlyJSONValue]
+        >,
+      ) => {
         onDataCallCount++;
         for (const entry of values) {
           log.push(entry);
@@ -346,7 +354,7 @@ test('subscribe with index and start', async () => {
 });
 
 test('subscribe with index and prefix', async () => {
-  const log: [[string, string], ReadonlyJSONValue][] = [];
+  const log: (readonly [readonly [string, string], ReadonlyJSONValue])[] = [];
 
   const rep = await replicacheForTesting('subscribe-with-index-and-prefix', {
     mutators: {
@@ -367,7 +375,11 @@ test('subscribe with index and prefix', async () => {
       return await tx.scan({indexName: 'i1', prefix: 'b'}).entries().toArray();
     },
     {
-      onData: (values: Iterable<[[string, string], ReadonlyJSONValue]>) => {
+      onData: (
+        values: Iterable<
+          readonly [readonly [string, string], ReadonlyJSONValue]
+        >,
+      ) => {
         onDataCallCount++;
         for (const entry of values) {
           log.push(entry);

--- a/src/scan-iterator.test.ts
+++ b/src/scan-iterator.test.ts
@@ -1,0 +1,623 @@
+import {expect} from '@esm-bundle/chai';
+import {asyncIterableToArray} from './async-iterable-to-array.js';
+import type {ReadonlyEntry} from './btree/node.js';
+import type {IndexKey} from './db/index.js';
+import type {ReadonlyJSONValue} from './json.js';
+import type {ScanIndexOptions, ScanOptions} from './mod.js';
+import {
+  fromKeyForIndexScan,
+  GetIndexScanIterator,
+  GetScanIterator,
+  makeScanResult,
+} from './scan-iterator.js';
+
+test('makeScanResult', async () => {
+  function getTestScanIterator(
+    entries: (readonly [key: string, value: ReadonlyJSONValue])[],
+  ): GetScanIterator {
+    return async function* (fromKey: string) {
+      for (const [key, value] of entries) {
+        if (key >= fromKey) {
+          yield [key, value];
+        }
+      }
+    };
+  }
+
+  const t = async (
+    entries: ReadonlyEntry<ReadonlyJSONValue>[],
+    options: ScanOptions,
+    expectedEntries = entries,
+  ) => {
+    const iter = makeScanResult(options, getTestScanIterator(entries));
+    expect(await asyncIterableToArray(iter.entries())).to.deep.equal(
+      expectedEntries,
+    );
+  };
+
+  await t([], {});
+  await t(
+    [
+      ['b', 1],
+      ['d', 2],
+    ],
+    {},
+  );
+
+  // prefix
+  await t(
+    [
+      ['b', 1],
+      ['d', 2],
+    ],
+    {prefix: 'a'},
+    [],
+  );
+  await t(
+    [
+      ['b', 1],
+      ['d', 2],
+    ],
+    {prefix: 'b'},
+    [['b', 1]],
+  );
+  await t(
+    [
+      ['b', 1],
+      ['d', 2],
+    ],
+    {prefix: 'c'},
+    [],
+  );
+  await t(
+    [
+      ['b', 1],
+      ['d', 2],
+    ],
+    {prefix: 'd'},
+    [['d', 2]],
+  );
+  await t(
+    [
+      ['b', 1],
+      ['d', 2],
+    ],
+    {prefix: 'e'},
+    [],
+  );
+
+  // start
+  await t(
+    [
+      ['b', 1],
+      ['d', 2],
+    ],
+    {start: {key: 'a'}},
+  );
+  await t(
+    [
+      ['b', 1],
+      ['d', 2],
+    ],
+    {start: {key: 'b'}},
+  );
+  await t(
+    [
+      ['b', 1],
+      ['d', 2],
+    ],
+    {start: {key: 'c'}},
+    [['d', 2]],
+  );
+  await t(
+    [
+      ['b', 1],
+      ['d', 2],
+    ],
+    {start: {key: 'd'}},
+    [['d', 2]],
+  );
+  await t(
+    [
+      ['b', 1],
+      ['d', 2],
+    ],
+    {start: {key: 'e'}},
+    [],
+  );
+
+  // start exclusive
+  await t(
+    [
+      ['b', 1],
+      ['d', 2],
+    ],
+    {start: {key: 'a', exclusive: true}},
+  );
+  await t(
+    [
+      ['b', 1],
+      ['d', 2],
+    ],
+    {start: {key: 'b', exclusive: true}},
+    [['d', 2]],
+  );
+  await t(
+    [
+      ['b', 1],
+      ['d', 2],
+    ],
+    {start: {key: 'c', exclusive: true}},
+    [['d', 2]],
+  );
+  await t(
+    [
+      ['b', 1],
+      ['d', 2],
+    ],
+    {start: {key: 'd', exclusive: true}},
+    [],
+  );
+  await t(
+    [
+      ['b', 1],
+      ['d', 2],
+    ],
+    {start: {key: 'e', exclusive: true}},
+    [],
+  );
+
+  // start & prefix
+  await t(
+    [
+      ['ab', 1],
+      ['ad', 2],
+      ['bf', 3],
+      ['bh', 4],
+    ],
+    {prefix: 'a', start: {key: 'aa'}},
+    [
+      ['ab', 1],
+      ['ad', 2],
+    ],
+  );
+  await t(
+    [
+      ['ab', 1],
+      ['ad', 2],
+      ['bf', 3],
+      ['bh', 4],
+    ],
+    {prefix: 'a', start: {key: 'ab'}},
+    [
+      ['ab', 1],
+      ['ad', 2],
+    ],
+  );
+  await t(
+    [
+      ['ab', 1],
+      ['ad', 2],
+      ['bf', 3],
+      ['bh', 4],
+    ],
+    {prefix: 'a', start: {key: 'ac'}},
+    [['ad', 2]],
+  );
+  await t(
+    [
+      ['ab', 1],
+      ['ad', 2],
+      ['bf', 3],
+      ['bh', 4],
+    ],
+    {prefix: 'a', start: {key: 'ad'}},
+    [['ad', 2]],
+  );
+  await t(
+    [
+      ['ab', 1],
+      ['ad', 2],
+      ['bf', 3],
+      ['bh', 4],
+    ],
+    {prefix: 'a', start: {key: 'ae'}},
+    [],
+  );
+
+  await t(
+    [
+      ['ab', 1],
+      ['ad', 2],
+      ['bf', 3],
+      ['bh', 4],
+    ],
+    {prefix: 'b', start: {key: 'aa'}},
+    [
+      ['bf', 3],
+      ['bh', 4],
+    ],
+  );
+  await t(
+    [
+      ['ab', 1],
+      ['ad', 2],
+      ['bf', 3],
+      ['bh', 4],
+    ],
+    {prefix: 'b', start: {key: 'ab'}},
+    [
+      ['bf', 3],
+      ['bh', 4],
+    ],
+  );
+  await t(
+    [
+      ['ab', 1],
+      ['ad', 2],
+      ['bf', 3],
+      ['bh', 4],
+    ],
+    {prefix: 'b', start: {key: 'ad'}},
+    [
+      ['bf', 3],
+      ['bh', 4],
+    ],
+  );
+  await t(
+    [
+      ['ab', 1],
+      ['ad', 2],
+      ['bf', 3],
+      ['bh', 4],
+    ],
+    {prefix: 'b', start: {key: 'bf'}},
+    [
+      ['bf', 3],
+      ['bh', 4],
+    ],
+  );
+  await t(
+    [
+      ['ab', 1],
+      ['ad', 2],
+      ['bf', 3],
+      ['bh', 4],
+    ],
+    {prefix: 'b', start: {key: 'bh'}},
+    [['bh', 4]],
+  );
+});
+
+test('makeScanResult with index', async () => {
+  function getTestScanIterator(
+    entries: (readonly [key: IndexKey, value: ReadonlyJSONValue])[],
+  ): GetIndexScanIterator {
+    return async function* (indexName, secondaryKey, primaryKey) {
+      expect(indexName).to.equal('index');
+      for (const [key, value] of entries) {
+        if (key[0] >= secondaryKey) {
+          if (primaryKey === undefined || key[1] >= primaryKey) {
+            yield [key, value];
+          }
+        }
+      }
+    };
+  }
+
+  const t = async (
+    entries: (readonly [key: IndexKey, value: ReadonlyJSONValue])[],
+    options: Omit<ScanIndexOptions, 'indexName'> = {},
+    expectedEntries = entries,
+  ) => {
+    const indexOptions = {indexName: 'index', ...options};
+    const iter = makeScanResult(indexOptions, getTestScanIterator(entries));
+    expect(await asyncIterableToArray(iter.entries())).to.deep.equal(
+      expectedEntries,
+    );
+  };
+
+  await t([]);
+  await t([[['sb', 'pb'], 1]]);
+  await t([
+    [['sb', 'pb'], 1],
+    [['sd', 'pd'], 2],
+  ]);
+
+  // prefix is always on secondary
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {prefix: 'sa'},
+    [],
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {prefix: 'sb'},
+    [[['sb', 'pb'], 1]],
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {prefix: 'sc'},
+    [],
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {prefix: 'sd'},
+    [[['sd', 'pd'], 2]],
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {prefix: 's'},
+  );
+
+  // start key
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: 'sa'}},
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: ['sa']}},
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: ['sa', 'pa']}},
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: 'sb'}},
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: ['sb']}},
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: ['sb', '']}},
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: ['sb', 'pb']}},
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: ['sb', 'pc']}},
+    [[['sd', 'pd'], 2]],
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: 'sc'}},
+    [[['sd', 'pd'], 2]],
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: 'sd'}},
+    [[['sd', 'pd'], 2]],
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: ['sd', 'pc']}},
+    [[['sd', 'pd'], 2]],
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: ['sd', 'pd']}},
+    [[['sd', 'pd'], 2]],
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: ['sd', 'pe']}},
+    [],
+  );
+
+  // start exclusive
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: 'sa', exclusive: true}},
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: ['sa'], exclusive: true}},
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: ['sa', 'pa'], exclusive: true}},
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: 'sb', exclusive: true}},
+    [[['sd', 'pd'], 2]],
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: ['sb'], exclusive: true}},
+    [[['sd', 'pd'], 2]],
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: ['sb', ''], exclusive: true}},
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: ['sb', 'pb'], exclusive: true}},
+    [[['sd', 'pd'], 2]],
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: ['sb', 'pc'], exclusive: true}},
+    [[['sd', 'pd'], 2]],
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: 'sc', exclusive: true}},
+    [[['sd', 'pd'], 2]],
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: 'sd', exclusive: true}},
+    [],
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: ['sd', 'pc'], exclusive: true}},
+    [[['sd', 'pd'], 2]],
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: ['sd', 'pd'], exclusive: true}},
+    [],
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {start: {key: ['sd', 'pe'], exclusive: true}},
+    [],
+  );
+
+  // prefix and start
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {prefix: 'sa', start: {key: 'sb'}},
+    [],
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {prefix: 's', start: {key: 'sb'}},
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {prefix: 'sb', start: {key: 'sb'}},
+    [[['sb', 'pb'], 1]],
+  );
+  await t(
+    [
+      [['sb', 'pb'], 1],
+      [['sd', 'pd'], 2],
+    ],
+    {prefix: 'sd', start: {key: 'sb'}},
+    [[['sd', 'pd'], 2]],
+  );
+});
+
+test('fromKeyForIndexScan', () => {
+  const t = (
+    options: Omit<ScanIndexOptions, 'indexName'>,
+    expected: [secondary: string, primary?: string],
+  ) => {
+    const indexOptions = {indexName: 'i', ...options};
+    expect(fromKeyForIndexScan(indexOptions)).to.deep.equal(expected);
+  };
+
+  t({}, ['', undefined]);
+  t({prefix: 'a'}, ['a', undefined]);
+  t({start: {key: 'a'}}, ['a']);
+  t({start: {key: ['a']}}, ['a']);
+  t({start: {key: ['a', undefined]}}, ['a', undefined]);
+  t({start: {key: ['a', 'b']}}, ['a', 'b']);
+
+  t({prefix: 'b', start: {key: 'a'}}, ['b', undefined]);
+  t({prefix: 'a', start: {key: 'b'}}, ['b']);
+  t({prefix: 'a', start: {key: ['a']}}, ['a', undefined]);
+  t({prefix: 'a', start: {key: ['a', '']}}, ['a', '']);
+});

--- a/src/scan-iterator.ts
+++ b/src/scan-iterator.ts
@@ -1,15 +1,24 @@
-import {deepClone, JSONValue, ReadonlyJSONValue} from './json';
-import {throwIfClosed} from './transaction-closed-error';
-import {ScanIndexOptions, ScanOptions, toDbScanOptions} from './scan-options';
+import {deepClone, ReadonlyJSONValue} from './json';
+import {Closed, throwIfClosed} from './transaction-closed-error';
+import {
+  isScanIndexOptions,
+  KeyTypeForScanOptions,
+  normalizeScanOptionIndexedStartKey,
+  ScanIndexOptions,
+  ScanOptionIndexedStartKey,
+  ScanOptions,
+} from './scan-options';
 import {asyncIterableToArray} from './async-iterable-to-array';
-import * as db from './db/mod';
-import type {Entry} from './btree/node';
+import type {ReadonlyEntry} from './btree/node';
 import {decodeIndexKey} from './db/mod';
+import {encodeIndexKey, encodeIndexScanKey, IndexKey} from './db/index.js';
+import {fromKeyForNonIndexScan} from './transactions.js';
 
-const VALUE = 0;
-const KEY = 1;
-const ENTRY = 2;
-type ScanIterableKind = typeof VALUE | typeof KEY | typeof ENTRY;
+type ScanKey = string | IndexKey;
+
+type ToValue<V> = (entry: ReadonlyEntry<ReadonlyJSONValue>) => V;
+
+type ShouldDeepClone = {shouldDeepClone: boolean};
 
 /**
  * This class is used for the results of [[ReadTransaction.scan|scan]]. It
@@ -17,21 +26,23 @@ type ScanIterableKind = typeof VALUE | typeof KEY | typeof ENTRY;
  * await` loop. There are also methods to iterate over the [[keys]],
  * [[entries]] or [[values]].
  */
-export class ScanResult<K, V extends ReadonlyJSONValue = JSONValue>
-  implements AsyncIterable<V>
+export class ScanResultImpl<K extends ScanKey, V extends ReadonlyJSONValue>
+  implements ScanResult<K, V>
 {
-  private readonly _options: ScanOptions | undefined;
-  private readonly _dbRead: db.Read;
-  private readonly _onLimitKey?: (inclusiveLimitKey: string) => void;
+  private readonly _iter: AsyncIterable<ReadonlyEntry<ReadonlyJSONValue>>;
+  private readonly _options: ScanOptions;
+  private readonly _dbDelegateOptions: Closed & ShouldDeepClone;
+  private readonly _onLimitKey: (inclusiveLimitKey: string) => void;
 
-  /** @internal */
   constructor(
-    options: ScanOptions | undefined,
-    dbRead: db.Read,
-    onLimitKey?: (inclusiveLimitKey: string) => void,
+    iter: AsyncIterable<ReadonlyEntry<ReadonlyJSONValue>>,
+    options: ScanOptions,
+    dbDelegateOptions: Closed & ShouldDeepClone,
+    onLimitKey: (inclusiveLimitKey: string) => void,
   ) {
+    this._iter = iter;
     this._options = options;
-    this._dbRead = dbRead;
+    this._dbDelegateOptions = dbDelegateOptions;
     this._onLimitKey = onLimitKey;
   }
 
@@ -42,7 +53,12 @@ export class ScanResult<K, V extends ReadonlyJSONValue = JSONValue>
 
   /** Async iterator over the values of the [[ReadTransaction.scan|scan]] call. */
   values(): AsyncIterableIteratorToArrayWrapper<V> {
-    return new AsyncIterableIteratorToArrayWrapper(this._newIterator(VALUE));
+    const clone = this._dbDelegateOptions.shouldDeepClone
+      ? deepClone
+      : (x: ReadonlyJSONValue) => x;
+    return new AsyncIterableIteratorToArrayWrapper(
+      this._newIterator(e => clone(e[1])) as AsyncIterableIterator<V>,
+    );
   }
 
   /**
@@ -51,7 +67,10 @@ export class ScanResult<K, V extends ReadonlyJSONValue = JSONValue>
    * is a tuple of `[secondaryKey: string, primaryKey]`
    */
   keys(): AsyncIterableIteratorToArrayWrapper<K> {
-    return new AsyncIterableIteratorToArrayWrapper(this._newIterator(KEY));
+    const toValue = isScanIndexOptions(this._options)
+      ? (e: ReadonlyEntry<ReadonlyJSONValue>) => decodeIndexKey(e[0]) as K
+      : (e: ReadonlyEntry<ReadonlyJSONValue>) => e[0] as K;
+    return new AsyncIterableIteratorToArrayWrapper(this._newIterator(toValue));
   }
 
   /**
@@ -60,8 +79,16 @@ export class ScanResult<K, V extends ReadonlyJSONValue = JSONValue>
    * [[ReadTransaction.scan|scan]] is over an index the key is a tuple of
    * `[secondaryKey: string, primaryKey]`
    */
-  entries(): AsyncIterableIteratorToArrayWrapper<[K, V]> {
-    return new AsyncIterableIteratorToArrayWrapper(this._newIterator(ENTRY));
+  entries(): AsyncIterableIteratorToArrayWrapper<readonly [K, V]> {
+    const clone = this._dbDelegateOptions.shouldDeepClone
+      ? deepClone
+      : (x: ReadonlyJSONValue) => x;
+    const toValue = isScanIndexOptions(this._options)
+      ? (e: ReadonlyEntry<ReadonlyJSONValue>) =>
+          [decodeIndexKey(e[0]), clone(e[1])] as [K, V]
+      : (e: ReadonlyEntry<ReadonlyJSONValue>) =>
+          clone(e) as unknown as readonly [K, V];
+    return new AsyncIterableIteratorToArrayWrapper(this._newIterator(toValue));
   }
 
   /** Returns all the values as an array. Same as `values().toArray()` */
@@ -69,9 +96,42 @@ export class ScanResult<K, V extends ReadonlyJSONValue = JSONValue>
     return this.values().toArray();
   }
 
-  private _newIterator<T>(kind: ScanIterableKind): AsyncIterableIterator<T> {
-    return scanIterator(kind, this._options, this._dbRead, this._onLimitKey);
+  private _newIterator<T>(toValue: ToValue<T>): AsyncIterableIterator<T> {
+    return scanIterator(
+      toValue,
+      this._iter,
+      this._options,
+      this._dbDelegateOptions,
+      this._onLimitKey,
+    );
   }
+}
+
+export interface ScanResult<K extends ScanKey, V extends ReadonlyJSONValue>
+  extends AsyncIterable<V> {
+  /** The default AsyncIterable. This is the same as [[values]]. */
+  [Symbol.asyncIterator](): AsyncIterableIteratorToArrayWrapper<V>;
+
+  /** Async iterator over the values of the [[ReadTransaction.scan|scan]] call. */
+  values(): AsyncIterableIteratorToArrayWrapper<V>;
+
+  /**
+   * Async iterator over the keys of the [[ReadTransaction.scan|scan]]
+   * call. If the [[ReadTransaction.scan|scan]] is over an index the key
+   * is a tuple of `[secondaryKey: string, primaryKey]`
+   */
+  keys(): AsyncIterableIteratorToArrayWrapper<K>;
+
+  /**
+   * Async iterator over the entries of the [[ReadTransaction.scan|scan]]
+   * call. An entry is a tuple of key values. If the
+   * [[ReadTransaction.scan|scan]] is over an index the key is a tuple of
+   * `[secondaryKey: string, primaryKey]`
+   */
+  entries(): AsyncIterableIteratorToArrayWrapper<readonly [K, V]>;
+
+  /** Returns all the values as an array. Same as `values().toArray()` */
+  toArray(): Promise<V[]>;
 }
 
 /**
@@ -116,35 +176,160 @@ export class AsyncIterableIteratorToArrayWrapper<V>
 }
 
 async function* scanIterator<V>(
-  kind: ScanIterableKind,
-  options: ScanOptions | undefined,
-  dbRead: db.Read,
-  onLimitKey?: (inclusiveLimitKey: string) => void,
+  toValue: ToValue<V>,
+  iter: AsyncIterable<ReadonlyEntry<ReadonlyJSONValue>>,
+  options: ScanOptions,
+  closed: Closed,
+  onLimitKey: (inclusiveLimitKey: string) => void,
 ): AsyncIterableIterator<V> {
-  throwIfClosed(dbRead);
+  throwIfClosed(closed);
 
-  type MaybeIndexName = Partial<ScanIndexOptions>;
-  const isIndexScan = (options as MaybeIndexName)?.indexName !== undefined;
+  let {limit = Infinity, prefix = ''} = options;
+  let exclusive = options.start?.exclusive;
 
-  const shouldClone = dbRead instanceof db.Write;
-  const toValue = shouldClone ? deepClone : <T>(x: T): T => x;
-
-  let convertEntry: (entry: Entry<ReadonlyJSONValue>) => V;
-  switch (kind) {
-    case VALUE:
-      convertEntry = entry => toValue(entry[1]) as V;
-      break;
-    case KEY:
-      convertEntry = isIndexScan
-        ? entry => decodeIndexKey(entry[0]) as unknown as V
-        : entry => entry[0] as unknown as V;
-      break;
-    case ENTRY:
-      convertEntry = isIndexScan
-        ? entry => [decodeIndexKey(entry[0]), toValue(entry[1])] as unknown as V
-        : entry => entry as unknown as V;
-      break;
+  const isIndexScan = isScanIndexOptions(options);
+  if (prefix && isIndexScan) {
+    prefix = encodeIndexScanKey(prefix, undefined);
   }
 
-  yield* dbRead.scan(toDbScanOptions(options), convertEntry, onLimitKey);
+  // iter has already been moved to the first entry
+  for await (const entry of iter) {
+    if (!entry[0].startsWith(prefix)) {
+      return;
+    }
+
+    if (exclusive) {
+      exclusive = true;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      if (shouldSkip(entry[0], isIndexScan, options.start!.key)) {
+        continue;
+      }
+    }
+
+    yield toValue(entry);
+
+    if (--limit === 0) {
+      onLimitKey(entry[0]);
+      return;
+    }
+  }
+}
+
+function shouldSkip(
+  key: string,
+  isIndexScan: boolean,
+  startKey: ScanOptionIndexedStartKey,
+): boolean {
+  if (isIndexScan) {
+    const [secondaryStartKey, primaryStartKey] =
+      normalizeScanOptionIndexedStartKey(startKey);
+    const [secondaryKey, primaryKey] = decodeIndexKey(key);
+    if (secondaryKey !== secondaryStartKey) {
+      return false;
+    }
+    if (primaryStartKey === undefined) {
+      return true;
+    }
+    return primaryKey === primaryStartKey;
+  }
+  return key === startKey;
+}
+
+/**
+ * This is called when doing a [[ReadTransaction.scan|scan]] without an
+ * `indexName`.
+ *
+ * @param fromKey The `fromKey` is computed by `scan` and is the key of the
+ * first entry to return in the iterator. It is based on `prefix` and
+ * `start.key` of the [[ScanNoIndexOptions]].
+ */
+export type GetScanIterator = (
+  fromKey: string,
+) => AsyncIterable<ReadonlyEntry<ReadonlyJSONValue>>;
+
+/**
+ * This is called when doing a [[ReadTransaction.scan|scan]] with an
+ * `indexName`.
+ *
+ * @param indexName The name of the index we are scanning over.
+ * @param fromSecondaryKey The `fromSecondaryKey` is computed by `scan` and is
+ * the secondary key of the first entry to return in the iterator. It is based
+ * on `prefix` and `start.key` of the [[ScanIndexOptions]].
+ * @param fromPrimaryKey The `fromPrimaryKey` is computed by `scan` and is the
+ * primary key of the first entry to return in the iterator. It is based on
+ * `prefix` and `start.key` of the [[ScanIndexOptions]].
+ */
+export type GetIndexScanIterator = (
+  indexName: string,
+  fromSecondaryKey: string,
+  fromPrimaryKey: string | undefined,
+) => AsyncIterable<readonly [key: IndexKey, value: ReadonlyJSONValue]>;
+
+/**
+ * A helper function that makes it easier to implement [[ReadTransaction.scan]]
+ * with a custom backend
+ */
+export function makeScanResult<Options extends ScanOptions>(
+  options: Options,
+  getScanIterator: Options extends ScanIndexOptions
+    ? GetIndexScanIterator
+    : GetScanIterator,
+): ScanResult<KeyTypeForScanOptions<Options>, ReadonlyJSONValue> {
+  let internalIter: AsyncIterable<ReadonlyEntry<ReadonlyJSONValue>>;
+  if (isScanIndexOptions(options)) {
+    const [fromSecondaryKey, fromPrimaryKey] = fromKeyForIndexScan(options);
+    const iter = (getScanIterator as GetIndexScanIterator)(
+      options.indexName,
+      fromSecondaryKey,
+      fromPrimaryKey,
+    );
+    internalIter = internalIndexScanIterator(iter);
+  } else {
+    const fromKey = fromKeyForNonIndexScan(options);
+    internalIter = (getScanIterator as GetScanIterator)(fromKey);
+  }
+
+  return new ScanResultImpl(
+    internalIter,
+    options,
+    {closed: false, shouldDeepClone: false},
+    _ => {
+      // noop
+    },
+  );
+}
+
+async function* internalIndexScanIterator<Value extends ReadonlyJSONValue>(
+  iter: AsyncIterable<readonly [key: IndexKey, value: Value]>,
+): AsyncIterable<ReadonlyEntry<Value>> {
+  for await (const entry of iter) {
+    yield [encodeIndexKey(entry[0]), entry[1]];
+  }
+}
+
+export function fromKeyForIndexScan(
+  options: ScanIndexOptions,
+): [secondary: string, primary?: string] {
+  const {prefix, start} = options;
+  const prefixNormalized: [secondary: string, primary?: string] = [
+    prefix ?? '',
+    undefined,
+  ];
+
+  if (!start) {
+    return prefixNormalized;
+  }
+
+  const startKeyNormalized = normalizeScanOptionIndexedStartKey(start.key);
+  if (startKeyNormalized[0] > prefixNormalized[0]) {
+    return startKeyNormalized;
+  }
+  if (
+    startKeyNormalized[0] === prefixNormalized[0] &&
+    startKeyNormalized[1] !== undefined
+  ) {
+    return startKeyNormalized;
+  }
+
+  return prefixNormalized;
 }

--- a/src/scan-options.ts
+++ b/src/scan-options.ts
@@ -50,6 +50,12 @@ export type ScanIndexOptions = {
   };
 };
 
+export function isScanIndexOptions(
+  options: ScanOptions,
+): options is ScanIndexOptions {
+  return (options as ScanIndexOptions).indexName !== undefined;
+}
+
 /**
  * If the options contains an `indexName` then the key type is a tuple of
  * secondary and primary.
@@ -71,10 +77,18 @@ export type KeyTypeForScanOptions<O extends ScanOptions> = O extends {
  * use the tuple form. In that case, `secondary` is the secondary key to start
  * scanning at, and `primary` (if any) is the primary key to start scanning at.
  */
-
 export type ScanOptionIndexedStartKey =
   | [secondary: string, primary?: string]
   | string;
+
+export function normalizeScanOptionIndexedStartKey(
+  startKey: ScanOptionIndexedStartKey,
+): [secondary: string, primary?: string] {
+  if (typeof startKey === 'string') {
+    return [startKey];
+  }
+  return startKey;
+}
 
 export function toDbScanOptions(options?: ScanOptions): db.ScanOptions {
   if (!options) {

--- a/src/sync/pull.test.ts
+++ b/src/sync/pull.test.ts
@@ -402,14 +402,9 @@ test('begin try pull', async () => {
         );
         let got = false;
 
+        const indexMap = await read.getMapForIndex('2');
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        for await (const _ of read.scan(
-          {
-            prefix: '',
-            indexName: '2',
-          },
-          e => e,
-        )) {
+        for await (const _ of indexMap.scan('')) {
           got = true;
           break;
         }
@@ -509,14 +504,9 @@ test('begin try pull', async () => {
               db.whenceHead(SYNC_HEAD_NAME),
               dagRead,
             );
+            const indexMap = await read.getMapForIndex('2');
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            for await (const _ of read.scan(
-              {
-                prefix: '',
-                indexName: '2',
-              },
-              e => e,
-            )) {
+            for await (const _ of indexMap.scan('')) {
               expect(false).to.be.true;
             }
           });
@@ -528,7 +518,7 @@ test('begin try pull', async () => {
         const gotHead = await read.getHead(SYNC_HEAD_NAME);
         expect(gotHead).to.be.undefined;
         // When createSyncBranch is false or sync is a noop (empty patch,
-        // same last mutation id, same cookie) we except Beginpull to succeed
+        // same last mutation id, same cookie) we except BeginPull to succeed
         // but sync_head will be empty.
         if (typeof c.expBeginPullResult !== 'string') {
           assertObject(result);

--- a/src/sync/push.test.ts
+++ b/src/sync/push.test.ts
@@ -208,8 +208,10 @@ test('try push', async () => {
         const read = await fromWhence(whenceHead(DEFAULT_HEAD_NAME), dagRead);
         let got = false;
 
+        const indexMap = await read.getMapForIndex('2');
+
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        for await (const _ of read.scan({prefix: '', indexName: '2'}, e => e)) {
+        for await (const _ of indexMap.scan('')) {
           got = true;
           break;
         }

--- a/src/transaction-closed-error.ts
+++ b/src/transaction-closed-error.ts
@@ -7,7 +7,9 @@ export class TransactionClosedError extends Error {
   }
 }
 
-export function throwIfClosed(tx: {closed: boolean}): void {
+export type Closed = {closed: boolean};
+
+export function throwIfClosed(tx: Closed): void {
   if (tx.closed) {
     throw new TransactionClosedError();
   }


### PR DESCRIPTION
We now expose a method called `makeScanResult`. It takes a `ScanOptions`
and a function that returns an async iterator.

```ts
makeScanResult({prefix: 'b'}, async function* (fromKey) {
  // yield ['a', 1];
  yield ['b', 2];
});
```

or when using an index:

```ts
makeScanResult(
  {prefix: 'b', indexName: 'i'},
  async function* (indexName, fromSecondaryKey, fromPrimaryKey) {
    // yield [['as', 'ap', 1];
    yield [['bs', 'bp', 2];
});
```

To make this work we moved the limit and exclusive handling to the top
level iterator loop.

We now compute the fromKey and pass that into the iterator.

Fixes #607