### PR TITLE
refactor: Small improvements to internal options

### DIFF
--- a/src/replicache-mutation-recovery.test.ts
+++ b/src/replicache-mutation-recovery.test.ts
@@ -1156,13 +1156,13 @@ test('mutation recovery returns early without running if push is disabled', asyn
   expect(await rep.recoverMutations()).to.equal(false);
 });
 
-test('disableMutationRecovery hidden option', async () => {
+test('mutation recovery returns early when internal option enableMutationRecovery is false', async () => {
   const rep = await replicacheForTestingNoDefaultURLs(
     'mutation-recovery-startup',
     {
       pullURL: 'https://diff.com/pull',
-      disableMutationRecovery: true,
-    } as unknown as ReplicacheOptions<Record<string, never>>,
+      enableMutationRecovery: false,
+    },
   );
   expect(rep.recoverMutationsSpy.callCount).to.equal(1);
   expect(await rep.recoverMutationsSpy.firstCall.returnValue).to.equal(false);

--- a/src/replicache-mutation-recovery.test.ts
+++ b/src/replicache-mutation-recovery.test.ts
@@ -26,7 +26,6 @@ import sinon from 'sinon';
 // @ts-expect-error
 import fetchMock from 'fetch-mock/esm/client';
 import {initClientWithClientID} from './persist/clients-test-helpers.js';
-import type {ReplicacheOptions} from './replicache-options';
 
 initReplicacheTesting();
 

--- a/src/replicache-options.ts
+++ b/src/replicache-options.ts
@@ -214,3 +214,14 @@ export interface ReplicacheOptions<MD extends MutatorDefs> {
    */
   experimentalKVStore?: kv.Store;
 }
+
+export type ReplicacheInternalOptions = {
+  /**
+   * Defaults to true.
+   */
+  enableLicensing?: boolean;
+  /**
+   * Defaults to true.
+   */
+  enableMutationRecovery?: boolean;
+};

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -2102,10 +2102,10 @@ async function licenseKeyCheckTest(tc: LicenseKeyCheckTestCase) {
   const {enableLicensing = true} = tc;
 
   const options = enableLicensing
-    ? ({
+    ? {
         licenseKey: tc.licenseKey,
         disableLicensing: true,
-      } as unknown as ReplicacheOptions<Record<string, never>>)
+      }
     : {licenseKey: tc.licenseKey};
 
   const rep = await replicacheForTesting(name, options);

--- a/src/replicache.test.ts
+++ b/src/replicache.test.ts
@@ -2079,7 +2079,7 @@ test('online', async () => {
 
 type LicenseKeyCheckTestCase = {
   licenseKey: string;
-  disableLicensing?: boolean;
+  enableLicensing?: boolean; // default true
   mockFetchParams: object | undefined;
   expectValid: boolean;
   expectDisable: boolean;
@@ -2099,7 +2099,9 @@ async function licenseKeyCheckTest(tc: LicenseKeyCheckTestCase) {
     fetchMock.postOnce(statusUrlMatcher, tc.mockFetchParams);
   }
 
-  const options = tc.disableLicensing
+  const {enableLicensing = true} = tc;
+
+  const options = enableLicensing
     ? ({
         licenseKey: tc.licenseKey,
         disableLicensing: true,
@@ -2145,10 +2147,10 @@ test('test licensing key is valid and does not send status check', async () => {
   });
 });
 
-test('test with hidden disableLicensing option any key is valid and does not send status check', async () => {
+test('test when internal option enableLicensing is false any key is valid and does not send status check', async () => {
   await licenseKeyCheckTest({
     licenseKey: 'any-random-key',
-    disableLicensing: true,
+    enableLicensing: false,
     mockFetchParams: undefined,
     expectValid: true,
     expectDisable: false,

--- a/src/test-util.ts
+++ b/src/test-util.ts
@@ -1,6 +1,9 @@
 import {expect} from '@esm-bundle/chai';
 import {MutatorDefs, Replicache, BeginPullResult} from './replicache';
-import type {ReplicacheOptions} from './replicache-options';
+import type {
+  ReplicacheOptions,
+  ReplicacheInternalOptions,
+} from './replicache-options';
 import * as kv from './kv/mod';
 import * as persist from './persist/mod';
 import {SinonFakeTimers, useFakeTimers} from 'sinon';
@@ -108,13 +111,17 @@ export function createReplicacheNameForTest(partialName: string): string {
   return replicacheName;
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-types
+type ReplicacheTestOptions<MD extends MutatorDefs> = Omit<
+  ReplicacheOptions<MD>,
+  'name' | 'licenseKey'
+> & {
+  onClientStateNotFound?: (() => void) | null;
+  licenseKey?: string;
+} & ReplicacheInternalOptions;
+
 export async function replicacheForTesting<MD extends MutatorDefs = {}>(
   partialName: string,
-  options: Omit<ReplicacheOptions<MD>, 'name' | 'licenseKey'> & {
-    onClientStateNotFound?: (() => void) | null;
-    licenseKey?: string;
-  } = {},
+  options: ReplicacheTestOptions<MD> = {},
 ): Promise<ReplicacheTest<MD>> {
   const pullURL = 'https://pull.com/?name=' + partialName;
   const pushURL = 'https://push.com/?name=' + partialName;
@@ -144,9 +151,7 @@ export async function replicacheForTestingNoDefaultURLs<
       );
     },
     ...rest
-  }: Omit<ReplicacheOptions<MD>, 'name' | 'licenseKey'> & {
-    onClientStateNotFound?: (() => void) | null;
-  } = {},
+  }: ReplicacheTestOptions<MD> = {},
 ): Promise<ReplicacheTest<MD>> {
   const rep = new ReplicacheTest<MD>({
     pullURL,

--- a/src/test-util.ts
+++ b/src/test-util.ts
@@ -119,7 +119,10 @@ type ReplicacheTestOptions<MD extends MutatorDefs> = Omit<
   licenseKey?: string;
 } & ReplicacheInternalOptions;
 
-export async function replicacheForTesting<MD extends MutatorDefs = {}>(
+export async function replicacheForTesting<
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  MD extends MutatorDefs = {},
+>(
   partialName: string,
   options: ReplicacheTestOptions<MD> = {},
 ): Promise<ReplicacheTest<MD>> {


### PR DESCRIPTION
1. Add a ReplicacheInternalOptions type def.
2. Have replicacheForTesting accept internal options so tests dont have to cast.
3. Switch options from disable to enable.