### PR TITLE
chore: Add type test for scan().keys().toArray

### DIFF
--- a/src/replicache-types.test.ts
+++ b/src/replicache-types.test.ts
@@ -1,6 +1,11 @@
 import {Replicache} from './replicache';
 import type {WriteTransaction} from './transactions';
 import {TEST_LICENSE_KEY} from '@rocicorp/licensing/src/client';
+import type {IndexKey} from './db/index.js';
+
+function use(..._args: unknown[]) {
+  // do nothing
+}
 
 // Only used for type checking
 test.skip('mutator optional args [type checking only]', async () => {
@@ -9,49 +14,49 @@ test.skip('mutator optional args [type checking only]', async () => {
     name: 'test-types',
     mutators: {
       mut: async (tx: WriteTransaction, x: number) => {
-        console.log(tx);
+        use(tx);
         return x;
       },
       mut2: (tx: WriteTransaction, x: string) => {
-        console.log(tx);
+        use(tx);
         return x;
       },
       mut3: tx => {
-        console.log(tx);
+        use(tx);
       },
       mut4: async tx => {
-        console.log(tx);
+        use(tx);
       },
     },
   });
 
   const {mut, mut2, mut3, mut4} = rep.mutate;
   const res: number = await mut(42);
-  console.log(res);
+  use(res);
 
   const res2: string = await mut2('s');
-  console.log(res2);
+  use(res2);
 
   await mut3();
   //  @ts-expect-error: Expected 0 arguments, but got 1.ts(2554)
   await mut3(42);
   //  @ts-expect-error: Type 'void' is not assignable to type 'number'.ts(2322)
   const res3: number = await mut3();
-  console.log(res3);
+  use(res3);
 
   await mut4();
   //  @ts-expect-error: Expected 0 arguments, but got 1.ts(2554)
   await mut4(42);
   //  @ts-expect-error: Type 'void' is not assignable to type 'number'.ts(2322)
   const res4: number = await mut4();
-  console.log(res4);
+  use(res4);
 
   // This should be an error!
   // new Replicache({name: 'test-types-2', {
   //   mutators: {
   //     // @ts-expect-error symbol is not a JSONValue
   //     mut5: (tx: WriteTransaction, x: symbol) => {
-  //       console.log(tx, x);
+  //       use(tx, x);
   //       return 42;
   //     },
   //   },
@@ -65,7 +70,7 @@ test.skip('Test partial JSONObject [type checking only]', async () => {
     name: 'test-types',
     mutators: {
       mut: async (tx: WriteTransaction, todo: Partial<Todo>) => {
-        console.log(tx);
+        use(tx);
         return todo;
       },
     },
@@ -91,35 +96,35 @@ test.skip('Test register param [type checking only]', async () => {
     name: 'test-types',
     mutators: {
       mut: async (tx: WriteTransaction) => {
-        console.log(tx);
+        use(tx);
       },
       mut2: async (tx: WriteTransaction, x: string) => {
-        console.log(tx, x);
+        use(tx, x);
       },
       mut3: async (tx: WriteTransaction, x: string) => {
-        console.log(tx, x);
+        use(tx, x);
       },
       mut4: async (tx: WriteTransaction) => {
-        console.log(tx);
+        use(tx);
       },
     },
   });
 
   /* eslint-disable prefer-destructuring */
   const mut: () => Promise<void> = rep.mutate.mut;
-  console.log(mut);
+  use(mut);
 
   // @ts-expect-error Type 'number' is not assignable to type 'string'.ts(2322)
   const mut2: (x: number) => Promise<void> = rep.mutate.mut2;
-  console.log(mut2);
+  use(mut2);
 
   // @ts-expect-error Type '(args: string) => Promise<void>' is not assignable to type '() => Promise<void>'.ts(2322)
   const mut3: () => Promise<void> = rep.mutate.mut3;
-  console.log(mut3);
+  use(mut3);
 
   // This is fine according to the rules of JS/TS
   const mut4: (x: number) => Promise<void> = rep.mutate.mut4;
-  console.log(mut4);
+  use(mut4);
   /* eslint-enable prefer-destructuring */
 
   new Replicache({
@@ -130,7 +135,7 @@ test.skip('Test register param [type checking only]', async () => {
       //   Promise<void>' is not assignable to type '(tx: WriteTransaction,
       //   args?: any) => MaybePromise<void | JSONValue>'.ts(2322)
       mut5: async (tx: WriteTransaction, a: string, b: number) => {
-        console.log(tx, a, b);
+        use(tx, a, b);
       },
     },
   });
@@ -147,13 +152,13 @@ test.skip('Key type for scans [type checking only]', async () => {
     for await (const k of tx.scan({indexName: 'n'}).keys()) {
       // @ts-expect-error Type '[secondary: string, primary?: string | undefined]' is not assignable to type 'string'.ts(2322)
       const k2: string = k;
-      console.log(k2);
+      use(k2);
     }
 
     for await (const k of tx.scan({indexName: 'n', start: {key: 's'}}).keys()) {
       // @ts-expect-error Type '[secondary: string, primary?: string | undefined]' is not assignable to type 'string'.ts(2322)
       const k2: string = k;
-      console.log(k2);
+      use(k2);
     }
 
     for await (const k of tx
@@ -161,13 +166,13 @@ test.skip('Key type for scans [type checking only]', async () => {
       .keys()) {
       // @ts-expect-error Type '[secondary: string, primary?: string | undefined]' is not assignable to type 'string'.ts(2322)
       const k2: string = k;
-      console.log(k2);
+      use(k2);
     }
 
     for await (const k of tx.scan({start: {key: 'p'}}).keys()) {
       // @ts-expect-error Type 'string' is not assignable to type '[string]'.ts(2322)
       const k2: [string] = k;
-      console.log(k2);
+      use(k2);
     }
 
     // @ts-expect-error Type 'number' is not assignable to type 'string | undefined'.ts(2322)
@@ -197,48 +202,48 @@ test.skip('mut [type checking only]', async () => {
     name: 'type-checking-only',
     mutators: {
       a: (tx: WriteTransaction) => {
-        console.log(tx);
+        use(tx);
         return 42;
       },
       b: (tx: WriteTransaction, x: number) => {
-        console.log(tx, x);
+        use(tx, x);
         return 'hi';
       },
 
       // Return void
       c: (tx: WriteTransaction) => {
-        console.log(tx);
+        use(tx);
       },
       d: (tx: WriteTransaction, x: number) => {
-        console.log(tx, x);
+        use(tx, x);
       },
 
       e: async (tx: WriteTransaction) => {
-        console.log(tx);
+        use(tx);
         return 42;
       },
       f: async (tx: WriteTransaction, x: number) => {
-        console.log(tx, x);
+        use(tx, x);
         return 'hi';
       },
 
       // Return void
       g: async (tx: WriteTransaction) => {
-        console.log(tx);
+        use(tx);
       },
       h: async (tx: WriteTransaction, x: number) => {
-        console.log(tx, x);
+        use(tx, x);
       },
 
       // // This should be flagged as an error but I need to use `any` for the
       // // arg since I need covariance and TS uses contravariance here.
       // // @ts-expect-error XXX
       // i: (tx: WriteTransaction, d: Date) =>
-      // {console.log(tx, d);
+      // {use(tx, d);
       // },
 
       j: async (tx: WriteTransaction, custom: CustomType) => {
-        console.log(tx, custom);
+        use(tx, custom);
         custom.n as number;
         custom.s as string;
         // @ts-expect-error xxx
@@ -248,7 +253,7 @@ test.skip('mut [type checking only]', async () => {
       },
 
       k: async (tx: WriteTransaction, custom: CustomInterface) => {
-        console.log(tx, custom);
+        use(tx, custom);
         custom.n as number;
         custom.s as string;
         // @ts-expect-error xxx
@@ -259,7 +264,7 @@ test.skip('mut [type checking only]', async () => {
       },
 
       l: async (tx: WriteTransaction, custom: ToRecord<CustomInterface>) => {
-        console.log(tx, custom);
+        use(tx, custom);
         custom.n as number;
         custom.s as string;
         // @ts-expect-error xxx
@@ -344,7 +349,34 @@ test.skip('scan with index [type checking only]', async () => {
       primary: string,
     ][];
 
-    (await tx.scan({}).keys().toArray()) as string[];
+    let indexKeys: IndexKey[] = await tx
+      .scan({indexName: 'a'})
+      .keys()
+      .toArray();
+    indexKeys = await tx.scan({indexName: 'a', prefix: 'a'}).keys().toArray();
+    use(indexKeys);
+
+    // @ts-expect-error Cannot convert Index[] to string[]
+    (await tx.scan({indexName: 'a'}).keys().toArray()) as string[];
+  });
+});
+
+// Only used for type checking
+test.skip('scan without index [type checking only]', async () => {
+  const rep = new Replicache({
+    licenseKey: TEST_LICENSE_KEY,
+    name: 'scan-with-index',
+  });
+
+  await rep.query(async tx => {
     (await tx.scan().keys().toArray()) as string[];
+    (await tx.scan({}).keys().toArray()) as string[];
+
+    let indexKeys: string[] = await tx.scan({}).keys().toArray();
+    indexKeys = await tx.scan({prefix: 'a'}).keys().toArray();
+    use(indexKeys);
+
+    // @ts-expect-error Cannot convert string[] to IndexKey[]
+    (await tx.scan({}).keys().toArray()) as IndexKey[];
   });
 });


### PR DESCRIPTION
This ensures that the type of `scan().keys().toArray()` has the correct
type.