### PR TITLE
fix: Prevent too many modules error in chrome

### DIFF
--- a/perf/replicache.ts
+++ b/perf/replicache.ts
@@ -1,5 +1,6 @@
 import {resolver} from '@rocicorp/resolver';
-import {range, sampleSize} from 'lodash-es';
+import range from 'lodash-es/range';
+import sampleSize from 'lodash-es/sampleSize';
 import {deepEqual} from '../src/json';
 import {assert} from '../src/asserts';
 import {

--- a/perf/runner.js
+++ b/perf/runner.js
@@ -191,7 +191,10 @@ async function main() {
 
 async function runInBrowser(browser, page, options) {
   async function waitForBenchmarks() {
-    await page.waitForFunction('typeof benchmarks !==  "undefined"');
+    await page.waitForFunction('typeof benchmarks !==  "undefined"', null, {
+      // There is no need to wait for 30s. Things fail much faster.
+      timeout: 1000,
+    });
   }
 
   await waitForBenchmarks();


### PR DESCRIPTION
Chromium has a bug where it fails to load if there are too many modules
in the dependency tree. We were depending on lodash-es which has hundreds
of modules which all tried to get loaded in Chrome.

Change to only load the sub modules of lodash-es.