### PR TITLE
feat: Collect old IDB databases

### DIFF
--- a/src/kv/idb-store.ts
+++ b/src/kv/idb-store.ts
@@ -163,7 +163,7 @@ function objectStore(tx: IDBTransaction): IDBObjectStore {
   return tx.objectStore(OBJECT_STORE);
 }
 
-async function openDatabase(name: string): Promise<IDBDatabase> {
+function openDatabase(name: string): Promise<IDBDatabase> {
   const req = indexedDB.open(name);
   req.onupgradeneeded = () => {
     const db = req.result;

--- a/src/persist/clients-test-helpers.ts
+++ b/src/persist/clients-test-helpers.ts
@@ -14,17 +14,29 @@ export function setClients(
   }, dagStore);
 }
 
-export function makeClient(partialClient: {
+export type PartialClient = {
   heartbeatTimestampMs: number;
   headHash: Hash;
   mutationID?: number;
   lastServerAckdMutationID?: number;
-}): Client {
+};
+
+export function makeClient(partialClient: PartialClient): Client {
   return {
     mutationID: 0,
     lastServerAckdMutationID: 0,
     ...partialClient,
   };
+}
+
+export function makeClientMap(
+  obj: Record<sync.ClientID, PartialClient>,
+): ClientMap {
+  return new Map(
+    Object.entries(obj).map(
+      ([id, client]) => [id, makeClient(client)] as const,
+    ),
+  );
 }
 
 export async function deleteClientForTesting(

--- a/src/persist/collect-idb-databases.test.ts
+++ b/src/persist/collect-idb-databases.test.ts
@@ -1,0 +1,236 @@
+import {expect} from '@esm-bundle/chai';
+import {fakeHash} from '../hash.js';
+import {TestMemStore} from '../kv/test-mem-store';
+import {makeClientMap, setClients} from './clients-test-helpers';
+import {
+  IDBDatabasesStore,
+  IndexedDBDatabase,
+  IndexedDBName,
+} from './idb-databases-store';
+import {collectIDBDatabases} from './collect-idb-databases';
+import * as dag from '../dag/mod';
+import type {ClientMap} from './clients.js';
+import {assertNotUndefined} from '../asserts.js';
+import {SinonFakeTimers, useFakeTimers} from 'sinon';
+import {REPLICACHE_FORMAT_VERSION} from '../replicache.js';
+
+suite('collectIDBDatabases', async () => {
+  let clock: SinonFakeTimers;
+
+  setup(() => {
+    clock = useFakeTimers(0);
+  });
+
+  teardown(() => {
+    clock.restore();
+  });
+
+  type Entries = [IndexedDBDatabase, ClientMap][];
+
+  const makeIndexedDBDatabase = (
+    name: string,
+    lastOpenedTimestampMS = Date.now(),
+    replicacheFormatVersion = REPLICACHE_FORMAT_VERSION,
+    schemaVersion = 'schemaVersion-' + name,
+    replicacheName = 'replicacheName-' + name,
+  ): IndexedDBDatabase => ({
+    name,
+    replicacheFormatVersion,
+    schemaVersion,
+    replicacheName,
+    lastOpenedTimestampMS,
+  });
+
+  const t = (
+    name: string,
+    entries: Entries,
+    now: number,
+    expectedDatabases: string[],
+  ) => {
+    for (const legacy of [false, true]) {
+      test(name + ' > time ' + now + (legacy ? ' > legacy' : ''), async () => {
+        const store = new IDBDatabasesStore(_ => new TestMemStore());
+        const clientDagStores = new Map<IndexedDBName, dag.Store>();
+        for (const [db, clients] of entries) {
+          const dagStore = new dag.TestStore();
+          clientDagStores.set(db.name, dagStore);
+          if (legacy) {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const {lastOpenedTimestampMS: _, ...rest} = db;
+            await store.putDatabaseForTesting(rest);
+          } else {
+            await store.putDatabaseForTesting(db);
+          }
+
+          await setClients(clients, dagStore);
+        }
+
+        const newDagStore = (name: string) => {
+          const dagStore = clientDagStores.get(name);
+          assertNotUndefined(dagStore);
+          return dagStore;
+        };
+
+        const maxAge = 1000;
+
+        const controller = new AbortController();
+        await collectIDBDatabases(
+          store,
+          controller.signal,
+          now,
+          maxAge,
+          newDagStore,
+        );
+
+        expect(Object.keys(await store.getDatabases())).to.deep.equal(
+          expectedDatabases,
+        );
+      });
+    }
+  };
+
+  t('empty', [], 0, []);
+
+  {
+    const entries: Entries = [
+      [
+        makeIndexedDBDatabase('a', 0),
+        makeClientMap({
+          clientA1: {
+            headHash: fakeHash('a1'),
+            heartbeatTimestampMs: 0,
+          },
+        }),
+      ],
+    ];
+    t('one idb, one client', entries, 0, ['a']);
+    t('one idb, one client', entries, 1000, []);
+    t('one idb, one client', entries, 2000, []);
+  }
+
+  {
+    const entries: Entries = [
+      [
+        makeIndexedDBDatabase('a', 0),
+        makeClientMap({
+          clientA1: {
+            headHash: fakeHash('a1'),
+            heartbeatTimestampMs: 0,
+          },
+        }),
+      ],
+      [
+        makeIndexedDBDatabase('b', 1000),
+        makeClientMap({
+          clientB1: {
+            headHash: fakeHash('b1'),
+            heartbeatTimestampMs: 1000,
+          },
+        }),
+      ],
+    ];
+    t('x', entries, 0, ['a', 'b']);
+    t('x', entries, 1000, ['b']);
+    t('x', entries, 2000, []);
+  }
+
+  {
+    const entries: Entries = [
+      [
+        makeIndexedDBDatabase('a', 2000),
+        makeClientMap({
+          clientA1: {
+            headHash: fakeHash('a1'),
+            heartbeatTimestampMs: 0,
+          },
+          clientA2: {
+            headHash: fakeHash('a2'),
+            heartbeatTimestampMs: 2000,
+          },
+        }),
+      ],
+      [
+        makeIndexedDBDatabase('b', 1000),
+        makeClientMap({
+          clientB1: {
+            headHash: fakeHash('b1'),
+            heartbeatTimestampMs: 1000,
+          },
+        }),
+      ],
+    ];
+    t('two idb, three clients', entries, 0, ['a', 'b']);
+    t('two idb, three clients', entries, 1000, ['a', 'b']);
+    t('two idb, three clients', entries, 2000, ['a']);
+    t('two idb, three clients', entries, 3000, []);
+  }
+
+  {
+    const entries: Entries = [
+      [
+        makeIndexedDBDatabase('a', 3000),
+        makeClientMap({
+          clientA1: {
+            headHash: fakeHash('a1'),
+            heartbeatTimestampMs: 1000,
+          },
+          clientA2: {
+            headHash: fakeHash('a2'),
+            heartbeatTimestampMs: 3000,
+          },
+        }),
+      ],
+      [
+        makeIndexedDBDatabase('b', 4000),
+        makeClientMap({
+          clientB1: {
+            headHash: fakeHash('b1'),
+            heartbeatTimestampMs: 2000,
+          },
+          clientB2: {
+            headHash: fakeHash('b2'),
+            heartbeatTimestampMs: 4000,
+          },
+        }),
+      ],
+    ];
+    t('two idb, four clients', entries, 1000, ['a', 'b']);
+    t('two idb, four clients', entries, 2000, ['a', 'b']);
+    t('two idb, four clients', entries, 3000, ['a', 'b']);
+    t('two idb, four clients', entries, 4000, ['b']);
+    t('two idb, four clients', entries, 5000, []);
+  }
+
+  {
+    const entries: Entries = [
+      [
+        makeIndexedDBDatabase('a', 0, REPLICACHE_FORMAT_VERSION + 1),
+        makeClientMap({
+          clientA1: {
+            headHash: fakeHash('a1'),
+            heartbeatTimestampMs: 0,
+          },
+        }),
+      ],
+    ];
+    t('one idb, one client, format version too new', entries, 0, ['a']);
+    t('one idb, one client, format version too new', entries, 1000, ['a']);
+    t('one idb, one client, format version too new', entries, 2000, ['a']);
+  }
+
+  {
+    const entries: Entries = [
+      [
+        makeIndexedDBDatabase('a', 0, REPLICACHE_FORMAT_VERSION - 1),
+        makeClientMap({
+          clientA1: {
+            headHash: fakeHash('a1'),
+            heartbeatTimestampMs: 0,
+          },
+        }),
+      ],
+    ];
+    t('one idb, one client, old format version', entries, 0, ['a']);
+    t('one idb, one client, old format version', entries, 1000, []);
+  }
+});

--- a/src/persist/collect-idb-databases.ts
+++ b/src/persist/collect-idb-databases.ts
@@ -1,0 +1,162 @@
+import * as kv from '../kv/mod';
+import * as dag from '../dag/mod';
+import {ClientMap, getClients} from './clients.js';
+import {assertNotTempHash} from '../hash.js';
+import {dropStore} from '../kv/idb-store.js';
+import type {IDBDatabasesStore, IndexedDBDatabase} from './idb-databases-store';
+import {initBgIntervalProcess} from './bg-interval.js';
+import type {LogContext} from '@rocicorp/logger';
+import {sleep} from '../sleep.js';
+import {AbortError} from '../abort-error.js';
+import {REPLICACHE_FORMAT_VERSION} from '../replicache.js';
+
+// How frequently to try to collect
+const COLLECT_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12 hours
+
+// If an IDB database is older than MAX_AGE, then it can be collected.
+const MAX_AGE = 3 * 30 * 24 * 60 * 60 * 1000; // 3 months
+
+// We delay the initial collection to prevent doing it at startup.
+const COLLECT_DELAY = 5 * 60 * 1000; // 5 minutes
+
+export function initCollectIDBDatabases(
+  idbDatabasesStore: IDBDatabasesStore,
+  lc: LogContext,
+  signal: AbortSignal,
+): void {
+  void sleepFiveAndCollect(idbDatabasesStore, signal);
+
+  const stopInterval = initBgIntervalProcess(
+    'CollectIDBDatabases',
+    async () => {
+      await collectIDBDatabases(
+        idbDatabasesStore,
+        signal,
+        Date.now(),
+        MAX_AGE,
+        undefined,
+      );
+    },
+    COLLECT_INTERVAL_MS,
+    lc,
+  );
+
+  signal.addEventListener('abort', stopInterval);
+}
+
+async function sleepFiveAndCollect(
+  idbDatabasesStore: IDBDatabasesStore,
+  signal: AbortSignal,
+) {
+  try {
+    await sleep(COLLECT_DELAY, signal);
+
+    await collectIDBDatabases(
+      idbDatabasesStore,
+      signal,
+      Date.now(),
+      MAX_AGE,
+      defaultNewDagStore,
+    );
+  } catch (e) {
+    if (e instanceof AbortError) {
+      return;
+    }
+    throw e;
+  }
+}
+
+export async function collectIDBDatabases(
+  idbDatabasesStore: IDBDatabasesStore,
+  signal: AbortSignal,
+  now: number,
+  maxAge: number,
+  newDagStore = defaultNewDagStore,
+): Promise<void> {
+  const databases = await idbDatabasesStore.getDatabases();
+
+  const dbs = Object.values(databases) as IndexedDBDatabase[];
+  const canCollectResults = await Promise.all(
+    dbs.map(
+      async db =>
+        [
+          db.name,
+          await canCollectDatabase(db, now, maxAge, newDagStore),
+        ] as const,
+    ),
+  );
+
+  const namesToRemove = canCollectResults
+    .filter(result => result[1])
+    .map(result => result[0]);
+
+  // Try to remove the databases in parallel. Don't let a single reject fail the
+  // other ones. We will check for failures afterwards.
+  const dropStoreResults = await Promise.allSettled(
+    namesToRemove.map(async name => {
+      await dropStore(name);
+      return name;
+    }),
+  );
+
+  const idbRemovedNames: string[] = [];
+  const errors: unknown[] = [];
+  for (const result of dropStoreResults) {
+    if (result.status === 'fulfilled') {
+      idbRemovedNames.push(result.value);
+    } else {
+      errors.push(result.reason);
+    }
+  }
+
+  if (idbRemovedNames.length && !signal.aborted) {
+    // Remove the database name from the meta table.
+    await idbDatabasesStore.deleteDatabases(idbRemovedNames);
+  }
+
+  if (errors.length) {
+    throw errors[0];
+  }
+}
+
+function defaultNewDagStore(name: string): dag.Store {
+  const perKvStore = new kv.IDBStore(name);
+  return new dag.StoreImpl(perKvStore, dag.throwChunkHasher, assertNotTempHash);
+}
+
+async function canCollectDatabase(
+  db: IndexedDBDatabase,
+  now: number,
+  maxAge: number,
+  newDagStore: typeof defaultNewDagStore,
+): Promise<boolean> {
+  if (db.replicacheFormatVersion > REPLICACHE_FORMAT_VERSION) {
+    return false;
+  }
+
+  // 0 is used in testing
+  if (db.lastOpenedTimestampMS !== undefined) {
+    return now - db.lastOpenedTimestampMS >= maxAge;
+  }
+
+  // For legacy databases we do not have a lastOpenedTimestampMS so we check the
+  // time stamps of the clients
+  const perdag = newDagStore(db.name);
+  const clientMap = await perdag.withRead(getClients);
+  await perdag.close();
+
+  return allClientsOlderThan(clientMap, now, maxAge);
+}
+
+function allClientsOlderThan(
+  clients: ClientMap,
+  now: number,
+  maxAge: number,
+): boolean {
+  for (const client of clients.values()) {
+    if (now - client.heartbeatTimestampMs < maxAge) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/persist/mod.ts
+++ b/src/persist/mod.ts
@@ -22,3 +22,4 @@ export type {
   IndexedDBDatabase,
   IndexedDBDatabaseRecord,
 } from './idb-databases-store';
+export {initCollectIDBDatabases} from './collect-idb-databases';

--- a/src/replicache-collect-idb-databases.test.ts
+++ b/src/replicache-collect-idb-databases.test.ts
@@ -1,0 +1,54 @@
+import {expect} from '@esm-bundle/chai';
+import {clock, initReplicacheTesting, replicacheForTesting} from './test-util';
+
+initReplicacheTesting();
+
+test('collect IDB databases', async () => {
+  if (!indexedDB.databases) {
+    // Firefox does not support indexedDB.databases
+    return;
+  }
+
+  const ONE_MINUTE = 1000 * 60 * 1;
+  const FIVE_MINUTES = ONE_MINUTE * 5;
+  const ONE_MONTH = 1000 * 60 * 60 * 24 * 30;
+  const THREE_MONTHS = ONE_MONTH * 3;
+
+  const rep = await replicacheForTesting('collect-idb-databases-1');
+  await rep.close();
+
+  expect(await getDatabases()).to.deep.equal(['collect-idb-databases-1']);
+
+  await clock.tickAsync(THREE_MONTHS);
+
+  const rep2 = await replicacheForTesting('collect-idb-databases-2');
+  await rep2.close();
+
+  expect(await getDatabases()).to.deep.equal([
+    'collect-idb-databases-1',
+    'collect-idb-databases-2',
+  ]);
+
+  await clock.tickAsync(ONE_MONTH);
+
+  // Open one more database and keep it open long enough to trigger the collection.
+  const rep3 = await replicacheForTesting('collect-idb-databases-3');
+  await clock.tickAsync(FIVE_MINUTES);
+  await rep3.close();
+
+  expect(await getDatabases()).to.deep.equal([
+    'collect-idb-databases-2',
+    'collect-idb-databases-3',
+  ]);
+
+  async function getDatabases() {
+    function parseName(idbName: string | undefined): string | undefined {
+      return idbName && /^rep:[^:]+:([^:]+):\d+$/.exec(idbName)?.[1];
+    }
+
+    return (await indexedDB.databases())
+      .map(({name}) => parseName(name))
+      .filter(name => name && name.startsWith('collect-idb-databases'))
+      .sort();
+  }
+});

--- a/src/replicache-mutation-recovery.test.ts
+++ b/src/replicache-mutation-recovery.test.ts
@@ -118,6 +118,8 @@ async function testRecoveringMutationsOfClient(args: {
   schemaVersionOfClientRecoveringMutations: string;
   numMutationsNotAcknowledgedByPull?: number;
 }) {
+  sinon.stub(console, 'error');
+
   const {
     schemaVersionOfClientWPendingMutations,
     schemaVersionOfClientRecoveringMutations,

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -32,7 +32,6 @@ export default {
         'src/dag/*.test.ts',
         'src/db/*.test.ts',
         'src/kv/*.test.ts',
-        'src/prolly/*.test.ts',
         'src/sync/*.test.ts',
         'src/migrate/*.test.ts',
         'src/btree/*.test.ts',


### PR DESCRIPTION
We now collect IDB databases that have not been opened for 3 months.

We check 5 minutes after startup as well as every 12 hours. In theory we
should be able to check much less frequently. We could compute when the
oldest one would expire and not check until then...

Fixes rocicorp/replicache#803, rocicorp/mono#121