### PR TITLE
fix: docs failed to build after a recent change

### DIFF
--- a/doc/package-lock.json
+++ b/doc/package-lock.json
@@ -20,7 +20,7 @@
         "docusaurus-plugin-typedoc": "^0.16.7",
         "typedoc": "^0.22.10",
         "typedoc-plugin-markdown": "^3.11.11",
-        "typescript": "^4.5.4"
+        "typescript": "^4.6.3"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -11327,9 +11327,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20704,9 +20704,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg=="
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw=="
     },
     "ua-parser-js": {
       "version": "0.7.31",

--- a/doc/package.json
+++ b/doc/package.json
@@ -38,6 +38,6 @@
     "docusaurus-plugin-typedoc": "^0.16.7",
     "typedoc": "^0.22.10",
     "typedoc-plugin-markdown": "^3.11.11",
-    "typescript": "^4.5.4"
+    "typescript": "^4.6.3"
   }
 }


### PR DESCRIPTION
We need to use a newer version of TS to allow statements before super.