### PR TITLE
wat

### DIFF
--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -15,4 +15,4 @@ if (process.argv.length < 3 || process.argv[2] !== 'get-license') {
 
 // TODO(phritz): add staging flag
 
-licensingCLI.main(PROD_LICENSE_SERVER_URL);
+licensingCLI.main();


### PR DESCRIPTION
This is a typescript thing I do not understand. The cli.ts file invokes `licensingCLI.main()` without the [required argument](https://github.com/rocicorp/licensing/blob/021cb42bdbd65c10b1d4ea0a609a56b8a3f394e9/src/cli/get-license.ts#L36). In VSCode that line is red showing me the expected error `Expected 1 arguments, but got 0. An argument for 'licenseServerURL' was not provided.`. However it compiles just fine and then fails at runtime when the missing argument is attempted to be used. To see this:
1. `rm $(which replicache)`
2. `rm out/cli.cjs`
3. `npm run build`
4. `npm link`
5. `npx replicache get-license`
6. enter data at the prompts 
7. notice that in the final step when it goes to use the missing argument it fails:
```
Fetching License Key...
Sorry, there was an error. Please file a bug at https://github.com/rocicorp/replicache/issues/new with the following information:
TypeError [ERR_INVALID_URL]: Invalid URL
```
The "invalid url" is `undefined`.